### PR TITLE
fix: White QR color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds internet permission in android manifest [PR #7](https://github.com/marmot-protocol/sloth/pull/7)
 - Fixes logout not working after app reinstall [PR #31](https://github.com/marmot-protocol/sloth/pull/31)
 - Fixes sign out exception and adds dedicated sign out screen with private key backup [PR #45](https://github.com/marmot-protocol/sloth/pull/45)
-- Hardcode white QR code color [PR #183](https://github.com/marmot-protocol/sloth/pull/183)
+- QR code color now uses theme-aware color [PR #183](https://github.com/marmot-protocol/sloth/pull/183)
 
 ### Security

--- a/lib/screens/share_profile_screen.dart
+++ b/lib/screens/share_profile_screen.dart
@@ -96,13 +96,13 @@ class ShareProfileScreen extends HookConsumerWidget {
                             QrImageView(
                               data: npub,
                               size: 256.w,
-                              eyeStyle: const QrEyeStyle(
+                              eyeStyle: QrEyeStyle(
                                 eyeShape: QrEyeShape.square,
-                                color: Colors.white,
+                                color: colors.qrCode,
                               ),
-                              dataModuleStyle: const QrDataModuleStyle(
+                              dataModuleStyle: QrDataModuleStyle(
                                 dataModuleShape: QrDataModuleShape.square,
-                                color: Colors.white,
+                                color: colors.qrCode,
                               ),
                             ),
                           ] else

--- a/lib/theme/semantic_colors.dart
+++ b/lib/theme/semantic_colors.dart
@@ -430,6 +430,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
   final Color intentionErrorContent;
   final Color shadow;
   final Color overlayPrimary;
+  final Color qrCode;
   final SemanticAccentColors accent;
 
   const SemanticColors({
@@ -476,6 +477,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     required this.intentionErrorContent,
     required this.shadow,
     required this.overlayPrimary,
+    required this.qrCode,
     required this.accent,
   });
 
@@ -523,6 +525,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     intentionErrorContent: _RedColors.red600,
     shadow: _BaseColors.black,
     overlayPrimary: _WhiteAlphaColors.whiteAlpha500,
+    qrCode: _NeutralColors.neutral950,
     accent: _lightAccentColors,
   );
 
@@ -570,6 +573,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     intentionErrorContent: _RedColors.red500,
     shadow: _BaseColors.black,
     overlayPrimary: _BlackAlphaColors.blackAlpha500,
+    qrCode: _BaseColors.white,
     accent: _darkAccentColors,
   );
 
@@ -618,6 +622,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     Color? intentionErrorContent,
     Color? shadow,
     Color? overlayPrimary,
+    Color? qrCode,
     SemanticAccentColors? accent,
   }) {
     return SemanticColors(
@@ -666,6 +671,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
       intentionErrorContent: intentionErrorContent ?? this.intentionErrorContent,
       shadow: shadow ?? this.shadow,
       overlayPrimary: overlayPrimary ?? this.overlayPrimary,
+      qrCode: qrCode ?? this.qrCode,
       accent: accent ?? this.accent,
     );
   }
@@ -773,6 +779,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
       intentionErrorContent: Color.lerp(intentionErrorContent, other.intentionErrorContent, t)!,
       shadow: Color.lerp(shadow, other.shadow, t)!,
       overlayPrimary: Color.lerp(overlayPrimary, other.overlayPrimary, t)!,
+      qrCode: Color.lerp(qrCode, other.qrCode, t)!,
       accent: SemanticAccentColors.lerp(accent, other.accent, t),
     );
   }


### PR DESCRIPTION
## Description
Since the QR colors matched the theme, QR was not visible in dark mode

<img width="1080" height="2404" alt="flutter_01" src="https://github.com/user-attachments/assets/93e2d9c9-b5a5-4936-bc1a-0a65bd9589de" />
<!--

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
- [ ] Updated android .so files by running `just build-android` (only needed if rust dependencies or rust code changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * QR code in profile sharing now uses a dedicated, theme-aware color for both eyes and data modules; encoded content and size unchanged.
* **Fixed**
  * Changelog updated to reflect that the QR code color is now sourced from the theme rather than a previous hardcoded value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->