### PR TITLE
fix: wipe old unencrypted database on upgrade

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,8 @@ import 'package:whitenoise/src/rust/api.dart' as rust_api;
 import 'package:whitenoise/src/rust/frb_generated.dart';
 import 'package:whitenoise/theme.dart';
 
+const kUnencryptedDatabaseError = 'database was created without encryption';
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await RustLib.init();
@@ -35,7 +37,7 @@ Future<ProviderContainer> initializeAppContainer() async {
   try {
     await rust_api.initializeWhitenoise(config: config);
   } catch (e) {
-    if (!e.toString().contains('database was created without encryption')) {
+    if (!e.toString().contains(kUnencryptedDatabaseError)) {
       rethrow;
     }
     final envDir = Directory('$dataDir/${kDebugMode ? 'dev' : 'release'}');

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart'
     show AsyncData, ProviderContainer, ProviderScope;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:whitenoise/main.dart';
+import 'package:whitenoise/main.dart' show WnApp, initializeAppContainer, kUnencryptedDatabaseError;
 import 'package:whitenoise/providers/auth_provider.dart';
 import 'package:whitenoise/providers/theme_provider.dart';
 import 'package:whitenoise/src/rust/api.dart' as rust_api;
@@ -90,7 +90,7 @@ class _MockInitApi extends MockWnApi {
   rust_api.WhitenoiseConfig? initializedConfig;
   int initCallCount = 0;
   int failFirstNCalls = 0;
-  String failMessage = 'database was created without encryption';
+  String failMessage = kUnencryptedDatabaseError;
 
   @override
   Future<rust_api.WhitenoiseConfig> crateApiCreateWhitenoiseConfig({
@@ -121,7 +121,7 @@ class _MockInitApi extends MockWnApi {
     initializedConfig = null;
     initCallCount = 0;
     failFirstNCalls = 0;
-    failMessage = 'database was created without encryption';
+    failMessage = kUnencryptedDatabaseError;
   }
 }
 
@@ -260,7 +260,7 @@ void main() {
     test('rethrows unencrypted db error when retry also fails', () async {
       mockApi.failFirstNCalls = 2;
 
-      expect(() => initializeAppContainer(), throwsException);
+      await expectLater(initializeAppContainer(), throwsException);
     });
 
     test('rethrows unrelated errors without wiping', () async {
@@ -271,7 +271,7 @@ void main() {
       await envDir.create(recursive: true);
       await marker.create();
 
-      expect(() => initializeAppContainer(), throwsException);
+      await expectLater(initializeAppContainer(), throwsException);
       expect(marker.existsSync(), isTrue);
     });
   });


### PR DESCRIPTION
## Summary

Fixes #222

When upgrading from the old unencrypted database to the new encrypted one, `initializeWhitenoise()` fails with `"database was created without encryption"`. This PR catches that specific error, wipes the env-specific data directory (`data/dev` or `data/release`), and retries initialization to create a fresh encrypted database.

- Only the specific unencrypted DB error triggers the wipe-and-retry; unrelated errors are rethrown immediately
- Deletes the env-specific subdirectory (not the parent `data/` dir) to match what the Rust crate creates
- Adds 3 tests: successful wipe-and-retry, retry failure propagation, and unrelated error passthrough

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup robustness: initialization now detects an unencrypted database error, removes affected development/release data when appropriate, and retries initialization to recover automatically.
* **Tests**
  * Expanded test coverage for failure and recovery scenarios, verifying cleanup-and-retry behavior, retry failures, and unrelated error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->