### PR TITLE
feat(theme): add Overlay Tertiary semantic color

### DIFF
--- a/lib/theme/semantic_colors.dart
+++ b/lib/theme/semantic_colors.dart
@@ -432,6 +432,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
   final Color shadow;
   final Color overlayPrimary;
   final Color overlaySecondary;
+  final Color overlayTertiary;
   final Color qrCode;
   final SemanticAccentColors accent;
 
@@ -480,6 +481,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     required this.shadow,
     required this.overlayPrimary,
     required this.overlaySecondary,
+    required this.overlayTertiary,
     required this.qrCode,
     required this.accent,
   });
@@ -529,6 +531,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     shadow: _BaseColors.black,
     overlayPrimary: _WhiteAlphaColors.whiteAlpha500,
     overlaySecondary: _WhiteAlphaColors.whiteAlpha500,
+    overlayTertiary: _BlackAlphaColors.blackAlpha500,
     qrCode: _NeutralColors.neutral950,
     accent: _lightAccentColors,
   );
@@ -578,6 +581,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     shadow: _BaseColors.black,
     overlayPrimary: _BlackAlphaColors.blackAlpha50,
     overlaySecondary: _BlackAlphaColors.blackAlpha500,
+    overlayTertiary: _BlackAlphaColors.blackAlpha500,
     qrCode: _BaseColors.white,
     accent: _darkAccentColors,
   );
@@ -628,6 +632,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
     Color? shadow,
     Color? overlayPrimary,
     Color? overlaySecondary,
+    Color? overlayTertiary,
     Color? qrCode,
     SemanticAccentColors? accent,
   }) {
@@ -678,6 +683,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
       shadow: shadow ?? this.shadow,
       overlayPrimary: overlayPrimary ?? this.overlayPrimary,
       overlaySecondary: overlaySecondary ?? this.overlaySecondary,
+      overlayTertiary: overlayTertiary ?? this.overlayTertiary,
       qrCode: qrCode ?? this.qrCode,
       accent: accent ?? this.accent,
     );
@@ -787,6 +793,7 @@ class SemanticColors extends ThemeExtension<SemanticColors> {
       shadow: Color.lerp(shadow, other.shadow, t)!,
       overlayPrimary: Color.lerp(overlayPrimary, other.overlayPrimary, t)!,
       overlaySecondary: Color.lerp(overlaySecondary, other.overlaySecondary, t)!,
+      overlayTertiary: Color.lerp(overlayTertiary, other.overlayTertiary, t)!,
       qrCode: Color.lerp(qrCode, other.qrCode, t)!,
       accent: SemanticAccentColors.lerp(accent, other.accent, t),
     );

--- a/test/theme/semantic_colors_test.dart
+++ b/test/theme/semantic_colors_test.dart
@@ -294,10 +294,12 @@ void main() {
         final updated = SemanticColors.light.copyWith(
           overlayPrimary: Colors.red,
           overlaySecondary: Colors.green,
+          overlayTertiary: Colors.blue,
         );
 
         expect(updated.overlayPrimary, Colors.red);
         expect(updated.overlaySecondary, Colors.green);
+        expect(updated.overlayTertiary, Colors.blue);
       });
 
       test('returns new instance with updated accent colors', () {
@@ -732,6 +734,14 @@ void main() {
           Color.lerp(
             SemanticColors.light.overlaySecondary,
             SemanticColors.dark.overlaySecondary,
+            0.5,
+          ),
+        );
+        expect(
+          result.overlayTertiary,
+          Color.lerp(
+            SemanticColors.light.overlayTertiary,
+            SemanticColors.dark.overlayTertiary,
             0.5,
           ),
         );

--- a/widgetbook/lib/foundations/semantic_colors.dart
+++ b/widgetbook/lib/foundations/semantic_colors.dart
@@ -298,6 +298,11 @@ Widget allColors(BuildContext context) {
               lightColor: light.overlaySecondary,
               darkColor: dark.overlaySecondary,
             ),
+            _ColorPairItem(
+              semanticName: 'Overlay Tertiary',
+              lightColor: light.overlayTertiary,
+              darkColor: dark.overlayTertiary,
+            ),
           ],
           description:
               'Overlay colors. Use for backdrops and overlay surfaces to separate Slate '


### PR DESCRIPTION
## Summary
- Adds `overlayTertiary` semantic color set to `BlackAlpha(500)` for both light and dark themes
- Updates `copyWith` and `lerp` methods, tests, and widgetbook catalog

Closes #213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new tertiary overlay color to the semantic colors theme system, available in both light and dark theme variants for enhanced UI customization.

* **Tests**
  * Extended test coverage to validate the new overlay color across theme copying operations and color interpolation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->