### PR TITLE
refactor: change hooks that received refs to receive data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
+- Change hooks that received refs to receive data [PR #27](https://github.com/marmot-protocol/sloth/pull/27)
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ genhtml coverage/lcov.info -o coverage/html
 - Sloths avoid caching in flutter side. Sloths remember that White Noise crate already persists data in a local DB.
 - Sloths put shared app state in providers.
 - Sloths put ephemeral widget state in hooks.
+- Sloths pass data to hooks, not widget refs.
+- Sloths let screens watch providers and pass data to hooks.
 - Sloths don't add code comments unless strictly necessary. Instead, they make big effort on writing code that is self-explanatory.
 
 ## 📚 Resources

--- a/lib/hooks/use_key_packages.dart
+++ b/lib/hooks/use_key_packages.dart
@@ -1,7 +1,5 @@
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
-import 'package:sloth/providers/account_pubkey_provider.dart';
 import 'package:sloth/src/rust/api/accounts.dart' as accounts_api;
 
 final _logger = Logger('useKeyPackages');
@@ -38,8 +36,7 @@ class KeyPackagesState {
   Future<void> Function(String id) delete,
   Future<void> Function() deleteAll,
 })
-useKeyPackages(WidgetRef ref) {
-  final pubkey = ref.watch(accountPubkeyProvider);
+useKeyPackages(String pubkey) {
   final state = useState(const KeyPackagesState());
 
   Future<void> fetch() async {

--- a/lib/hooks/use_signup.dart
+++ b/lib/hooks/use_signup.dart
@@ -1,7 +1,5 @@
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
-import 'package:sloth/providers/auth_provider.dart' show authProvider;
 import 'package:sloth/services/profile_service.dart' show ProfileService;
 
 final _logger = Logger('useSignup');
@@ -35,7 +33,7 @@ class SignupState {
   }
 }
 
-typedef SignupCallback =
+typedef SubmitCallback =
     Future<bool> Function({
       required String displayName,
       String? bio,
@@ -47,11 +45,11 @@ typedef ClearErrorsCallback = void Function();
 
 ({
   SignupState state,
-  SignupCallback submit,
+  SubmitCallback submit,
   OnImageSelectedCallback onImageSelected,
   ClearErrorsCallback clearErrors,
 })
-useSignup(WidgetRef ref) {
+useSignup(Future<String> Function() signup) {
   final state = useState(const SignupState());
 
   void onImageSelected(String imagePath) {
@@ -75,7 +73,7 @@ useSignup(WidgetRef ref) {
     state.value = state.value.copyWith(isLoading: true, clearError: true);
 
     try {
-      final pubkey = await ref.read(authProvider.notifier).signup();
+      final pubkey = await signup();
       final profileService = ProfileService(pubkey);
 
       String? pictureUrl;

--- a/lib/screens/developer_settings_screen.dart
+++ b/lib/screens/developer_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sloth/extensions/build_context.dart';
 import 'package:sloth/hooks/use_key_packages.dart';
+import 'package:sloth/providers/account_pubkey_provider.dart';
 import 'package:sloth/src/rust/api/accounts.dart' show FlutterEvent;
 import 'package:sloth/widgets/wn_filled_button.dart';
 import 'package:sloth/widgets/wn_screen_header.dart';
@@ -15,7 +16,8 @@ class DeveloperSettingsScreen extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final colors = context.colors;
-    final (:state, :fetch, :publish, :delete, :deleteAll) = useKeyPackages(ref);
+    final pubkey = ref.watch(accountPubkeyProvider);
+    final (:state, :fetch, :publish, :delete, :deleteAll) = useKeyPackages(pubkey);
 
     useEffect(() {
       fetch();

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -6,6 +6,7 @@ import 'package:gap/gap.dart' show Gap;
 import 'package:hooks_riverpod/hooks_riverpod.dart' show HookConsumerWidget, WidgetRef;
 import 'package:sloth/extensions/build_context.dart';
 import 'package:sloth/hooks/use_signup.dart' show useSignup;
+import 'package:sloth/providers/auth_provider.dart' show authProvider;
 import 'package:sloth/routes.dart' show Routes;
 import 'package:sloth/widgets/wn_filled_button.dart' show WnFilledButton;
 import 'package:sloth/widgets/wn_image_picker.dart' show WnImagePicker;
@@ -23,7 +24,9 @@ class SignupScreen extends HookConsumerWidget {
     final displayNameController = useTextEditingController();
     final bioController = useTextEditingController();
     final scrollController = useScrollController();
-    final (:state, :submit, :onImageSelected, :clearErrors) = useSignup(ref);
+    final (:state, :submit, :onImageSelected, :clearErrors) = useSignup(
+      () => ref.read(authProvider.notifier).signup(),
+    );
 
     final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
     useEffect(() {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

When reviewing #22 , I realized that I had commited a bad practice: adding a couple of hooks that received the widget ref and watched providers internally. By recieveing a widget ref and watching providers, the hook ends up with an implicit dependency that is not obvious from the data parameters.  Then, when a provider changes, it becomes less clear which hooks will rebuild.

This PR fixes that issue in the `useKeyPackages` and `useSignup` hooks

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Sloth mode docs clarified: hooks receive data inputs and screens watch providers to supply those inputs.

* **Refactor**
  * Hooks now accept explicit inputs or callbacks instead of reading providers directly; screens updated to pass needed values and signup callbacks. Public callback type renamed to reflect the new submit-oriented API.

* **Tests**
  * Tests simplified to hook-based scaffolding with local mock callbacks; removed provider overrides and heavy mock wiring.

* **Changelog**
  * Added entry noting hooks now receive data instead of refs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->