### PR TITLE
Docs reaction colors story

### DIFF
--- a/widgetbook/lib/foundations/semantic_colors.dart
+++ b/widgetbook/lib/foundations/semantic_colors.dart
@@ -304,6 +304,69 @@ Widget allColors(BuildContext context) {
               'from background content and keep focus on it.',
         ),
         const SizedBox(height: 24),
+        _buildColorSection('Reaction', [
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Incoming',
+            lightColor: light.reaction.incoming.fill,
+            darkColor: dark.reaction.incoming.fill,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Incoming Hover',
+            lightColor: light.reaction.incoming.fillHover,
+            darkColor: dark.reaction.incoming.fillHover,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Incoming Selected',
+            lightColor: light.reaction.incoming.fillSelected,
+            darkColor: dark.reaction.incoming.fillSelected,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Outgoing',
+            lightColor: light.reaction.outgoing.fill,
+            darkColor: dark.reaction.outgoing.fill,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Outgoing Hover',
+            lightColor: light.reaction.outgoing.fillHover,
+            darkColor: dark.reaction.outgoing.fillHover,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Fill Outgoing Selected',
+            lightColor: light.reaction.outgoing.fillSelected,
+            darkColor: dark.reaction.outgoing.fillSelected,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Incoming',
+            lightColor: light.reaction.incoming.content,
+            darkColor: dark.reaction.incoming.content,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Incoming Hover',
+            lightColor: light.reaction.incoming.contentHover,
+            darkColor: dark.reaction.incoming.contentHover,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Incoming Selected',
+            lightColor: light.reaction.incoming.contentSelected,
+            darkColor: dark.reaction.incoming.contentSelected,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Outgoing',
+            lightColor: light.reaction.outgoing.content,
+            darkColor: dark.reaction.outgoing.content,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Outgoing Hover',
+            lightColor: light.reaction.outgoing.contentHover,
+            darkColor: dark.reaction.outgoing.contentHover,
+          ),
+          _ColorPairItem(
+            semanticName: 'Reaction Content Outgoing Selected',
+            lightColor: light.reaction.outgoing.contentSelected,
+            darkColor: dark.reaction.outgoing.contentSelected,
+          ),
+        ], description: 'Use for reaction fills and content.'),
+        const SizedBox(height: 24),
         _buildColorSection(
           'Accent',
           [


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Adds reaction colors to widget book story, to keep stories updated
<img width="905" height="463" alt="Screenshot 2026-02-12 at 10 15 17 AM" src="https://github.com/user-attachments/assets/40c7e4e4-db3f-4323-a0fb-2ab08f797650" />


<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reaction color tokens to the design system, supporting incoming and outgoing states with fill and content variants for different interaction states (default, hover, selected).

* **Documentation**
  * Updated the semantic colors reference guide to display the new reaction colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->