### PR TITLE
Fix reversed order in chat list screen

### DIFF
--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -37,7 +37,7 @@ class ChatListScreen extends HookConsumerWidget {
             header: const WnSearchAndFilters(),
             headerHeight: _searchAndFiltersHeight.h,
             itemBuilder: (context, index) {
-              final chatSummary = chatList[chatList.length - 1 - index];
+              final chatSummary = chatList[index];
               return ChatListTile(
                 key: Key(chatSummary.mlsGroupId),
                 chatSummary: chatSummary,

--- a/test/screens/chat_list_screen_test.dart
+++ b/test/screens/chat_list_screen_test.dart
@@ -186,8 +186,8 @@ void main() {
         await pumpChatListScreen(tester);
         final tiles = tester.widgetList<ChatListTile>(find.byType(ChatListTile)).toList();
 
-        expect(tiles.first.key, const Key(testPubkeyB));
-        expect(tiles.last.key, const Key(testPubkeyA));
+        expect(tiles.first.key, const Key(testPubkeyA));
+        expect(tiles.last.key, const Key(testPubkeyB));
       });
 
       testWidgets('hides empty state', (tester) async {
@@ -198,7 +198,7 @@ void main() {
 
       testWidgets('tapping pending chat navigates to invite screen', (tester) async {
         await pumpChatListScreen(tester);
-        await tester.tap(find.byType(ChatListTile).last);
+        await tester.tap(find.byType(ChatListTile).first);
         await tester.pumpAndSettle();
 
         expect(find.byType(ChatInviteScreen), findsOneWidget);
@@ -206,7 +206,7 @@ void main() {
 
       testWidgets('tapping accepted chat navigates to chat screen', (tester) async {
         await pumpChatListScreen(tester);
-        await tester.tap(find.byType(ChatListTile).first);
+        await tester.tap(find.byType(ChatListTile).last);
         await tester.pumpAndSettle();
 
         expect(find.byType(ChatScreen), findsOneWidget);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Fixes #198  by removing an unnecessary reverse on chat list screen (it  is already returned in the expected order by the use chat list hook)

Video after this changes:

https://github.com/user-attachments/assets/994a9d70-1ee3-47a8-8ffd-b899efe8a2a3




<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ordering of chat items displayed in the chat list view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->