### PR TITLE
feat(widgets): add WnScrollEdgeEffect widget for scroll edge fade effects

### DIFF
--- a/lib/widgets/wn_scroll_edge_effect.dart
+++ b/lib/widgets/wn_scroll_edge_effect.dart
@@ -1,0 +1,139 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+enum ScrollEdgeEffectType {
+  canvas,
+  slate,
+  dropdown,
+}
+
+enum ScrollEdgePosition {
+  top,
+  bottom,
+}
+
+class WnScrollEdgeEffect extends StatelessWidget {
+  const WnScrollEdgeEffect._({
+    super.key,
+    required this.type,
+    required this.position,
+    required this.color,
+    this.height,
+  });
+
+  const WnScrollEdgeEffect.canvasTop({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.canvas,
+         position: ScrollEdgePosition.top,
+         color: color,
+         height: height,
+       );
+
+  const WnScrollEdgeEffect.canvasBottom({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.canvas,
+         position: ScrollEdgePosition.bottom,
+         color: color,
+         height: height,
+       );
+
+  const WnScrollEdgeEffect.slateTop({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.slate,
+         position: ScrollEdgePosition.top,
+         color: color,
+         height: height,
+       );
+
+  const WnScrollEdgeEffect.slateBottom({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.slate,
+         position: ScrollEdgePosition.bottom,
+         color: color,
+         height: height,
+       );
+
+  const WnScrollEdgeEffect.dropdownTop({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.dropdown,
+         position: ScrollEdgePosition.top,
+         color: color,
+         height: height,
+       );
+
+  const WnScrollEdgeEffect.dropdownBottom({
+    Key? key,
+    required Color color,
+    double? height,
+  }) : this._(
+         key: key,
+         type: ScrollEdgeEffectType.dropdown,
+         position: ScrollEdgePosition.bottom,
+         color: color,
+         height: height,
+       );
+
+  final ScrollEdgeEffectType type;
+  final ScrollEdgePosition position;
+  final Color color;
+  final double? height;
+
+  double get _defaultHeight {
+    switch (type) {
+      case ScrollEdgeEffectType.canvas:
+        return 48.h;
+      case ScrollEdgeEffectType.slate:
+        return 80.h;
+      case ScrollEdgeEffectType.dropdown:
+        return 40.h;
+    }
+  }
+
+  bool get _isTop => position == ScrollEdgePosition.top;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveHeight = height ?? _defaultHeight;
+
+    return Positioned(
+      top: _isTop ? 0 : null,
+      bottom: _isTop ? null : 0,
+      left: 0,
+      right: 0,
+      height: effectiveHeight,
+      child: IgnorePointer(
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: _isTop
+                  ? [color, color.withValues(alpha: 0)]
+                  : [color.withValues(alpha: 0), color],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/widgets/wn_scroll_edge_effect_test.dart
+++ b/test/widgets/wn_scroll_edge_effect_test.dart
@@ -1,0 +1,375 @@
+import 'package:flutter/material.dart'
+    show BoxDecoration, Colors, Container, IgnorePointer, Key, LinearGradient, Positioned;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sloth/widgets/wn_scroll_edge_effect.dart'
+    show ScrollEdgeEffectType, ScrollEdgePosition, WnScrollEdgeEffect;
+import '../test_helpers.dart' show mountStackedWidget;
+
+void main() {
+  group('WnScrollEdgeEffect tests', () {
+    group('Canvas type', () {
+      group('canvasTop', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasTop(key: Key('canvas_top'), color: Colors.black),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('canvas_top')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from solid to transparent', (WidgetTester tester) async {
+          const testColor = Colors.red;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasTop(key: Key('canvas_top'), color: testColor),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('canvas_top')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor);
+          expect(gradient.colors.last, testColor.withValues(alpha: 0));
+        });
+
+        testWidgets('is positioned at top', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasTop(key: Key('canvas_top'), color: Colors.black),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.top, 0);
+          expect(positioned.bottom, isNull);
+        });
+      });
+
+      group('canvasBottom', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasBottom(key: Key('canvas_bottom'), color: Colors.black),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('canvas_bottom')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from transparent to solid', (WidgetTester tester) async {
+          const testColor = Colors.blue;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasBottom(key: Key('canvas_bottom'), color: testColor),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('canvas_bottom')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor.withValues(alpha: 0));
+          expect(gradient.colors.last, testColor);
+        });
+
+        testWidgets('is positioned at bottom', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.canvasBottom(key: Key('canvas_bottom'), color: Colors.black),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.bottom, 0);
+          expect(positioned.top, isNull);
+        });
+      });
+    });
+
+    group('Slate type', () {
+      group('slateTop', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateTop(key: Key('slate_top'), color: Colors.black),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('slate_top')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from solid to transparent', (WidgetTester tester) async {
+          const testColor = Colors.green;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateTop(key: Key('slate_top'), color: testColor),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('slate_top')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor);
+          expect(gradient.colors.last, testColor.withValues(alpha: 0));
+        });
+
+        testWidgets('is positioned at top', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateTop(key: Key('slate_top'), color: Colors.black),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.top, 0);
+          expect(positioned.bottom, isNull);
+        });
+      });
+
+      group('slateBottom', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateBottom(key: Key('slate_bottom'), color: Colors.black),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('slate_bottom')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from transparent to solid', (WidgetTester tester) async {
+          const testColor = Colors.purple;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateBottom(key: Key('slate_bottom'), color: testColor),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('slate_bottom')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor.withValues(alpha: 0));
+          expect(gradient.colors.last, testColor);
+        });
+
+        testWidgets('is positioned at bottom', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.slateBottom(key: Key('slate_bottom'), color: Colors.black),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.bottom, 0);
+          expect(positioned.top, isNull);
+        });
+      });
+    });
+
+    group('Dropdown type', () {
+      group('dropdownTop', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownTop(key: Key('dropdown_top'), color: Colors.black),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('dropdown_top')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from solid to transparent', (WidgetTester tester) async {
+          const testColor = Colors.orange;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownTop(key: Key('dropdown_top'), color: testColor),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('dropdown_top')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor);
+          expect(gradient.colors.last, testColor.withValues(alpha: 0));
+        });
+
+        testWidgets('is positioned at top', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownTop(key: Key('dropdown_top'), color: Colors.black),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.top, 0);
+          expect(positioned.bottom, isNull);
+        });
+      });
+
+      group('dropdownBottom', () {
+        testWidgets('renders with IgnorePointer that ignores input', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownBottom(
+              key: Key('dropdown_bottom'),
+              color: Colors.black,
+            ),
+            tester,
+          );
+
+          final ignorePointer = tester.widget<IgnorePointer>(
+            find.descendant(
+              of: find.byKey(const Key('dropdown_bottom')),
+              matching: find.byType(IgnorePointer),
+            ),
+          );
+          expect(ignorePointer.ignoring, isTrue);
+        });
+
+        testWidgets('gradient fades from transparent to solid', (WidgetTester tester) async {
+          const testColor = Colors.teal;
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownBottom(
+              key: Key('dropdown_bottom'),
+              color: testColor,
+            ),
+            tester,
+          );
+
+          final container = tester.widget<Container>(
+            find.descendant(
+              of: find.byKey(const Key('dropdown_bottom')),
+              matching: find.byType(Container),
+            ),
+          );
+          final decoration = container.decoration as BoxDecoration;
+          final gradient = decoration.gradient as LinearGradient;
+
+          expect(gradient.colors.first, testColor.withValues(alpha: 0));
+          expect(gradient.colors.last, testColor);
+        });
+
+        testWidgets('is positioned at bottom', (WidgetTester tester) async {
+          await mountStackedWidget(
+            const WnScrollEdgeEffect.dropdownBottom(
+              key: Key('dropdown_bottom'),
+              color: Colors.black,
+            ),
+            tester,
+          );
+
+          final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+          expect(positioned.bottom, 0);
+          expect(positioned.top, isNull);
+        });
+      });
+    });
+
+    group('custom height', () {
+      testWidgets('applies custom height to canvas', (WidgetTester tester) async {
+        const customHeight = 100.0;
+        await mountStackedWidget(
+          const WnScrollEdgeEffect.canvasTop(
+            key: Key('canvas_custom'),
+            color: Colors.black,
+            height: customHeight,
+          ),
+          tester,
+        );
+
+        final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+        expect(positioned.height, customHeight);
+      });
+
+      testWidgets('applies custom height to slate', (WidgetTester tester) async {
+        const customHeight = 120.0;
+        await mountStackedWidget(
+          const WnScrollEdgeEffect.slateTop(
+            key: Key('slate_custom'),
+            color: Colors.black,
+            height: customHeight,
+          ),
+          tester,
+        );
+
+        final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+        expect(positioned.height, customHeight);
+      });
+
+      testWidgets('applies custom height to dropdown', (WidgetTester tester) async {
+        const customHeight = 60.0;
+        await mountStackedWidget(
+          const WnScrollEdgeEffect.dropdownTop(
+            key: Key('dropdown_custom'),
+            color: Colors.black,
+            height: customHeight,
+          ),
+          tester,
+        );
+
+        final positioned = tester.widget<Positioned>(find.byType(Positioned).first);
+        expect(positioned.height, customHeight);
+      });
+    });
+
+    group('enum values', () {
+      test('ScrollEdgeEffectType has all expected values', () {
+        expect(ScrollEdgeEffectType.values, contains(ScrollEdgeEffectType.canvas));
+        expect(ScrollEdgeEffectType.values, contains(ScrollEdgeEffectType.slate));
+        expect(ScrollEdgeEffectType.values, contains(ScrollEdgeEffectType.dropdown));
+        expect(ScrollEdgeEffectType.values.length, 3);
+      });
+
+      test('ScrollEdgePosition has all expected values', () {
+        expect(ScrollEdgePosition.values, contains(ScrollEdgePosition.top));
+        expect(ScrollEdgePosition.values, contains(ScrollEdgePosition.bottom));
+        expect(ScrollEdgePosition.values.length, 2);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `WnScrollEdgeEffect` widget implementing the scroll edge effect design from Figma
- Supports three types: Canvas, Slate, and Dropdown with appropriate default heights
- Provides top and bottom positioning with gradient fade overlays
- Uses `IgnorePointer` so effects don't block user input

## Changes
- `lib/widgets/wn_scroll_edge_effect.dart` - New widget with named constructors for each type/position combination
- `test/widgets/wn_scroll_edge_effect_test.dart` - Comprehensive tests with 100% coverage

## Usage
```dart
Stack(
  children: [
    // Scrollable content
    WnScrollEdgeEffect.canvasTop(color: context.colors.backgroundPrimary),
    WnScrollEdgeEffect.canvasBottom(color: context.colors.backgroundPrimary),
  ],
)
```

Closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a scroll edge effect widget with customizable gradient edges for scrollable content. Includes canvas, slate, and dropdown style options with top and bottom positioning.

* **Tests**
  * Added comprehensive test coverage for the scroll edge effect widget.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->