### PR TITLE
feat(avatar): add xSmall (36px) avatar size variant

### DIFF
--- a/lib/widgets/wn_avatar.dart
+++ b/lib/widgets/wn_avatar.dart
@@ -11,7 +11,7 @@ import 'package:whitenoise/widgets/wn_icon.dart';
 
 export 'package:whitenoise/utils/avatar_color.dart';
 
-enum WnAvatarSize { small, medium, large }
+enum WnAvatarSize { xSmall, small, medium, large }
 
 class WnAvatar extends HookWidget {
   const WnAvatar({
@@ -35,6 +35,7 @@ class WnAvatar extends HookWidget {
 
   double _getAvatarSize() {
     return switch (size) {
+      WnAvatarSize.xSmall => 36.w,
       WnAvatarSize.small => 48.w,
       WnAvatarSize.medium => 56.w,
       WnAvatarSize.large => 96.w,
@@ -43,6 +44,7 @@ class WnAvatar extends HookWidget {
 
   double _getFontSize() {
     return switch (size) {
+      WnAvatarSize.xSmall => 12.sp,
       WnAvatarSize.small => 14.sp,
       WnAvatarSize.medium => 16.sp,
       WnAvatarSize.large => 32.sp,
@@ -51,6 +53,7 @@ class WnAvatar extends HookWidget {
 
   double _getIconSize() {
     return switch (size) {
+      WnAvatarSize.xSmall => 14.w,
       WnAvatarSize.small => 16.w,
       WnAvatarSize.medium => 20.w,
       WnAvatarSize.large => 32.w,
@@ -201,6 +204,7 @@ class _InitialsContent extends StatelessWidget {
     final initials = formatInitials(displayName);
 
     final textStyle = switch (avatarSizeEnum) {
+      WnAvatarSize.xSmall => typography.semiBold12,
       WnAvatarSize.small => typography.semiBold14,
       WnAvatarSize.medium => typography.semiBold16,
       WnAvatarSize.large => typography.semiBold32,

--- a/test/widgets/wn_avatar_test.dart
+++ b/test/widgets/wn_avatar_test.dart
@@ -222,13 +222,80 @@ void main() {
       });
     });
 
-    group('edit button', () {
-      testWidgets('does not show edit button when onEditTap is null', (tester) async {
+    group('xSmall size', () {
+      testWidgets('renders at xSmall size', (tester) async {
         await mountWidget(
-          const WnAvatar(displayName: 'alice', size: WnAvatarSize.large),
+          const WnAvatar(displayName: 'alice', size: WnAvatarSize.xSmall),
+          tester,
+        );
+        expect(find.text('A'), findsOneWidget);
+        expect(find.byKey(const Key('avatar_container')), findsOneWidget);
+      });
+
+      testWidgets('shows user icon at xSmall size when no displayName', (tester) async {
+        await mountWidget(
+          const WnAvatar(size: WnAvatarSize.xSmall),
+          tester,
+        );
+        expect(find.byType(WnIcon), findsOneWidget);
+      });
+
+      testWidgets('does not show edit button for xSmall size even with onEditTap', (tester) async {
+        await mountWidget(
+          WnAvatar(
+            displayName: 'alice',
+            size: WnAvatarSize.xSmall,
+            onEditTap: () {},
+          ),
+          tester,
+        );
+        expect(find.byKey(const Key('avatar_edit_button')), findsNothing);
+      });
+
+      testWidgets('does not show pin badge for xSmall size even with showPinned', (tester) async {
+        await mountWidget(
+          const WnAvatar(
+            displayName: 'alice',
+            size: WnAvatarSize.xSmall,
+            showPinned: true,
+          ),
+          tester,
+        );
+        expect(find.byKey(const Key('avatar_pin_badge')), findsNothing);
+      });
+
+      testWidgets('renders image at xSmall size', (tester) async {
+        await mountWidget(
+          WnAvatar(
+            imageProvider: _SuccessImageProvider(),
+            size: WnAvatarSize.xSmall,
+          ),
+          tester,
+        );
+        await tester.pumpAndSettle();
+        expect(find.byType(Image), findsNWidgets(2));
+      });
+
+      testWidgets('applies color at xSmall size', (tester) async {
+        await mountWidget(
+          const WnAvatar(
+            displayName: 'alice',
+            size: WnAvatarSize.xSmall,
+            color: AvatarColor.cyan,
+          ),
           tester,
         );
 
+        final container = tester.widget<Container>(find.byKey(const Key('avatar_container')));
+        final decoration = container.decoration! as BoxDecoration;
+
+        expect(decoration.color, SemanticColors.light.accent.cyan.fill);
+      });
+    });
+
+    group('edit button', () {
+      testWidgets('does not show edit button when onEditTap is null', (tester) async {
+        await mountWidget(const WnAvatar(), tester);
         expect(find.byKey(const Key('avatar_edit_button')), findsNothing);
       });
 

--- a/widgetbook/lib/components/wn_avatar.dart
+++ b/widgetbook/lib/components/wn_avatar.dart
@@ -161,6 +161,17 @@ Widget _buildHeader(SemanticColors colors) {
       ),
       Expanded(
         child: Text(
+          'XSmall (36px)',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w600,
+            color: colors.backgroundContentSecondary,
+          ),
+        ),
+      ),
+      Expanded(
+        child: Text(
           'Small (48px)',
           textAlign: TextAlign.center,
           style: TextStyle(
@@ -228,6 +239,15 @@ Widget _buildInitialsRow(AvatarColor color, SemanticColors colors) {
             child: WnAvatar(
               displayName: 'A',
               color: color,
+              size: WnAvatarSize.xSmall,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Center(
+            child: WnAvatar(
+              displayName: 'A',
+              color: color,
               size: WnAvatarSize.small,
             ),
           ),
@@ -271,6 +291,11 @@ Widget _buildIconRow(AvatarColor color) {
     child: Row(
       children: [
         const SizedBox(width: 80),
+        Expanded(
+          child: Center(
+            child: WnAvatar(color: color, size: WnAvatarSize.xSmall),
+          ),
+        ),
         Expanded(
           child: Center(
             child: WnAvatar(color: color, size: WnAvatarSize.small),
@@ -372,6 +397,15 @@ Widget _buildImageRow(SemanticColors colors) {
               fontSize: 13,
               fontWeight: FontWeight.w500,
               color: colors.backgroundContentPrimary,
+            ),
+          ),
+        ),
+        Expanded(
+          child: Center(
+            child: WnAvatar(
+              pictureUrl: _sampleImageUrl,
+              displayName: 'A',
+              size: WnAvatarSize.xSmall,
             ),
           ),
         ),


### PR DESCRIPTION
## Summary

Closes #215

- Adds `xSmall` variant to `WnAvatarSize` enum, mapping to 36px as specified in the [Figma designs](https://www.figma.com/design/J9pCZpUhcm0MRs7dFX7LTN/01.-Application-Components?node-id=107-986&t=IQkCsYxnnlkiQV16-1)
- Configures font size (12sp / semiBold12), icon size (14w), and avatar size (36w) for the new variant
- Adds 6 tests covering rendering, color, image, and verifying no edit button / pin badge on xSmall
- Updates widgetbook to include xSmall column across all variant rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new xSmall size variant for avatars, providing a compact 36px option with optimized icon and typography sizing for space-constrained layouts.

* **Tests**
  * Added comprehensive test coverage for the xSmall avatar variant, validating rendering, icon display, and styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->