### PR TITLE
fix(api): serialize tags as structured arrays instead of Debug format

### DIFF
--- a/lib/src/rust/api/accounts.dart
+++ b/lib/src/rust/api/accounts.dart
@@ -159,7 +159,7 @@ class FlutterEvent {
   final String pubkey;
   final DateTime createdAt;
   final int kind;
-  final List<String> tags;
+  final List<List<String>> tags;
   final String content;
 
   const FlutterEvent({

--- a/lib/src/rust/api/messages.dart
+++ b/lib/src/rust/api/messages.dart
@@ -57,7 +57,7 @@ class ChatMessage {
   final String pubkey;
   final String content;
   final DateTime createdAt;
-  final List<String> tags;
+  final List<List<String>> tags;
   final bool isReply;
   final String? replyToId;
   final bool isDeleted;

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -3645,7 +3645,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pubkey: dco_decode_String(arr[1]),
       content: dco_decode_String(arr[2]),
       createdAt: dco_decode_Chrono_Utc(arr[3]),
-      tags: dco_decode_list_String(arr[4]),
+      tags: dco_decode_list_list_String(arr[4]),
       isReply: dco_decode_bool(arr[5]),
       replyToId: dco_decode_opt_String(arr[6]),
       isDeleted: dco_decode_bool(arr[7]),
@@ -3725,7 +3725,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pubkey: dco_decode_String(arr[1]),
       createdAt: dco_decode_Chrono_Utc(arr[2]),
       kind: dco_decode_u_16(arr[3]),
-      tags: dco_decode_list_String(arr[4]),
+      tags: dco_decode_list_list_String(arr[4]),
       content: dco_decode_String(arr[5]),
     );
   }
@@ -3881,6 +3881,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   List<GroupInformation> dco_decode_list_group_information(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     return (raw as List<dynamic>).map(dco_decode_group_information).toList();
+  }
+
+  @protected
+  List<List<String>> dco_decode_list_list_String(dynamic raw) {
+    // Codec=Dco (DartCObject based), see doc to use other codecs
+    return (raw as List<dynamic>).map(dco_decode_list_String).toList();
   }
 
   @protected
@@ -4695,7 +4701,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final var_pubkey = sse_decode_String(deserializer);
     final var_content = sse_decode_String(deserializer);
     final var_createdAt = sse_decode_Chrono_Utc(deserializer);
-    final var_tags = sse_decode_list_String(deserializer);
+    final var_tags = sse_decode_list_list_String(deserializer);
     final var_isReply = sse_decode_bool(deserializer);
     final var_replyToId = sse_decode_opt_String(deserializer);
     final var_isDeleted = sse_decode_bool(deserializer);
@@ -4800,7 +4806,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final var_pubkey = sse_decode_String(deserializer);
     final var_createdAt = sse_decode_Chrono_Utc(deserializer);
     final var_kind = sse_decode_u_16(deserializer);
-    final var_tags = sse_decode_list_String(deserializer);
+    final var_tags = sse_decode_list_list_String(deserializer);
     final var_content = sse_decode_String(deserializer);
     return FlutterEvent(
       id: var_id,
@@ -5051,6 +5057,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final ans_ = <GroupInformation>[];
     for (var idx_ = 0; idx_ < len_; ++idx_) {
       ans_.add(sse_decode_group_information(deserializer));
+    }
+    return ans_;
+  }
+
+  @protected
+  List<List<String>> sse_decode_list_list_String(SseDeserializer deserializer) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+
+    final len_ = sse_decode_i_32(deserializer);
+    final ans_ = <List<String>>[];
+    for (var idx_ = 0; idx_ < len_; ++idx_) {
+      ans_.add(sse_decode_list_String(deserializer));
     }
     return ans_;
   }
@@ -6005,7 +6023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.pubkey, serializer);
     sse_encode_String(self.content, serializer);
     sse_encode_Chrono_Utc(self.createdAt, serializer);
-    sse_encode_list_String(self.tags, serializer);
+    sse_encode_list_list_String(self.tags, serializer);
     sse_encode_bool(self.isReply, serializer);
     sse_encode_opt_String(self.replyToId, serializer);
     sse_encode_bool(self.isDeleted, serializer);
@@ -6071,7 +6089,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_String(self.pubkey, serializer);
     sse_encode_Chrono_Utc(self.createdAt, serializer);
     sse_encode_u_16(self.kind, serializer);
-    sse_encode_list_String(self.tags, serializer);
+    sse_encode_list_list_String(self.tags, serializer);
     sse_encode_String(self.content, serializer);
   }
 
@@ -6259,6 +6277,18 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_i_32(self.length, serializer);
     for (final item in self) {
       sse_encode_group_information(item, serializer);
+    }
+  }
+
+  @protected
+  void sse_encode_list_list_String(
+    List<List<String>> self,
+    SseSerializer serializer,
+  ) {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    sse_encode_i_32(self.length, serializer);
+    for (final item in self) {
+      sse_encode_list_String(item, serializer);
     }
   }
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -311,6 +311,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<GroupInformation> dco_decode_list_group_information(dynamic raw);
 
   @protected
+  List<List<String>> dco_decode_list_list_String(dynamic raw);
+
+  @protected
   List<MediaFile> dco_decode_list_media_file(dynamic raw);
 
   @protected
@@ -719,6 +722,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   List<GroupInformation> sse_decode_list_group_information(
     SseDeserializer deserializer,
   );
+
+  @protected
+  List<List<String>> sse_decode_list_list_String(SseDeserializer deserializer);
 
   @protected
   List<MediaFile> sse_decode_list_media_file(SseDeserializer deserializer);
@@ -1203,6 +1209,12 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   @protected
   void sse_encode_list_group_information(
     List<GroupInformation> self,
+    SseSerializer serializer,
+  );
+
+  @protected
+  void sse_encode_list_list_String(
+    List<List<String>> self,
     SseSerializer serializer,
   );
 

--- a/rust/src/api/accounts.rs
+++ b/rust/src/api/accounts.rs
@@ -31,7 +31,7 @@ pub struct FlutterEvent {
     pub pubkey: String,
     pub created_at: DateTime<Utc>,
     pub kind: u16,
-    pub tags: Vec<String>,
+    pub tags: Vec<Vec<String>>,
     pub content: String,
 }
 
@@ -47,7 +47,11 @@ impl From<Event> for FlutterEvent {
                     .unwrap_or_else(|| Utc.timestamp_opt(0, 0).single().unwrap())
             },
             kind: event.kind.as_u16(),
-            tags: event.tags.iter().map(|tag| format!("{:?}", tag)).collect(),
+            tags: event
+                .tags
+                .iter()
+                .map(|tag| tag.as_slice().to_vec())
+                .collect(),
             content: event.content,
         }
     }

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -36,7 +36,7 @@ pub struct ChatMessage {
     pub pubkey: String,
     pub content: String,
     pub created_at: DateTime<Utc>,
-    pub tags: Vec<String>, // Simplified tags representation for Flutter
+    pub tags: Vec<Vec<String>>,
     pub is_reply: bool,
     pub reply_to_id: Option<String>,
     pub is_deleted: bool,
@@ -257,11 +257,10 @@ impl From<WhitenoiseReactionSummary> for ReactionSummary {
 
 impl From<&WhitenoiseChatMessage> for ChatMessage {
     fn from(chat_message: &WhitenoiseChatMessage) -> Self {
-        // Convert tags to simplified string representation
         let tags = chat_message
             .tags
             .iter()
-            .map(|tag| format!("{tag:?}"))
+            .map(|tag| tag.as_slice().to_vec())
             .collect();
 
         // Convert content tokens to proper Flutter-compatible structs

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -3702,7 +3702,7 @@ impl SseDecode for crate::api::messages::ChatMessage {
         let mut var_pubkey = <String>::sse_decode(deserializer);
         let mut var_content = <String>::sse_decode(deserializer);
         let mut var_createdAt = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
-        let mut var_tags = <Vec<String>>::sse_decode(deserializer);
+        let mut var_tags = <Vec<Vec<String>>>::sse_decode(deserializer);
         let mut var_isReply = <bool>::sse_decode(deserializer);
         let mut var_replyToId = <Option<String>>::sse_decode(deserializer);
         let mut var_isDeleted = <bool>::sse_decode(deserializer);
@@ -3815,7 +3815,7 @@ impl SseDecode for crate::api::accounts::FlutterEvent {
         let mut var_pubkey = <String>::sse_decode(deserializer);
         let mut var_createdAt = <chrono::DateTime<chrono::Utc>>::sse_decode(deserializer);
         let mut var_kind = <u16>::sse_decode(deserializer);
-        let mut var_tags = <Vec<String>>::sse_decode(deserializer);
+        let mut var_tags = <Vec<Vec<String>>>::sse_decode(deserializer);
         let mut var_content = <String>::sse_decode(deserializer);
         return crate::api::accounts::FlutterEvent {
             id: var_id,
@@ -4077,6 +4077,18 @@ impl SseDecode for Vec<crate::api::groups::GroupInformation> {
             ans_.push(<crate::api::groups::GroupInformation>::sse_decode(
                 deserializer,
             ));
+        }
+        return ans_;
+    }
+}
+
+impl SseDecode for Vec<Vec<String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
+        let mut len_ = <i32>::sse_decode(deserializer);
+        let mut ans_ = vec![];
+        for idx_ in 0..len_ {
+            ans_.push(<Vec<String>>::sse_decode(deserializer));
         }
         return ans_;
     }
@@ -5928,7 +5940,7 @@ impl SseEncode for crate::api::messages::ChatMessage {
         <String>::sse_encode(self.pubkey, serializer);
         <String>::sse_encode(self.content, serializer);
         <chrono::DateTime<chrono::Utc>>::sse_encode(self.created_at, serializer);
-        <Vec<String>>::sse_encode(self.tags, serializer);
+        <Vec<Vec<String>>>::sse_encode(self.tags, serializer);
         <bool>::sse_encode(self.is_reply, serializer);
         <Option<String>>::sse_encode(self.reply_to_id, serializer);
         <bool>::sse_encode(self.is_deleted, serializer);
@@ -5996,7 +6008,7 @@ impl SseEncode for crate::api::accounts::FlutterEvent {
         <String>::sse_encode(self.pubkey, serializer);
         <chrono::DateTime<chrono::Utc>>::sse_encode(self.created_at, serializer);
         <u16>::sse_encode(self.kind, serializer);
-        <Vec<String>>::sse_encode(self.tags, serializer);
+        <Vec<Vec<String>>>::sse_encode(self.tags, serializer);
         <String>::sse_encode(self.content, serializer);
     }
 }
@@ -6190,6 +6202,16 @@ impl SseEncode for Vec<crate::api::groups::GroupInformation> {
         <i32>::sse_encode(self.len() as _, serializer);
         for item in self {
             <crate::api::groups::GroupInformation>::sse_encode(item, serializer);
+        }
+    }
+}
+
+impl SseEncode for Vec<Vec<String>> {
+    // Codec=Sse (Serialization based), see doc to use other codecs
+    fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
+        <i32>::sse_encode(self.len() as _, serializer);
+        for item in self {
+            <Vec<String>>::sse_encode(item, serializer);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace `format!("{:?}", tag)` with `tag.as_slice().to_vec()` for tag serialization
- Change `tags` field type from `Vec<String>` to `Vec<Vec<String>>` in both `FlutterEvent` and `ChatMessage`
- Regenerate flutter_rust_bridge bindings

## Why

Tags were being serialized using Rust's Debug trait, producing output like:
```
Tag { buf: ["p", "pubkey123"], standardized: None }
```

This approach was:
- **Slow**: Debug formatting has overhead
- **Unstable**: Output format may change between Rust versions  
- **Hard to parse**: Would require string parsing on Flutter side

## After

Tags are now proper 2D arrays:
```dart
[["p", "pubkey123", "relay_url"], ["e", "event_id"]]
```

This is faster, stable, and type-safe in Dart.

## Note

The `tags` property is currently not actively used in the Flutter codebase, but this fix ensures correct serialization for future use.

Closes #123