### PR TITLE
feat(widgets): add WnSlot placeholder component with dashed border

### DIFF
--- a/lib/widgets/wn_slot.dart
+++ b/lib/widgets/wn_slot.dart
@@ -30,7 +30,7 @@ class WnSlot extends StatelessWidget {
     }
 
     return CustomPaint(
-      painter: _DashedBorderPainter(
+      painter: DashedBorderPainter(
         color: borderColor,
         strokeWidth: 1.w,
         dashWidth: 4.w,
@@ -63,7 +63,7 @@ class WnSlot extends StatelessWidget {
                   fontSize: 14.sp,
                   fontWeight: FontWeight.w500,
                   color: borderColor,
-                  letterSpacing: 0.4,
+                  letterSpacing: 0.4.sp,
                   height: 20 / 14,
                 ),
               ),
@@ -75,8 +75,9 @@ class WnSlot extends StatelessWidget {
   }
 }
 
-class _DashedBorderPainter extends CustomPainter {
-  _DashedBorderPainter({
+@visibleForTesting
+class DashedBorderPainter extends CustomPainter {
+  DashedBorderPainter({
     required this.color,
     required this.strokeWidth,
     required this.dashWidth,
@@ -137,7 +138,7 @@ class _DashedBorderPainter extends CustomPainter {
   }
 
   @override
-  bool shouldRepaint(_DashedBorderPainter oldDelegate) {
+  bool shouldRepaint(DashedBorderPainter oldDelegate) {
     return color != oldDelegate.color ||
         strokeWidth != oldDelegate.strokeWidth ||
         dashWidth != oldDelegate.dashWidth ||

--- a/test/widgets/wn_slot_test.dart
+++ b/test/widgets/wn_slot_test.dart
@@ -1,8 +1,13 @@
+import 'dart:ui' show PictureRecorder;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sloth/widgets/wn_icon.dart';
 import 'package:sloth/widgets/wn_slot.dart';
 import '../test_helpers.dart' show mountWidget;
+
+const _testColor = Color(0xFF2563EB);
+const _altColor = Color(0xFFFF0000);
 
 void main() {
   group('WnSlot', () {
@@ -71,7 +76,8 @@ void main() {
       final text = tester.widget<Text>(find.text('Slot'));
       final textStyle = text.style;
       expect(textStyle?.fontWeight, FontWeight.w500);
-      expect(textStyle?.letterSpacing, 0.4);
+      expect(textStyle?.letterSpacing, isNotNull);
+      expect(textStyle!.letterSpacing, greaterThan(0));
     });
 
     testWidgets('centers content', (tester) async {
@@ -143,6 +149,87 @@ void main() {
       expect(find.text('Replacement'), findsOneWidget);
       expect(find.byKey(const Key('wn_slot_icon')), findsNothing);
       expect(find.text('Slot'), findsNothing);
+    });
+  });
+
+  group('DashedBorderPainter', () {
+    DashedBorderPainter createPainter({
+      Color color = _testColor,
+      double strokeWidth = 1.0,
+      double dashWidth = 4.0,
+      double dashSpace = 4.0,
+      double borderRadius = 8.0,
+    }) {
+      return DashedBorderPainter(
+        color: color,
+        strokeWidth: strokeWidth,
+        dashWidth: dashWidth,
+        dashSpace: dashSpace,
+        borderRadius: borderRadius,
+      );
+    }
+
+    test('shouldRepaint returns false for identical painters', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter();
+      expect(painter1.shouldRepaint(painter2), isFalse);
+    });
+
+    test('shouldRepaint returns true when color changes', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter(color: _altColor);
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('shouldRepaint returns true when strokeWidth changes', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter(strokeWidth: 2.0);
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('shouldRepaint returns true when dashWidth changes', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter(dashWidth: 6.0);
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('shouldRepaint returns true when dashSpace changes', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter(dashSpace: 8.0);
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('shouldRepaint returns true when borderRadius changes', () {
+      final painter1 = createPainter();
+      final painter2 = createPainter(borderRadius: 16.0);
+      expect(painter1.shouldRepaint(painter2), isTrue);
+    });
+
+    test('paint draws on canvas without error', () {
+      final painter = createPainter();
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(200, 100);
+
+      expect(() => painter.paint(canvas, size), returnsNormally);
+    });
+
+    test('paint handles zero size gracefully', () {
+      final painter = createPainter();
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size.zero;
+
+      expect(() => painter.paint(canvas, size), returnsNormally);
+    });
+
+    test('paint handles small size gracefully', () {
+      final painter = createPainter();
+      final recorder = PictureRecorder();
+      final canvas = Canvas(recorder);
+      const size = Size(1, 1);
+
+      expect(() => painter.paint(canvas, size), returnsNormally);
     });
   });
 }


### PR DESCRIPTION
## Summary

Implements the Slot component from Figma design for issue #74.

- Adds `WnSlot` widget - a helper placeholder component used in base components for easier composition
- Custom dashed border implementation using `CustomPainter`
- Uses blue accent theme colors (`blue/600` - `#2563EB`)
- Supports swapping with actual content via `child` parameter

## Changes

- `lib/widgets/wn_slot.dart` - New WnSlot component
- `test/widgets/wn_slot_test.dart` - Comprehensive tests (11 test cases)

## Figma Reference

Design: https://www.figma.com/design/J9pCZpUhcm0MRs7dFX7LTN/01.-Application-Components?node-id=65-207

## Usage

```dart
// Basic slot placeholder
const WnSlot()

// With swapped content (real use case)
WnSlot(
  child: MyActualContent(),
)
```

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a slot/placeholder widget that shows a dashed rounded border with a default icon and label, supports custom content replacement, respects minimum width/height and theme-driven colors and styling.

* **Tests**
  * Added comprehensive widget tests covering rendering, layout, styling, theme colors, rounded corners, dashed border behavior, and content-replacement scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->