### PR TITLE
Add settings restructure with delete all app data feature

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Profilschlüssel",
   "networkRelays": "Netzwerk-Relays",
   "appSettings": "App-Einstellungen",
+  "privacyAndSecurity": "Datenschutz & Sicherheit",
+  "dataUsage": "Datennutzung",
+  "appearance": "Erscheinungsbild",
   "donateToWhiteNoise": "An White Noise spenden",
   "developerSettings": "Entwicklereinstellungen",
   "signOut": "Abmelden",
@@ -123,5 +126,11 @@
   "timeJustNow": "gerade eben",
   "timeMinutesAgo": "{count, plural, =1{vor 1 Minute} other{vor {count} Minuten}}",
   "timeHoursAgo": "{count, plural, =1{vor 1 Stunde} other{vor {count} Stunden}}",
-  "timeDaysAgo": "{count, plural, =1{gestern} other{vor {count} Tagen}}"
+  "timeDaysAgo": "{count, plural, =1{gestern} other{vor {count} Tagen}}",
+  "deleteAllAppData": "Alle App-Daten löschen",
+  "deleteAppData": "App-Daten löschen",
+  "deleteAllAppDataDescription": "Löscht alle Profile, Schlüssel, Chats und lokalen Dateien von diesem Gerät.",
+  "deleteAllAppDataConfirmation": "Alle App-Daten löschen?",
+  "deleteAllAppDataWarning": "Dies wird alle Profile, Schlüssel, Chats und lokalen Dateien von diesem Gerät löschen. Dies kann nicht rückgängig gemacht werden.",
+  "deleteAllAppDataFailed": "App-Daten konnten nicht gelöscht werden. Bitte erneut versuchen."
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -116,6 +116,21 @@
     "description": "Settings menu item"
   },
 
+  "privacyAndSecurity": "Privacy & Security",
+  "@privacyAndSecurity": {
+    "description": "Settings menu item"
+  },
+
+  "dataUsage": "Data Usage",
+  "@dataUsage": {
+    "description": "Settings menu item"
+  },
+
+  "appearance": "Appearance",
+  "@appearance": {
+    "description": "Settings menu item"
+  },
+
   "donateToWhiteNoise": "Donate to White Noise",
   "@donateToWhiteNoise": {
     "description": "Settings menu item"
@@ -669,5 +684,35 @@
         "type": "int"
       }
     }
+  },
+
+  "deleteAllAppData": "Delete all app data",
+  "@deleteAllAppData": {
+    "description": "Section label for delete all app data"
+  },
+
+  "deleteAppData": "Delete app data",
+  "@deleteAppData": {
+    "description": "Button text for delete app data"
+  },
+
+  "deleteAllAppDataDescription": "Erase every profile, key, chat, and local file from this device.",
+  "@deleteAllAppDataDescription": {
+    "description": "Description for delete all app data action"
+  },
+
+  "deleteAllAppDataConfirmation": "Delete all app data?",
+  "@deleteAllAppDataConfirmation": {
+    "description": "Delete all app data confirmation screen title"
+  },
+
+  "deleteAllAppDataWarning": "This will erase every profile, key, chat, and local file from this device. This cannot be undone.",
+  "@deleteAllAppDataWarning": {
+    "description": "Delete all app data warning message"
+  },
+
+  "deleteAllAppDataFailed": "Failed to delete app data. Please try again.",
+  "@deleteAllAppDataFailed": {
+    "description": "Error message when deleting app data fails"
   }
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Llaves del perfil",
   "networkRelays": "Relés de red",
   "appSettings": "Ajustes de la app",
+  "privacyAndSecurity": "Privacidad y seguridad",
+  "dataUsage": "Uso de datos",
+  "appearance": "Apariencia",
   "donateToWhiteNoise": "Donar a White Noise",
   "developerSettings": "Ajustes de desarrollador",
   "signOut": "Cerrar sesión",
@@ -123,5 +126,11 @@
   "timeJustNow": "ahora mismo",
   "timeMinutesAgo": "{count, plural, =1{hace 1 minuto} other{hace {count} minutos}}",
   "timeHoursAgo": "{count, plural, =1{hace 1 hora} other{hace {count} horas}}",
-  "timeDaysAgo": "{count, plural, =1{ayer} other{hace {count} días}}"
+  "timeDaysAgo": "{count, plural, =1{ayer} other{hace {count} días}}",
+  "deleteAllAppData": "Eliminar todos los datos de la app",
+  "deleteAppData": "Eliminar datos de la app",
+  "deleteAllAppDataDescription": "Borra todos los perfiles, claves, chats y archivos locales de este dispositivo.",
+  "deleteAllAppDataConfirmation": "¿Eliminar todos los datos de la app?",
+  "deleteAllAppDataWarning": "Esto borrará todos los perfiles, claves, chats y archivos locales de este dispositivo. No se puede deshacer.",
+  "deleteAllAppDataFailed": "Error al eliminar los datos de la app. Por favor, inténtalo de nuevo."
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Clés du profil",
   "networkRelays": "Relais réseau",
   "appSettings": "Paramètres de l'app",
+  "privacyAndSecurity": "Confidentialité et sécurité",
+  "dataUsage": "Utilisation des données",
+  "appearance": "Apparence",
   "donateToWhiteNoise": "Faire un don à White Noise",
   "developerSettings": "Paramètres développeur",
   "signOut": "Déconnexion",
@@ -123,5 +126,11 @@
   "timeJustNow": "à l'instant",
   "timeMinutesAgo": "{count, plural, =1{il y a 1 minute} other{il y a {count} minutes}}",
   "timeHoursAgo": "{count, plural, =1{il y a 1 heure} other{il y a {count} heures}}",
-  "timeDaysAgo": "{count, plural, =1{hier} other{il y a {count} jours}}"
+  "timeDaysAgo": "{count, plural, =1{hier} other{il y a {count} jours}}",
+  "deleteAllAppData": "Supprimer toutes les données de l'app",
+  "deleteAppData": "Supprimer les données de l'app",
+  "deleteAllAppDataDescription": "Efface tous les profils, clés, conversations et fichiers locaux de cet appareil.",
+  "deleteAllAppDataConfirmation": "Supprimer toutes les données de l'app ?",
+  "deleteAllAppDataWarning": "Cela effacera tous les profils, clés, conversations et fichiers locaux de cet appareil. Cette action est irréversible.",
+  "deleteAllAppDataFailed": "Échec de la suppression des données de l'app. Veuillez réessayer."
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Chiavi del profilo",
   "networkRelays": "Relay di rete",
   "appSettings": "Impostazioni app",
+  "privacyAndSecurity": "Privacy e sicurezza",
+  "dataUsage": "Utilizzo dati",
+  "appearance": "Aspetto",
   "donateToWhiteNoise": "Dona a White Noise",
   "developerSettings": "Impostazioni sviluppatore",
   "signOut": "Esci",
@@ -123,5 +126,11 @@
   "timeJustNow": "proprio ora",
   "timeMinutesAgo": "{count, plural, =1{1 minuto fa} other{{count} minuti fa}}",
   "timeHoursAgo": "{count, plural, =1{1 ora fa} other{{count} ore fa}}",
-  "timeDaysAgo": "{count, plural, =1{ieri} other{{count} giorni fa}}"
+  "timeDaysAgo": "{count, plural, =1{ieri} other{{count} giorni fa}}",
+  "deleteAllAppData": "Elimina tutti i dati dell'app",
+  "deleteAppData": "Elimina dati dell'app",
+  "deleteAllAppDataDescription": "Cancella tutti i profili, le chiavi, le chat e i file locali da questo dispositivo.",
+  "deleteAllAppDataConfirmation": "Eliminare tutti i dati dell'app?",
+  "deleteAllAppDataWarning": "Questo cancellerà tutti i profili, le chiavi, le chat e i file locali da questo dispositivo. Non può essere annullato.",
+  "deleteAllAppDataFailed": "Eliminazione dei dati dell'app fallita. Riprova."
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Chaves do perfil",
   "networkRelays": "Relays de rede",
   "appSettings": "Configurações do app",
+  "privacyAndSecurity": "Privacidade e segurança",
+  "dataUsage": "Uso de dados",
+  "appearance": "Aparência",
   "donateToWhiteNoise": "Doar para o White Noise",
   "developerSettings": "Configurações de desenvolvedor",
   "signOut": "Sair",
@@ -123,5 +126,11 @@
   "timeJustNow": "agora mesmo",
   "timeMinutesAgo": "{count, plural, =1{há 1 minuto} other{há {count} minutos}}",
   "timeHoursAgo": "{count, plural, =1{há 1 hora} other{há {count} horas}}",
-  "timeDaysAgo": "{count, plural, =1{ontem} other{há {count} dias}}"
+  "timeDaysAgo": "{count, plural, =1{ontem} other{há {count} dias}}",
+  "deleteAllAppData": "Excluir todos os dados do app",
+  "deleteAppData": "Excluir dados do app",
+  "deleteAllAppDataDescription": "Apaga todos os perfis, chaves, conversas e arquivos locais deste dispositivo.",
+  "deleteAllAppDataConfirmation": "Excluir todos os dados do app?",
+  "deleteAllAppDataWarning": "Isso apagará todos os perfis, chaves, conversas e arquivos locais deste dispositivo. Não pode ser desfeito.",
+  "deleteAllAppDataFailed": "Falha ao excluir dados do app. Por favor, tente novamente."
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Ключи профиля",
   "networkRelays": "Сетевые реле",
   "appSettings": "Настройки приложения",
+  "privacyAndSecurity": "Конфиденциальность и безопасность",
+  "dataUsage": "Использование данных",
+  "appearance": "Оформление",
   "donateToWhiteNoise": "Пожертвовать White Noise",
   "developerSettings": "Настройки разработчика",
   "signOut": "Выйти",
@@ -123,5 +126,11 @@
   "timeJustNow": "только что",
   "timeMinutesAgo": "{count, plural, =1{1 минуту назад} few{{count} минуты назад} many{{count} минут назад} other{{count} минут назад}}",
   "timeHoursAgo": "{count, plural, =1{1 час назад} few{{count} часа назад} many{{count} часов назад} other{{count} часов назад}}",
-  "timeDaysAgo": "{count, plural, =1{вчера} few{{count} дня назад} many{{count} дней назад} other{{count} дней назад}}"
+  "timeDaysAgo": "{count, plural, =1{вчера} few{{count} дня назад} many{{count} дней назад} other{{count} дней назад}}",
+  "deleteAllAppData": "Удалить все данные приложения",
+  "deleteAppData": "Удалить данные приложения",
+  "deleteAllAppDataDescription": "Удалит все профили, ключи, чаты и локальные файлы с этого устройства.",
+  "deleteAllAppDataConfirmation": "Удалить все данные приложения?",
+  "deleteAllAppDataWarning": "Это удалит все профили, ключи, чаты и локальные файлы с этого устройства. Это нельзя отменить.",
+  "deleteAllAppDataFailed": "Не удалось удалить данные приложения. Попробуйте снова."
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -23,6 +23,9 @@
   "profileKeys": "Profil anahtarları",
   "networkRelays": "Ağ röleleri",
   "appSettings": "Uygulama ayarları",
+  "privacyAndSecurity": "Gizlilik ve güvenlik",
+  "dataUsage": "Veri kullanımı",
+  "appearance": "Görünüm",
   "donateToWhiteNoise": "White Noise'a bağış yap",
   "developerSettings": "Geliştirici ayarları",
   "signOut": "Çıkış yap",
@@ -123,5 +126,11 @@
   "timeJustNow": "şimdi",
   "timeMinutesAgo": "{count, plural, =1{1 dakika önce} other{{count} dakika önce}}",
   "timeHoursAgo": "{count, plural, =1{1 saat önce} other{{count} saat önce}}",
-  "timeDaysAgo": "{count, plural, =1{dün} other{{count} gün önce}}"
+  "timeDaysAgo": "{count, plural, =1{dün} other{{count} gün önce}}",
+  "deleteAllAppData": "Tüm uygulama verilerini sil",
+  "deleteAppData": "Uygulama verilerini sil",
+  "deleteAllAppDataDescription": "Bu cihazdaki tüm profilleri, anahtarları, sohbetleri ve yerel dosyaları siler.",
+  "deleteAllAppDataConfirmation": "Tüm uygulama verileri silinsin mi?",
+  "deleteAllAppDataWarning": "Bu, bu cihazdaki tüm profilleri, anahtarları, sohbetleri ve yerel dosyaları silecektir. Bu geri alınamaz.",
+  "deleteAllAppDataFailed": "Uygulama verileri silinemedi. Lütfen tekrar deneyin."
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -249,6 +249,24 @@ abstract class AppLocalizations {
   /// Settings menu item
   ///
   /// In en, this message translates to:
+  /// **'Privacy & Security'**
+  String get privacyAndSecurity;
+
+  /// Settings menu item
+  ///
+  /// In en, this message translates to:
+  /// **'Data Usage'**
+  String get dataUsage;
+
+  /// Settings menu item
+  ///
+  /// In en, this message translates to:
+  /// **'Appearance'**
+  String get appearance;
+
+  /// Settings menu item
+  ///
+  /// In en, this message translates to:
   /// **'Donate to White Noise'**
   String get donateToWhiteNoise;
 
@@ -851,6 +869,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{count, plural, =1{yesterday} other{{count} days ago}}'**
   String timeDaysAgo(int count);
+
+  /// Section label for delete all app data
+  ///
+  /// In en, this message translates to:
+  /// **'Delete all app data'**
+  String get deleteAllAppData;
+
+  /// Button text for delete app data
+  ///
+  /// In en, this message translates to:
+  /// **'Delete app data'**
+  String get deleteAppData;
+
+  /// Description for delete all app data action
+  ///
+  /// In en, this message translates to:
+  /// **'Erase every profile, key, chat, and local file from this device.'**
+  String get deleteAllAppDataDescription;
+
+  /// Delete all app data confirmation screen title
+  ///
+  /// In en, this message translates to:
+  /// **'Delete all app data?'**
+  String get deleteAllAppDataConfirmation;
+
+  /// Delete all app data warning message
+  ///
+  /// In en, this message translates to:
+  /// **'This will erase every profile, key, chat, and local file from this device. This cannot be undone.'**
+  String get deleteAllAppDataWarning;
+
+  /// Error message when deleting app data fails
+  ///
+  /// In en, this message translates to:
+  /// **'Failed to delete app data. Please try again.'**
+  String get deleteAllAppDataFailed;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/l10n/generated/app_localizations_de.dart
+++ b/lib/l10n/generated/app_localizations_de.dart
@@ -79,6 +79,15 @@ class AppLocalizationsDe extends AppLocalizations {
   String get appSettings => 'App-Einstellungen';
 
   @override
+  String get privacyAndSecurity => 'Datenschutz & Sicherheit';
+
+  @override
+  String get dataUsage => 'Datennutzung';
+
+  @override
+  String get appearance => 'Erscheinungsbild';
+
+  @override
   String get donateToWhiteNoise => 'An White Noise spenden';
 
   @override
@@ -435,4 +444,25 @@ class AppLocalizationsDe extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Alle App-Daten löschen';
+
+  @override
+  String get deleteAppData => 'App-Daten löschen';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Löscht alle Profile, Schlüssel, Chats und lokalen Dateien von diesem Gerät.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Alle App-Daten löschen?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Dies wird alle Profile, Schlüssel, Chats und lokalen Dateien von diesem Gerät löschen. Dies kann nicht rückgängig gemacht werden.';
+
+  @override
+  String get deleteAllAppDataFailed =>
+      'App-Daten konnten nicht gelöscht werden. Bitte erneut versuchen.';
 }

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -79,6 +79,15 @@ class AppLocalizationsEn extends AppLocalizations {
   String get appSettings => 'App settings';
 
   @override
+  String get privacyAndSecurity => 'Privacy & Security';
+
+  @override
+  String get dataUsage => 'Data Usage';
+
+  @override
+  String get appearance => 'Appearance';
+
+  @override
   String get donateToWhiteNoise => 'Donate to White Noise';
 
   @override
@@ -429,4 +438,24 @@ class AppLocalizationsEn extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Delete all app data';
+
+  @override
+  String get deleteAppData => 'Delete app data';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Erase every profile, key, chat, and local file from this device.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Delete all app data?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'This will erase every profile, key, chat, and local file from this device. This cannot be undone.';
+
+  @override
+  String get deleteAllAppDataFailed => 'Failed to delete app data. Please try again.';
 }

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -79,6 +79,15 @@ class AppLocalizationsEs extends AppLocalizations {
   String get appSettings => 'Ajustes de la app';
 
   @override
+  String get privacyAndSecurity => 'Privacidad y seguridad';
+
+  @override
+  String get dataUsage => 'Uso de datos';
+
+  @override
+  String get appearance => 'Apariencia';
+
+  @override
   String get donateToWhiteNoise => 'Donar a White Noise';
 
   @override
@@ -431,4 +440,25 @@ class AppLocalizationsEs extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Eliminar todos los datos de la app';
+
+  @override
+  String get deleteAppData => 'Eliminar datos de la app';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Borra todos los perfiles, claves, chats y archivos locales de este dispositivo.';
+
+  @override
+  String get deleteAllAppDataConfirmation => '¿Eliminar todos los datos de la app?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Esto borrará todos los perfiles, claves, chats y archivos locales de este dispositivo. No se puede deshacer.';
+
+  @override
+  String get deleteAllAppDataFailed =>
+      'Error al eliminar los datos de la app. Por favor, inténtalo de nuevo.';
 }

--- a/lib/l10n/generated/app_localizations_fr.dart
+++ b/lib/l10n/generated/app_localizations_fr.dart
@@ -79,6 +79,15 @@ class AppLocalizationsFr extends AppLocalizations {
   String get appSettings => 'Paramètres de l\'app';
 
   @override
+  String get privacyAndSecurity => 'Confidentialité et sécurité';
+
+  @override
+  String get dataUsage => 'Utilisation des données';
+
+  @override
+  String get appearance => 'Apparence';
+
+  @override
   String get donateToWhiteNoise => 'Faire un don à White Noise';
 
   @override
@@ -431,4 +440,25 @@ class AppLocalizationsFr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Supprimer toutes les données de l\'app';
+
+  @override
+  String get deleteAppData => 'Supprimer les données de l\'app';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Efface tous les profils, clés, conversations et fichiers locaux de cet appareil.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Supprimer toutes les données de l\'app ?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Cela effacera tous les profils, clés, conversations et fichiers locaux de cet appareil. Cette action est irréversible.';
+
+  @override
+  String get deleteAllAppDataFailed =>
+      'Échec de la suppression des données de l\'app. Veuillez réessayer.';
 }

--- a/lib/l10n/generated/app_localizations_it.dart
+++ b/lib/l10n/generated/app_localizations_it.dart
@@ -79,6 +79,15 @@ class AppLocalizationsIt extends AppLocalizations {
   String get appSettings => 'Impostazioni app';
 
   @override
+  String get privacyAndSecurity => 'Privacy e sicurezza';
+
+  @override
+  String get dataUsage => 'Utilizzo dati';
+
+  @override
+  String get appearance => 'Aspetto';
+
+  @override
   String get donateToWhiteNoise => 'Dona a White Noise';
 
   @override
@@ -430,4 +439,24 @@ class AppLocalizationsIt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Elimina tutti i dati dell\'app';
+
+  @override
+  String get deleteAppData => 'Elimina dati dell\'app';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Cancella tutti i profili, le chiavi, le chat e i file locali da questo dispositivo.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Eliminare tutti i dati dell\'app?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Questo cancellerà tutti i profili, le chiavi, le chat e i file locali da questo dispositivo. Non può essere annullato.';
+
+  @override
+  String get deleteAllAppDataFailed => 'Eliminazione dei dati dell\'app fallita. Riprova.';
 }

--- a/lib/l10n/generated/app_localizations_pt.dart
+++ b/lib/l10n/generated/app_localizations_pt.dart
@@ -79,6 +79,15 @@ class AppLocalizationsPt extends AppLocalizations {
   String get appSettings => 'Configurações do app';
 
   @override
+  String get privacyAndSecurity => 'Privacidade e segurança';
+
+  @override
+  String get dataUsage => 'Uso de dados';
+
+  @override
+  String get appearance => 'Aparência';
+
+  @override
   String get donateToWhiteNoise => 'Doar para o White Noise';
 
   @override
@@ -430,4 +439,24 @@ class AppLocalizationsPt extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Excluir todos os dados do app';
+
+  @override
+  String get deleteAppData => 'Excluir dados do app';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Apaga todos os perfis, chaves, conversas e arquivos locais deste dispositivo.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Excluir todos os dados do app?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Isso apagará todos os perfis, chaves, conversas e arquivos locais deste dispositivo. Não pode ser desfeito.';
+
+  @override
+  String get deleteAllAppDataFailed => 'Falha ao excluir dados do app. Por favor, tente novamente.';
 }

--- a/lib/l10n/generated/app_localizations_ru.dart
+++ b/lib/l10n/generated/app_localizations_ru.dart
@@ -79,6 +79,15 @@ class AppLocalizationsRu extends AppLocalizations {
   String get appSettings => 'Настройки приложения';
 
   @override
+  String get privacyAndSecurity => 'Конфиденциальность и безопасность';
+
+  @override
+  String get dataUsage => 'Использование данных';
+
+  @override
+  String get appearance => 'Оформление';
+
+  @override
   String get donateToWhiteNoise => 'Пожертвовать White Noise';
 
   @override
@@ -435,4 +444,24 @@ class AppLocalizationsRu extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Удалить все данные приложения';
+
+  @override
+  String get deleteAppData => 'Удалить данные приложения';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Удалит все профили, ключи, чаты и локальные файлы с этого устройства.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Удалить все данные приложения?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Это удалит все профили, ключи, чаты и локальные файлы с этого устройства. Это нельзя отменить.';
+
+  @override
+  String get deleteAllAppDataFailed => 'Не удалось удалить данные приложения. Попробуйте снова.';
 }

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -79,6 +79,15 @@ class AppLocalizationsTr extends AppLocalizations {
   String get appSettings => 'Uygulama ayarları';
 
   @override
+  String get privacyAndSecurity => 'Gizlilik ve güvenlik';
+
+  @override
+  String get dataUsage => 'Veri kullanımı';
+
+  @override
+  String get appearance => 'Görünüm';
+
+  @override
   String get donateToWhiteNoise => 'White Noise\'a bağış yap';
 
   @override
@@ -429,4 +438,24 @@ class AppLocalizationsTr extends AppLocalizations {
     );
     return '$_temp0';
   }
+
+  @override
+  String get deleteAllAppData => 'Tüm uygulama verilerini sil';
+
+  @override
+  String get deleteAppData => 'Uygulama verilerini sil';
+
+  @override
+  String get deleteAllAppDataDescription =>
+      'Bu cihazdaki tüm profilleri, anahtarları, sohbetleri ve yerel dosyaları siler.';
+
+  @override
+  String get deleteAllAppDataConfirmation => 'Tüm uygulama verileri silinsin mi?';
+
+  @override
+  String get deleteAllAppDataWarning =>
+      'Bu, bu cihazdaki tüm profilleri, anahtarları, sohbetleri ve yerel dosyaları silecektir. Bu geri alınamaz.';
+
+  @override
+  String get deleteAllAppDataFailed => 'Uygulama verileri silinemedi. Lütfen tekrar deneyin.';
 }

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -7,10 +7,12 @@ import 'package:sloth/hooks/use_route_refresh.dart' show routeObserver;
 import 'package:sloth/providers/auth_provider.dart' show authProvider;
 import 'package:sloth/providers/is_adding_account_provider.dart' show isAddingAccountProvider;
 import 'package:sloth/screens/add_profile_screen.dart' show AddProfileScreen;
-import 'package:sloth/screens/app_settings_screen.dart' show AppSettingsScreen;
+import 'package:sloth/screens/appearance_screen.dart' show AppearanceScreen;
 import 'package:sloth/screens/chat_invite_screen.dart' show ChatInviteScreen;
 import 'package:sloth/screens/chat_list_screen.dart' show ChatListScreen;
 import 'package:sloth/screens/chat_screen.dart' show ChatScreen;
+import 'package:sloth/screens/delete_all_data_confirmation_screen.dart'
+    show DeleteAllDataConfirmationScreen;
 import 'package:sloth/screens/developer_settings_screen.dart' show DeveloperSettingsScreen;
 import 'package:sloth/screens/donate_screen.dart' show DonateScreen;
 import 'package:sloth/screens/edit_profile_screen.dart' show EditProfileScreen;
@@ -18,6 +20,7 @@ import 'package:sloth/screens/home_screen.dart' show HomeScreen;
 import 'package:sloth/screens/login_screen.dart' show LoginScreen;
 import 'package:sloth/screens/network_screen.dart' show NetworkScreen;
 import 'package:sloth/screens/onboarding_screen.dart' show OnboardingScreen;
+import 'package:sloth/screens/privacy_security_screen.dart' show PrivacySecurityScreen;
 import 'package:sloth/screens/profile_keys_screen.dart' show ProfileKeysScreen;
 import 'package:sloth/screens/settings_screen.dart' show SettingsScreen;
 import 'package:sloth/screens/share_profile_screen.dart' show ShareProfileScreen;
@@ -34,7 +37,9 @@ abstract final class Routes {
   static const _chatList = '/chats';
   static const _settings = '/settings';
   static const _donate = '/donate';
-  static const _appSettings = '/app-settings';
+  static const _appearance = '/appearance';
+  static const _privacySecurity = '/privacy-security';
+  static const _deleteAllDataConfirmation = '/delete-all-data-confirmation';
   static const _wip = '/wip';
   static const _onboarding = '/onboarding';
   static const _developerSettings = '/developer-settings';
@@ -108,10 +113,24 @@ abstract final class Routes {
           ),
         ),
         GoRoute(
-          path: _appSettings,
+          path: _appearance,
           pageBuilder: (context, state) => _navigationTransition(
             state: state,
-            child: const AppSettingsScreen(),
+            child: const AppearanceScreen(),
+          ),
+        ),
+        GoRoute(
+          path: _privacySecurity,
+          pageBuilder: (context, state) => _navigationTransition(
+            state: state,
+            child: const PrivacySecurityScreen(),
+          ),
+        ),
+        GoRoute(
+          path: _deleteAllDataConfirmation,
+          pageBuilder: (context, state) => _navigationTransition(
+            state: state,
+            child: const DeleteAllDataConfirmationScreen(),
           ),
         ),
         GoRoute(
@@ -279,8 +298,16 @@ abstract final class Routes {
     GoRouter.of(context).push(_donate);
   }
 
-  static void pushToAppSettings(BuildContext context) {
-    GoRouter.of(context).push(_appSettings);
+  static void pushToAppearance(BuildContext context) {
+    GoRouter.of(context).push(_appearance);
+  }
+
+  static void pushToPrivacySecurity(BuildContext context) {
+    GoRouter.of(context).push(_privacySecurity);
+  }
+
+  static void pushToDeleteAllDataConfirmation(BuildContext context) {
+    GoRouter.of(context).push(_deleteAllDataConfirmation);
   }
 
   static void goToOnboarding(BuildContext context) {

--- a/lib/screens/appearance_screen.dart
+++ b/lib/screens/appearance_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:sloth/l10n/l10n.dart';
 import 'package:sloth/providers/locale_provider.dart';
 import 'package:sloth/providers/theme_provider.dart';
@@ -9,8 +10,8 @@ import 'package:sloth/widgets/wn_dropdown_selector.dart';
 import 'package:sloth/widgets/wn_screen_header.dart';
 import 'package:sloth/widgets/wn_slate_container.dart';
 
-class AppSettingsScreen extends ConsumerWidget {
-  const AppSettingsScreen({super.key});
+class AppearanceScreen extends HookConsumerWidget {
+  const AppearanceScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -44,16 +45,17 @@ class AppSettingsScreen extends ConsumerWidget {
           padding: EdgeInsets.symmetric(vertical: 16.h),
           child: WnSlateContainer(
             child: Column(
-              spacing: 24.h,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                WnScreenHeader(title: context.l10n.appSettingsTitle),
+                WnScreenHeader(title: context.l10n.appearance),
+                Gap(24.h),
                 WnDropdownSelector<ThemeMode>(
                   label: context.l10n.theme,
                   options: themeOptions,
                   value: currentThemeMode,
                   onChanged: (mode) => ref.read(themeProvider.notifier).setThemeMode(mode),
                 ),
+                Gap(24.h),
                 WnDropdownSelector<LocaleSetting>(
                   label: context.l10n.language,
                   options: languageOptions,

--- a/lib/screens/delete_all_data_confirmation_screen.dart
+++ b/lib/screens/delete_all_data_confirmation_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:sloth/l10n/l10n.dart';
+import 'package:sloth/providers/auth_provider.dart';
+import 'package:sloth/routes.dart';
+import 'package:sloth/src/rust/api.dart' as rust_api;
+import 'package:sloth/theme.dart';
+import 'package:sloth/widgets/wn_button.dart';
+import 'package:sloth/widgets/wn_screen_header.dart';
+import 'package:sloth/widgets/wn_slate_container.dart';
+
+class DeleteAllDataConfirmationScreen extends HookConsumerWidget {
+  const DeleteAllDataConfirmationScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colors = context.colors;
+    final isDeleting = useState(false);
+
+    Future<void> deleteAllAppData() async {
+      isDeleting.value = true;
+      try {
+        await rust_api.deleteAllData();
+        final storage = ref.read(secureStorageProvider);
+        await storage.deleteAll();
+        ref.invalidate(authProvider);
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (context.mounted) {
+            Routes.goToHome(context);
+          }
+        });
+      } catch (e) {
+        isDeleting.value = false;
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(context.l10n.deleteAllAppDataFailed)),
+          );
+        }
+      }
+    }
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 16.h),
+          child: WnSlateContainer(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                WnScreenHeader(
+                  title: context.l10n.deleteAllAppDataConfirmation,
+                ),
+                Gap(12.h),
+                Text(
+                  context.l10n.deleteAllAppDataWarning,
+                  style: TextStyle(
+                    fontSize: 14.sp,
+                    fontWeight: FontWeight.w500,
+                    letterSpacing: 0.4,
+                    color: colors.backgroundContentPrimary,
+                  ),
+                ),
+                Gap(20.h),
+                SizedBox(
+                  width: double.infinity,
+                  child: WnButton(
+                    key: const Key('cancel_button'),
+                    text: context.l10n.cancel,
+                    type: WnButtonType.outline,
+                    size: WnButtonSize.medium,
+                    onPressed: () => Routes.goBack(context),
+                  ),
+                ),
+                Gap(8.h),
+                SizedBox(
+                  width: double.infinity,
+                  child: WnButton(
+                    key: const Key('confirm_delete_button'),
+                    text: context.l10n.deleteAppData,
+                    type: WnButtonType.destructive,
+                    size: WnButtonSize.medium,
+                    loading: isDeleting.value,
+                    onPressed: deleteAllAppData,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/privacy_security_screen.dart
+++ b/lib/screens/privacy_security_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:sloth/l10n/l10n.dart';
+import 'package:sloth/routes.dart';
+import 'package:sloth/theme.dart';
+import 'package:sloth/widgets/wn_button.dart';
+import 'package:sloth/widgets/wn_icon.dart';
+import 'package:sloth/widgets/wn_screen_header.dart';
+import 'package:sloth/widgets/wn_slate_container.dart';
+
+class PrivacySecurityScreen extends StatelessWidget {
+  const PrivacySecurityScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return Scaffold(
+      backgroundColor: colors.backgroundPrimary,
+      body: SafeArea(
+        child: Padding(
+          padding: EdgeInsets.symmetric(vertical: 16.h),
+          child: WnSlateContainer(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                WnScreenHeader(title: context.l10n.privacyAndSecurity),
+                Gap(12.h),
+                Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 2.w),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        context.l10n.deleteAllAppData,
+                        style: TextStyle(
+                          fontSize: 16.sp,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0.2,
+                          color: colors.backgroundContentSecondary,
+                        ),
+                      ),
+                      Gap(8.h),
+                      SizedBox(
+                        width: double.infinity,
+                        child: WnButton(
+                          key: const Key('delete_app_data_button'),
+                          text: context.l10n.deleteAppData,
+                          type: WnButtonType.destructive,
+                          size: WnButtonSize.medium,
+                          trailingIcon: WnIcons.trashCan,
+                          onPressed: () => Routes.pushToDeleteAllDataConfirmation(context),
+                        ),
+                      ),
+                      Gap(4.h),
+                      Text(
+                        context.l10n.deleteAllAppDataDescription,
+                        style: TextStyle(
+                          fontSize: 14.sp,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0.4,
+                          color: colors.backgroundContentSecondary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -9,8 +9,9 @@ import 'package:sloth/theme.dart';
 import 'package:sloth/utils/formatting.dart';
 import 'package:sloth/utils/metadata.dart';
 import 'package:sloth/widgets/wn_avatar.dart';
+import 'package:sloth/widgets/wn_button.dart';
 import 'package:sloth/widgets/wn_icon.dart';
-import 'package:sloth/widgets/wn_outlined_button.dart';
+import 'package:sloth/widgets/wn_menu_item.dart';
 import 'package:sloth/widgets/wn_screen_header.dart';
 import 'package:sloth/widgets/wn_slate_container.dart';
 
@@ -36,158 +37,130 @@ class SettingsScreen extends HookConsumerWidget {
         child: Padding(
           padding: EdgeInsets.symmetric(vertical: 16.h),
           child: WnSlateContainer(
-            child: Column(
-              spacing: 16.h,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                WnScreenHeader(title: context.l10n.settings),
-                Center(
-                  child: Row(
-                    spacing: 8.w,
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: [
-                      WnAvatar(
-                        pictureUrl: metadata?.picture,
-                        displayName: displayName,
-                        size: 56.w,
-                      ),
-                      Flexible(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            if (displayName != null)
-                              Text(
-                                displayName,
-                                style: TextStyle(
-                                  fontSize: 16.sp,
-                                  fontWeight: FontWeight.w600,
-                                  color: colors.backgroundContentPrimary,
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  WnScreenHeader(title: context.l10n.settings),
+                  SizedBox(height: 16.h),
+                  Center(
+                    child: Row(
+                      spacing: 8.w,
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        WnAvatar(
+                          pictureUrl: metadata?.picture,
+                          displayName: displayName,
+                          size: 56.w,
+                        ),
+                        Flexible(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (displayName != null)
+                                Text(
+                                  displayName,
+                                  style: TextStyle(
+                                    fontSize: 16.sp,
+                                    fontWeight: FontWeight.w600,
+                                    color: colors.backgroundContentPrimary,
+                                  ),
                                 ),
-                              ),
-                            Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    formatPublicKey(npubFromHex(pubkey) ?? pubkey),
-                                    maxLines: 2,
-                                    style: TextStyle(
-                                      fontSize: 12.sp,
-                                      fontWeight: FontWeight.w500,
-                                      color: colors.backgroundContentSecondary,
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: Text(
+                                      formatPublicKey(npubFromHex(pubkey) ?? pubkey),
+                                      maxLines: 2,
+                                      style: TextStyle(
+                                        fontSize: 12.sp,
+                                        fontWeight: FontWeight.w500,
+                                        color: colors.backgroundContentSecondary,
+                                      ),
                                     ),
                                   ),
-                                ),
-                                SizedBox(width: 8.w),
-                                IconButton(
-                                  key: const Key('qr_code_button'),
-                                  onPressed: () => Routes.pushToShareProfile(context),
-                                  icon: WnIcon(
-                                    WnIcons.qrCode,
-                                    color: colors.backgroundContentTertiary,
+                                  SizedBox(width: 8.w),
+                                  IconButton(
+                                    key: const Key('qr_code_button'),
+                                    onPressed: () => Routes.pushToShareProfile(context),
+                                    icon: WnIcon(
+                                      WnIcons.qrCode,
+                                      color: colors.backgroundContentTertiary,
+                                    ),
+                                    padding: EdgeInsets.zero,
+                                    constraints: BoxConstraints(
+                                      minWidth: 24.w,
+                                      minHeight: 24.w,
+                                    ),
                                   ),
-                                  padding: EdgeInsets.zero,
-                                  constraints: BoxConstraints(
-                                    minWidth: 24.w,
-                                    minHeight: 24.w,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ],
+                                ],
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
+                      ],
+                    ),
                   ),
-                ),
-                SizedBox(
-                  width: double.infinity,
-                  child: WnOutlinedButton(
-                    text: 'Switch Profile',
-                    onPressed: () => Routes.pushToSwitchProfile(context),
+                  SizedBox(
+                    width: double.infinity,
+                    child: WnButton(
+                      text: 'Switch Profile',
+                      type: WnButtonType.outline,
+                      onPressed: () => Routes.pushToSwitchProfile(context),
+                    ),
                   ),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.user,
-                  label: context.l10n.editProfile,
-                  onTap: () => Routes.pushToEditProfile(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.key,
-                  label: context.l10n.profileKeys,
-                  onTap: () => Routes.pushToProfileKeys(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.network,
-                  label: context.l10n.networkRelays,
-                  onTap: () => Routes.pushToNetwork(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.settings,
-                  label: context.l10n.appSettings,
-                  onTap: () => Routes.pushToAppSettings(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.heart,
-                  label: context.l10n.donateToWhiteNoise,
-                  onTap: () => Routes.pushToDonate(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.developerSettings,
-                  label: context.l10n.developerSettings,
-                  onTap: () => Routes.pushToDeveloperSettings(context),
-                ),
-                _SettingsTile(
-                  icon: WnIcons.logout,
-                  label: context.l10n.signOut,
-                  onTap: () => Routes.pushToSignOut(context),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _SettingsTile extends StatelessWidget {
-  const _SettingsTile({
-    required this.icon,
-    required this.label,
-    required this.onTap,
-  });
-
-  final WnIcons icon;
-  final String label;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return GestureDetector(
-      onTap: onTap,
-      behavior: HitTestBehavior.opaque,
-      child: Padding(
-        padding: EdgeInsets.symmetric(vertical: 12.h),
-        child: Row(
-          children: [
-            WnIcon(
-              icon,
-              color: colors.backgroundContentPrimary,
-            ),
-            SizedBox(width: 12.w),
-            Expanded(
-              child: Text(
-                label,
-                style: TextStyle(
-                  color: colors.backgroundContentPrimary,
-                  fontSize: 16.sp,
-                  fontWeight: FontWeight.w600,
-                ),
+                  WnMenuItem(
+                    icon: WnIcons.user,
+                    label: context.l10n.editProfile,
+                    onTap: () => Routes.pushToEditProfile(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.key,
+                    label: context.l10n.profileKeys,
+                    onTap: () => Routes.pushToProfileKeys(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.network,
+                    label: context.l10n.networkRelays,
+                    onTap: () => Routes.pushToNetwork(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.privacy,
+                    label: context.l10n.privacyAndSecurity,
+                    onTap: () => Routes.pushToPrivacySecurity(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.dataUsage,
+                    label: context.l10n.dataUsage,
+                    onTap: () => Routes.pushToWip(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.appearance,
+                    label: context.l10n.appearance,
+                    onTap: () => Routes.pushToAppearance(context),
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.logout,
+                    label: context.l10n.signOut,
+                    onTap: () => Routes.pushToSignOut(context),
+                  ),
+                  Divider(color: colors.borderTertiary, height: 1.h),
+                  WnMenuItem(
+                    icon: WnIcons.heart,
+                    label: context.l10n.donate,
+                    onTap: () => Routes.pushToDonate(context),
+                    type: WnMenuItemType.secondary,
+                  ),
+                  WnMenuItem(
+                    icon: WnIcons.developerSettings,
+                    label: context.l10n.developerSettings,
+                    onTap: () => Routes.pushToDeveloperSettings(context),
+                    type: WnMenuItemType.secondary,
+                  ),
+                ],
               ),
             ),
-          ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/wn_button.dart
+++ b/lib/widgets/wn_button.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:sloth/theme.dart';
+import 'package:sloth/widgets/wn_icon.dart';
+
+enum WnButtonType { primary, outline, ghost, overlay, destructive }
+
+enum WnButtonSize {
+  large(56),
+  medium(44),
+  small(32);
+
+  const WnButtonSize(this.height);
+  final double height;
+}
+
+class WnButton extends StatelessWidget {
+  const WnButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+    this.type = WnButtonType.primary,
+    this.size = WnButtonSize.large,
+    this.loading = false,
+    this.disabled = false,
+    this.leadingIcon,
+    this.trailingIcon,
+  });
+
+  final String text;
+  final VoidCallback? onPressed;
+  final WnButtonType type;
+  final WnButtonSize size;
+  final bool loading;
+  final bool disabled;
+  final WnIcons? leadingIcon;
+  final WnIcons? trailingIcon;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return switch (type) {
+      WnButtonType.primary => _buildPrimaryButton(colors),
+      WnButtonType.outline => _buildOutlineButton(colors),
+      WnButtonType.ghost => _buildGhostButton(colors),
+      WnButtonType.overlay => _buildOverlayButton(colors),
+      WnButtonType.destructive => _buildDestructiveButton(colors),
+    };
+  }
+
+  Widget _buildPrimaryButton(SemanticColors colors) {
+    final bgColor = disabled ? colors.fillPrimary.withValues(alpha: 0.25) : colors.fillPrimary;
+    final contentColor = disabled
+        ? colors.fillContentPrimary.withValues(alpha: 0.25)
+        : colors.fillContentPrimary;
+
+    return _buildButton(
+      backgroundColor: bgColor,
+      overlayColor: colors.fillPrimaryHover,
+      contentColor: contentColor,
+      borderSide: BorderSide.none,
+    );
+  }
+
+  Widget _buildOutlineButton(SemanticColors colors) {
+    final borderColor = disabled
+        ? colors.borderTertiary.withValues(alpha: 0.25)
+        : colors.borderTertiary;
+    final bgColor = disabled ? colors.fillSecondary.withValues(alpha: 0.25) : colors.fillSecondary;
+    final contentColor = disabled
+        ? colors.fillContentSecondary.withValues(alpha: 0.25)
+        : colors.fillContentSecondary;
+
+    return _buildButton(
+      backgroundColor: bgColor,
+      overlayColor: colors.fillSecondaryHover,
+      contentColor: contentColor,
+      borderSide: BorderSide(color: borderColor),
+    );
+  }
+
+  Widget _buildGhostButton(SemanticColors colors) {
+    final contentColor = disabled
+        ? colors.fillContentSecondary.withValues(alpha: 0.25)
+        : colors.fillContentSecondary;
+
+    return _buildButton(
+      backgroundColor: colors.fillTertiary,
+      overlayColor: colors.fillTertiaryHover,
+      contentColor: contentColor,
+      borderSide: BorderSide.none,
+    );
+  }
+
+  Widget _buildOverlayButton(SemanticColors colors) {
+    final bgColor = disabled
+        ? colors.fillQuaternary.withValues(alpha: 0.25)
+        : colors.fillQuaternary;
+    final contentColor = disabled
+        ? colors.backgroundContentPrimary.withValues(alpha: 0.25)
+        : colors.backgroundContentPrimary;
+
+    return _buildButton(
+      backgroundColor: bgColor,
+      overlayColor: colors.fillQuaternaryHover,
+      contentColor: contentColor,
+      borderSide: BorderSide.none,
+    );
+  }
+
+  Widget _buildDestructiveButton(SemanticColors colors) {
+    final borderColor = disabled
+        ? colors.borderDestructivePrimary.withValues(alpha: 0.25)
+        : colors.borderDestructivePrimary;
+    final bgColor = disabled
+        ? colors.fillDestructive.withValues(alpha: 0.25)
+        : colors.fillDestructive;
+    final contentColor = disabled
+        ? colors.fillContentDestructive.withValues(alpha: 0.25)
+        : colors.fillContentDestructive;
+
+    return _buildButton(
+      backgroundColor: bgColor,
+      overlayColor: colors.fillDestructiveHover,
+      contentColor: contentColor,
+      borderSide: BorderSide(color: borderColor),
+    );
+  }
+
+  Widget _buildButton({
+    required Color backgroundColor,
+    required Color overlayColor,
+    required Color contentColor,
+    required BorderSide borderSide,
+  }) {
+    final verticalPadding = _getVerticalPadding();
+    final iconSize = _getIconSize();
+    final fontSize = _getFontSize();
+    final iconPadding = size == WnButtonSize.small ? 4.w : 8.w;
+
+    return FilledButton(
+      onPressed: (loading || disabled) ? null : onPressed,
+      style: FilledButton.styleFrom(
+        padding: EdgeInsets.symmetric(vertical: verticalPadding, horizontal: 8.w),
+        backgroundColor: backgroundColor,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8.r),
+          side: borderSide,
+        ),
+        overlayColor: overlayColor,
+      ),
+      child: loading
+          ? _buildLoadingIndicator(contentColor)
+          : _buildContent(contentColor, iconSize, fontSize, iconPadding),
+    );
+  }
+
+  Widget _buildLoadingIndicator(Color color) {
+    final indicatorSize = size == WnButtonSize.small ? 14.w : 18.w;
+    return SizedBox.square(
+      dimension: indicatorSize,
+      child: CircularProgressIndicator(
+        key: const Key('loading_indicator'),
+        strokeWidth: 2.w,
+        strokeCap: StrokeCap.round,
+        color: color,
+      ),
+    );
+  }
+
+  Widget _buildContent(Color contentColor, double iconSize, double fontSize, double iconPadding) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        if (leadingIcon != null) ...[
+          WnIcon(
+            leadingIcon!,
+            size: iconSize,
+            color: contentColor,
+            key: const Key('leading_icon'),
+          ),
+          SizedBox(width: iconPadding),
+        ],
+        Text(
+          text,
+          style: TextStyle(
+            fontWeight: FontWeight.w500,
+            fontSize: fontSize,
+            color: contentColor,
+            letterSpacing: 0.4,
+            height: 20 / 14,
+          ),
+        ),
+        if (trailingIcon != null) ...[
+          SizedBox(width: iconPadding),
+          WnIcon(
+            trailingIcon!,
+            size: iconSize,
+            color: contentColor,
+            key: const Key('trailing_icon'),
+          ),
+        ],
+      ],
+    );
+  }
+
+  double _getVerticalPadding() {
+    return switch (size) {
+      WnButtonSize.large => 18.h,
+      WnButtonSize.medium => 12.h,
+      WnButtonSize.small => 6.h,
+    };
+  }
+
+  double _getIconSize() {
+    return switch (size) {
+      WnButtonSize.large => 18.w,
+      WnButtonSize.medium => 18.w,
+      WnButtonSize.small => 16.w,
+    };
+  }
+
+  double _getFontSize() {
+    return switch (size) {
+      WnButtonSize.large => 14.sp,
+      WnButtonSize.medium => 14.sp,
+      WnButtonSize.small => 12.sp,
+    };
+  }
+}

--- a/lib/widgets/wn_menu_item.dart
+++ b/lib/widgets/wn_menu_item.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:sloth/theme.dart';
+import 'package:sloth/widgets/wn_icon.dart';
+
+enum WnMenuItemType { primary, secondary }
+
+class WnMenuItem extends StatelessWidget {
+  const WnMenuItem({
+    super.key,
+    required this.icon,
+    required this.label,
+    required this.onTap,
+    this.type = WnMenuItemType.primary,
+  });
+
+  final WnIcons icon;
+  final String label;
+  final VoidCallback onTap;
+  final WnMenuItemType type;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final contentColor = type == WnMenuItemType.primary
+        ? colors.backgroundContentPrimary
+        : colors.backgroundContentSecondary;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: SizedBox(
+        height: 56.h,
+        child: Row(
+          children: [
+            SizedBox(
+              width: 18.w,
+              height: 18.w,
+              child: WnIcon(
+                icon,
+                size: 18.w,
+                color: contentColor,
+              ),
+            ),
+            SizedBox(width: 10.w),
+            Expanded(
+              child: Text(
+                label,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  color: contentColor,
+                  fontSize: 16.sp,
+                  fontWeight: FontWeight.w500,
+                  height: 22 / 16,
+                  letterSpacing: 0.2,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/scripts/validate-locales-keys.sh
+++ b/scripts/validate-locales-keys.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -eo pipefail
+export LC_ALL=C
 
 TEMPLATE="${1:-lib/l10n/app_en.arb}"
 ERRORS=0

--- a/test/mocks/mock_secure_storage.dart
+++ b/test/mocks/mock_secure_storage.dart
@@ -3,6 +3,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 class MockSecureStorage implements FlutterSecureStorage {
   final Map<String, String> _data = {};
   bool shouldThrowOnRead = false;
+  bool deleteAllCalled = false;
 
   @override
   Future<String?> read({
@@ -42,6 +43,19 @@ class MockSecureStorage implements FlutterSecureStorage {
     AppleOptions? mOptions,
     WindowsOptions? wOptions,
   }) async => _data.remove(key);
+
+  @override
+  Future<void> deleteAll({
+    AppleOptions? iOptions,
+    AndroidOptions? aOptions,
+    LinuxOptions? lOptions,
+    WebOptions? webOptions,
+    AppleOptions? mOptions,
+    WindowsOptions? wOptions,
+  }) async {
+    deleteAllCalled = true;
+    _data.clear();
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError();

--- a/test/mocks/mock_wn_api.dart
+++ b/test/mocks/mock_wn_api.dart
@@ -36,6 +36,7 @@ class MockWnApi implements RustLibApi {
   String currentLanguage = 'en';
   bool shouldFailUpdateLanguage = false;
   bool shouldFailNpubConversion = false;
+  bool shouldFailDeleteAllData = false;
   List<Account> accounts = [];
   Completer<List<Account>>? getAccountsCompleter;
 
@@ -228,11 +229,19 @@ class MockWnApi implements RustLibApi {
     }
   }
 
+  @override
+  Future<void> crateApiDeleteAllData() async {
+    if (shouldFailDeleteAllData) {
+      throw Exception('Failed to delete all data');
+    }
+  }
+
   void reset() {
     currentThemeMode = 'system';
     currentLanguage = 'en';
     shouldFailUpdateLanguage = false;
     shouldFailNpubConversion = false;
+    shouldFailDeleteAllData = false;
     accounts = [];
     getAccountsCompleter = null;
   }

--- a/test/screens/appearance_screen_test.dart
+++ b/test/screens/appearance_screen_test.dart
@@ -32,7 +32,7 @@ void main() {
     mockApi.reset();
   });
 
-  Future<void> pumpAppSettingsScreen(
+  Future<void> pumpAppearanceScreen(
     WidgetTester tester, {
     String? initialThemeMode,
   }) async {
@@ -47,35 +47,35 @@ void main() {
         secureStorageProvider.overrideWithValue(MockSecureStorage()),
       ],
     );
-    Routes.pushToAppSettings(tester.element(find.byType(Scaffold)));
+    Routes.pushToAppearance(tester.element(find.byType(Scaffold)));
     await tester.pumpAndSettle();
   }
 
-  group('AppSettingsScreen', () {
-    testWidgets('displays App Settings title', (tester) async {
-      await pumpAppSettingsScreen(tester);
-      expect(find.text('App Settings'), findsOneWidget);
+  group('AppearanceScreen', () {
+    testWidgets('displays Appearance title', (tester) async {
+      await pumpAppearanceScreen(tester);
+      expect(find.text('Appearance'), findsOneWidget);
     });
 
     testWidgets('displays Theme dropdown label', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
       expect(find.text('Theme'), findsOneWidget);
     });
 
     testWidgets('displays current theme and language values in dropdowns', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
       expect(find.text('System'), findsNWidgets(2));
     });
 
     testWidgets('tapping close icon returns to previous screen', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
       await tester.tap(find.byKey(const Key('close_button')));
       await tester.pumpAndSettle();
       expect(find.byType(ChatListScreen), findsOneWidget);
     });
 
     testWidgets('can select Light theme from dropdown', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -87,7 +87,7 @@ void main() {
     });
 
     testWidgets('can select Dark theme from dropdown', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -100,7 +100,7 @@ void main() {
 
     testWidgets('can select System theme from dropdown', (tester) async {
       mockApi.currentThemeMode = 'light';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -112,7 +112,7 @@ void main() {
     });
 
     testWidgets('dropdown shows all theme options', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -123,7 +123,7 @@ void main() {
     });
 
     testWidgets('theme selection persists across navigation', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -133,14 +133,14 @@ void main() {
       await tester.tap(find.byKey(const Key('close_button')));
       await tester.pumpAndSettle();
 
-      Routes.pushToAppSettings(tester.element(find.byType(Scaffold)));
+      Routes.pushToAppearance(tester.element(find.byType(Scaffold)));
       await tester.pumpAndSettle();
 
       expect(mockApi.currentThemeMode, 'dark');
     });
 
     testWidgets('can switch themes multiple times', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<ThemeMode>));
       await tester.pumpAndSettle();
@@ -163,20 +163,20 @@ void main() {
     });
 
     testWidgets('displays dropdown icons for theme and language', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
       expect(find.byKey(const Key('dropdown_icon')), findsNWidgets(2));
     });
   });
 
   group('Language Dropdown', () {
     testWidgets('displays Language dropdown label', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
       expect(find.text('Language'), findsOneWidget);
     });
 
     testWidgets('can select English from dropdown', (tester) async {
       mockApi.currentLanguage = 'de';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -189,7 +189,7 @@ void main() {
 
     testWidgets('can select Spanish from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -202,7 +202,7 @@ void main() {
 
     testWidgets('can select German from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -215,7 +215,7 @@ void main() {
 
     testWidgets('can select French from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -228,7 +228,7 @@ void main() {
 
     testWidgets('can select Italian from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -248,7 +248,7 @@ void main() {
 
     testWidgets('can select Portuguese from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -268,7 +268,7 @@ void main() {
 
     testWidgets('can select Russian from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -288,7 +288,7 @@ void main() {
 
     testWidgets('can select Turkish from dropdown', (tester) async {
       mockApi.currentLanguage = 'en';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -307,7 +307,7 @@ void main() {
     });
 
     testWidgets('dropdown contains all 8 languages plus System', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -333,7 +333,7 @@ void main() {
     });
 
     testWidgets('language selection persists across navigation', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -343,14 +343,14 @@ void main() {
       await tester.tap(find.byKey(const Key('close_button')));
       await tester.pumpAndSettle();
 
-      Routes.pushToAppSettings(tester.element(find.byType(Scaffold)));
+      Routes.pushToAppearance(tester.element(find.byType(Scaffold)));
       await tester.pumpAndSettle();
 
       expect(mockApi.currentLanguage, 'de');
     });
 
     testWidgets('can switch languages multiple times', (tester) async {
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -373,7 +373,7 @@ void main() {
 
     testWidgets('can select System language from dropdown', (tester) async {
       mockApi.currentLanguage = 'de';
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();
@@ -387,7 +387,7 @@ void main() {
 
     testWidgets('shows snackbar error when language update fails', (tester) async {
       mockApi.shouldFailUpdateLanguage = true;
-      await pumpAppSettingsScreen(tester);
+      await pumpAppearanceScreen(tester);
 
       await tester.tap(find.byType(WnDropdownSelector<LocaleSetting>));
       await tester.pumpAndSettle();

--- a/test/screens/privacy_security_screen_test.dart
+++ b/test/screens/privacy_security_screen_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart' show AsyncData;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sloth/providers/auth_provider.dart';
+import 'package:sloth/routes.dart';
+import 'package:sloth/screens/chat_list_screen.dart';
+import 'package:sloth/screens/delete_all_data_confirmation_screen.dart';
+import 'package:sloth/src/rust/frb_generated.dart';
+
+import '../mocks/mock_secure_storage.dart';
+import '../mocks/mock_wn_api.dart';
+import '../test_helpers.dart';
+
+class _MockAuthNotifier extends AuthNotifier {
+  @override
+  Future<String?> build() async {
+    state = const AsyncData('test_pubkey');
+    return 'test_pubkey';
+  }
+}
+
+void main() {
+  late MockWnApi mockApi;
+  late MockSecureStorage mockStorage;
+
+  setUpAll(() {
+    mockApi = MockWnApi();
+    RustLib.initMock(api: mockApi);
+  });
+
+  setUp(() {
+    mockApi.reset();
+    mockStorage = MockSecureStorage();
+  });
+
+  Future<void> pumpPrivacySecurityScreen(WidgetTester tester) async {
+    await mountTestApp(
+      tester,
+      overrides: [
+        authProvider.overrideWith(() => _MockAuthNotifier()),
+        secureStorageProvider.overrideWithValue(mockStorage),
+      ],
+    );
+    Routes.pushToPrivacySecurity(tester.element(find.byType(Scaffold)));
+    await tester.pumpAndSettle();
+  }
+
+  group('PrivacySecurityScreen', () {
+    testWidgets('displays Privacy & Security title', (tester) async {
+      await pumpPrivacySecurityScreen(tester);
+      expect(find.text('Privacy & Security'), findsOneWidget);
+    });
+
+    testWidgets('displays Delete all app data section', (tester) async {
+      await pumpPrivacySecurityScreen(tester);
+      expect(find.text('Delete all app data'), findsOneWidget);
+      expect(find.text('Delete app data'), findsOneWidget);
+      expect(
+        find.text('Erase every profile, key, chat, and local file from this device.'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('tapping close icon returns to previous screen', (tester) async {
+      await pumpPrivacySecurityScreen(tester);
+      await tester.tap(find.byKey(const Key('close_button')));
+      await tester.pumpAndSettle();
+      expect(find.byType(ChatListScreen), findsOneWidget);
+    });
+
+    testWidgets('tapping delete button navigates to confirmation screen', (tester) async {
+      await pumpPrivacySecurityScreen(tester);
+
+      await tester.tap(find.byKey(const Key('delete_app_data_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DeleteAllDataConfirmationScreen), findsOneWidget);
+    });
+  });
+
+  group('DeleteAllDataConfirmationScreen', () {
+    Future<void> pumpConfirmationScreen(WidgetTester tester) async {
+      await mountTestApp(
+        tester,
+        overrides: [
+          authProvider.overrideWith(() => _MockAuthNotifier()),
+          secureStorageProvider.overrideWithValue(mockStorage),
+        ],
+      );
+      Routes.pushToDeleteAllDataConfirmation(tester.element(find.byType(Scaffold)));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('displays confirmation title', (tester) async {
+      await pumpConfirmationScreen(tester);
+      expect(find.text('Delete all app data?'), findsOneWidget);
+    });
+
+    testWidgets('displays warning message', (tester) async {
+      await pumpConfirmationScreen(tester);
+      expect(
+        find.text(
+          'This will erase every profile, key, chat, and local file from this device. This cannot be undone.',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('displays Cancel and Delete app data buttons', (tester) async {
+      await pumpConfirmationScreen(tester);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Delete app data'), findsOneWidget);
+    });
+
+    testWidgets('tapping Cancel returns to previous screen', (tester) async {
+      await pumpPrivacySecurityScreen(tester);
+      await tester.tap(find.byKey(const Key('delete_app_data_button')));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('cancel_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Privacy & Security'), findsOneWidget);
+    });
+
+    testWidgets('confirming delete calls rust API and clears storage', (tester) async {
+      await pumpConfirmationScreen(tester);
+
+      await tester.tap(find.byKey(const Key('confirm_delete_button')));
+      await tester.pumpAndSettle();
+
+      expect(mockStorage.deleteAllCalled, isTrue);
+    });
+
+    testWidgets('shows error snackbar when delete fails', (tester) async {
+      mockApi.shouldFailDeleteAllData = true;
+      await pumpConfirmationScreen(tester);
+
+      await tester.tap(find.byKey(const Key('confirm_delete_button')));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Failed to delete app data. Please try again.'), findsOneWidget);
+    });
+  });
+}

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -3,12 +3,13 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' show AsyncData;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sloth/providers/auth_provider.dart';
 import 'package:sloth/routes.dart';
-import 'package:sloth/screens/app_settings_screen.dart';
+import 'package:sloth/screens/appearance_screen.dart';
 import 'package:sloth/screens/chat_list_screen.dart';
 import 'package:sloth/screens/developer_settings_screen.dart';
 import 'package:sloth/screens/donate_screen.dart';
 import 'package:sloth/screens/edit_profile_screen.dart';
 import 'package:sloth/screens/network_screen.dart';
+import 'package:sloth/screens/privacy_security_screen.dart';
 import 'package:sloth/screens/profile_keys_screen.dart';
 import 'package:sloth/screens/share_profile_screen.dart';
 import 'package:sloth/screens/sign_out_screen.dart';
@@ -126,16 +127,23 @@ void main() {
       expect(find.byType(NetworkScreen), findsOneWidget);
     });
 
-    testWidgets('tapping App settings navigates to AppSettingsScreen', (tester) async {
+    testWidgets('tapping Appearance navigates to AppearanceScreen', (tester) async {
       await pumpSettingsScreen(tester);
-      await tester.tap(find.text('App settings'));
+      await tester.tap(find.text('Appearance'));
       await tester.pumpAndSettle();
-      expect(find.byType(AppSettingsScreen), findsOneWidget);
+      expect(find.byType(AppearanceScreen), findsOneWidget);
+    });
+
+    testWidgets('tapping Privacy & Security navigates to PrivacySecurityScreen', (tester) async {
+      await pumpSettingsScreen(tester);
+      await tester.tap(find.text('Privacy & Security'));
+      await tester.pumpAndSettle();
+      expect(find.byType(PrivacySecurityScreen), findsOneWidget);
     });
 
     testWidgets('tapping Donate navigates to Donate screen', (tester) async {
       await pumpSettingsScreen(tester);
-      await tester.tap(find.text('Donate to White Noise'));
+      await tester.tap(find.text('Donate'));
       await tester.pumpAndSettle();
       expect(find.byType(DonateScreen), findsOneWidget);
     });

--- a/test/widgets/wn_button_test.dart
+++ b/test/widgets/wn_button_test.dart
@@ -1,0 +1,403 @@
+import 'package:flutter/material.dart' show Key;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sloth/widgets/wn_button.dart';
+import 'package:sloth/widgets/wn_icon.dart';
+import '../test_helpers.dart' show mountWidget;
+
+void main() {
+  group('WnButton tests', () {
+    group('basic functionality', () {
+      testWidgets('displays text', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Click me',
+          onPressed: () {},
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Click me'), findsOneWidget);
+      });
+
+      testWidgets('calls onPressed when tapped', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Click me',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isTrue);
+      });
+    });
+
+    group('button types', () {
+      testWidgets('renders primary type by default', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Primary',
+          onPressed: () {},
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Primary'), findsOneWidget);
+      });
+
+      testWidgets('renders outline type', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Outline',
+          onPressed: () {},
+          type: WnButtonType.outline,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Outline'), findsOneWidget);
+      });
+
+      testWidgets('renders ghost type', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Ghost',
+          onPressed: () {},
+          type: WnButtonType.ghost,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Ghost'), findsOneWidget);
+      });
+
+      testWidgets('renders overlay type', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Overlay',
+          onPressed: () {},
+          type: WnButtonType.overlay,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Overlay'), findsOneWidget);
+      });
+
+      testWidgets('renders destructive type', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Destructive',
+          onPressed: () {},
+          type: WnButtonType.destructive,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Destructive'), findsOneWidget);
+      });
+    });
+
+    group('button sizes', () {
+      testWidgets('renders large size by default', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Large',
+          onPressed: () {},
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Large'), findsOneWidget);
+      });
+
+      testWidgets('renders medium size', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Medium',
+          onPressed: () {},
+          size: WnButtonSize.medium,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Medium'), findsOneWidget);
+      });
+
+      testWidgets('renders small size', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Small',
+          onPressed: () {},
+          size: WnButtonSize.small,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Small'), findsOneWidget);
+      });
+    });
+
+    group('icons', () {
+      testWidgets('renders leading icon when provided', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'With Icon',
+          onPressed: () {},
+          leadingIcon: WnIcons.addLarge,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('leading_icon')), findsOneWidget);
+      });
+
+      testWidgets('renders trailing icon when provided', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'With Icon',
+          onPressed: () {},
+          trailingIcon: WnIcons.arrowRight,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('trailing_icon')), findsOneWidget);
+      });
+
+      testWidgets('renders both leading and trailing icons', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'With Icons',
+          onPressed: () {},
+          leadingIcon: WnIcons.addLarge,
+          trailingIcon: WnIcons.arrowRight,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('leading_icon')), findsOneWidget);
+        expect(find.byKey(const Key('trailing_icon')), findsOneWidget);
+      });
+
+      testWidgets('does not render icons when not provided', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'No Icons',
+          onPressed: () {},
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('leading_icon')), findsNothing);
+        expect(find.byKey(const Key('trailing_icon')), findsNothing);
+      });
+    });
+
+    group('loading state', () {
+      testWidgets('displays loading indicator when loading', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Loading',
+          onPressed: () {},
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('hides text when loading', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Loading',
+          onPressed: () {},
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Loading'), findsNothing);
+      });
+
+      testWidgets('does not call onPressed when loading', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Loading',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('hides icons when loading', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Loading',
+          onPressed: () {},
+          loading: true,
+          leadingIcon: WnIcons.addLarge,
+          trailingIcon: WnIcons.arrowRight,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('leading_icon')), findsNothing);
+        expect(find.byKey(const Key('trailing_icon')), findsNothing);
+      });
+    });
+
+    group('disabled state', () {
+      testWidgets('displays text when disabled', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Disabled',
+          onPressed: () {},
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.text('Disabled'), findsOneWidget);
+      });
+
+      testWidgets('does not display loading indicator when disabled', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Disabled',
+          onPressed: () {},
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsNothing);
+      });
+
+      testWidgets('does not call onPressed when disabled', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Disabled',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('displays icons when disabled', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Disabled',
+          onPressed: () {},
+          disabled: true,
+          leadingIcon: WnIcons.addLarge,
+          trailingIcon: WnIcons.arrowRight,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('leading_icon')), findsOneWidget);
+        expect(find.byKey(const Key('trailing_icon')), findsOneWidget);
+      });
+    });
+
+    group('disabled state for each button type', () {
+      testWidgets('primary button respects disabled state', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Primary',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('outline button respects disabled state', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Outline',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          type: WnButtonType.outline,
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('ghost button respects disabled state', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Ghost',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          type: WnButtonType.ghost,
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('overlay button respects disabled state', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Overlay',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          type: WnButtonType.overlay,
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+
+      testWidgets('destructive button respects disabled state', (WidgetTester tester) async {
+        var onPressedCalled = false;
+        final widget = WnButton(
+          text: 'Destructive',
+          onPressed: () {
+            onPressedCalled = true;
+          },
+          type: WnButtonType.destructive,
+          disabled: true,
+        );
+        await mountWidget(widget, tester);
+        await tester.tap(find.byType(WnButton));
+        expect(onPressedCalled, isFalse);
+      });
+    });
+
+    group('loading state for each button type', () {
+      testWidgets('primary button shows loading indicator', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Primary',
+          onPressed: () {},
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('outline button shows loading indicator', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Outline',
+          onPressed: () {},
+          type: WnButtonType.outline,
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('ghost button shows loading indicator', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Ghost',
+          onPressed: () {},
+          type: WnButtonType.ghost,
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('overlay button shows loading indicator', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Overlay',
+          onPressed: () {},
+          type: WnButtonType.overlay,
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('destructive button shows loading indicator', (WidgetTester tester) async {
+        final widget = WnButton(
+          text: 'Destructive',
+          onPressed: () {},
+          type: WnButtonType.destructive,
+          loading: true,
+        );
+        await mountWidget(widget, tester);
+        expect(find.byKey(const Key('loading_indicator')), findsOneWidget);
+      });
+    });
+
+    group('WnButtonSize enum', () {
+      test('large size has height of 56', () {
+        expect(WnButtonSize.large.height, 56);
+      });
+
+      test('medium size has height of 44', () {
+        expect(WnButtonSize.medium.height, 44);
+      });
+
+      test('small size has height of 32', () {
+        expect(WnButtonSize.small.height, 32);
+      });
+    });
+  });
+}

--- a/test/widgets/wn_menu_item_test.dart
+++ b/test/widgets/wn_menu_item_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sloth/widgets/wn_icon.dart';
+import 'package:sloth/widgets/wn_menu_item.dart';
+
+import '../test_helpers.dart';
+
+void main() {
+  group('WnMenuItem', () {
+    testWidgets('displays label and icon for primary type', (tester) async {
+      setUpTestView(tester);
+
+      await mountWidget(
+        WnMenuItem(
+          icon: WnIcons.user,
+          label: 'Test Label',
+          onTap: () {},
+        ),
+        tester,
+      );
+
+      expect(find.text('Test Label'), findsOneWidget);
+      expect(find.byType(WnIcon), findsOneWidget);
+    });
+
+    testWidgets('displays label and icon for secondary type', (tester) async {
+      setUpTestView(tester);
+
+      await mountWidget(
+        WnMenuItem(
+          icon: WnIcons.heart,
+          label: 'Secondary Label',
+          onTap: () {},
+          type: WnMenuItemType.secondary,
+        ),
+        tester,
+      );
+
+      expect(find.text('Secondary Label'), findsOneWidget);
+      expect(find.byType(WnIcon), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      setUpTestView(tester);
+      bool tapped = false;
+
+      await mountWidget(
+        WnMenuItem(
+          icon: WnIcons.settings,
+          label: 'Tap Me',
+          onTap: () => tapped = true,
+        ),
+        tester,
+      );
+
+      await tester.tap(find.text('Tap Me'));
+      expect(tapped, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Restructure settings screen with new `WnMenuItem` component for cleaner navigation
- Add Privacy & Security screen with delete all data option
- Add Appearance screen (renamed from App Settings)
- Add delete all data confirmation screen with destructive action

## New Components
- `WnButton` - unified button with multiple types (primary, outline, ghost, overlay, destructive) and sizes
- `WnMenuItem` - reusable menu item for settings-style navigation

## Changes
- New screens: `appearance_screen.dart`, `privacy_security_screen.dart`, `delete_all_data_confirmation_screen.dart`
- Updated `settings_screen.dart` with new layout and menu items
- Added localization strings for all 8 languages
- Updated routes for new screens

## Note
This PR includes `WnButton` which is also in PR #90. Once #90 merges, this branch should be rebased to remove the duplicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Privacy & Security and Appearance settings screens
  * Introduced app data deletion workflow with confirmation dialogs
  * New customizable button component with multiple visual styles and sizes
  * Expanded multi-language support across all new settings features
  * Added reusable menu item component for settings navigation

* **Tests**
  * Added comprehensive test coverage for new screens and UI components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->