### PR TITLE
Message quote  style

### DIFF
--- a/lib/widgets/wn_message_quote.dart
+++ b/lib/widgets/wn_message_quote.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:whitenoise/theme.dart';
+import 'package:whitenoise/widgets/wn_icon.dart';
+
+class WnMessageQuote extends StatelessWidget {
+  const WnMessageQuote({
+    super.key,
+    required this.author,
+    required this.text,
+    this.onCancel,
+    this.onTap,
+    this.image,
+  });
+
+  final String author;
+  final String text;
+  final VoidCallback? onCancel;
+  final VoidCallback? onTap;
+  final ImageProvider? image;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+    final typography = context.typographyScaled;
+
+    return GestureDetector(
+      key: onTap != null ? const Key('message_quote_tap_area') : null,
+      onTap: onTap,
+      child: Container(
+        padding: EdgeInsets.all(4.w),
+        decoration: BoxDecoration(
+          color: colors.backgroundPrimary,
+          borderRadius: BorderRadius.circular(4.r),
+        ),
+        child: IntrinsicHeight(
+          child: Row(
+            children: [
+              Container(
+                key: const Key('quote_bar'),
+                width: 2.w,
+                decoration: BoxDecoration(
+                  color: colors.borderTertiary,
+                  borderRadius: BorderRadius.circular(1.w),
+                ),
+              ),
+              Gap(4.w),
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(right: 6.w, top: 2.h, bottom: 2.h),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        author,
+                        style: typography.semiBold12.copyWith(
+                          color: colors.backgroundContentTertiary,
+                        ),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                      Gap(4.h),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (text.isNotEmpty)
+                            Flexible(
+                              child: Text(
+                                text,
+                                style: typography.medium14Compact.copyWith(
+                                  color: colors.backgroundContentSecondary,
+                                ),
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              if (image != null) ...[
+                Gap(10.w),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4.r),
+                  child: Image(
+                    key: const Key('quote_thumbnail'),
+                    image: image!,
+                    fit: BoxFit.cover,
+                    width: 40.w,
+                    height: 40.w,
+                  ),
+                ),
+              ],
+              if (onCancel != null) ...[
+                Gap(4.w),
+                IconButton(
+                  key: const Key('cancel_quote_button'),
+                  onPressed: onCancel,
+                  icon: WnIcon(
+                    WnIcons.closeSmall,
+                    color: colors.backgroundContentTertiary,
+                    size: 18.w,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -38,6 +40,78 @@ const testNpubToHex = <String, String>{
 const testGroupId = 'abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234';
 const otherTestGroupId = 'dbcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234';
 const testNostrGroupId = 'dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321dcba4321';
+
+final testImageProvider = MemoryImage(
+  Uint8List.fromList([
+    0x89,
+    0x50,
+    0x4E,
+    0x47,
+    0x0D,
+    0x0A,
+    0x1A,
+    0x0A,
+    0x00,
+    0x00,
+    0x00,
+    0x0D,
+    0x49,
+    0x48,
+    0x44,
+    0x52,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x01,
+    0x08,
+    0x06,
+    0x00,
+    0x00,
+    0x00,
+    0x1F,
+    0x15,
+    0xC4,
+    0x89,
+    0x00,
+    0x00,
+    0x00,
+    0x0A,
+    0x49,
+    0x44,
+    0x41,
+    0x54,
+    0x78,
+    0x9C,
+    0x63,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x05,
+    0x00,
+    0x01,
+    0x0D,
+    0x0A,
+    0x2D,
+    0xB4,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x49,
+    0x45,
+    0x4E,
+    0x44,
+    0xAE,
+    0x42,
+    0x60,
+    0x82,
+  ]),
+);
 
 void setUpTestView(WidgetTester tester) {
   tester.view.physicalSize = testDesignSize;

--- a/test/widgets/wn_message_quote_test.dart
+++ b/test/widgets/wn_message_quote_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/widgets/wn_message_quote.dart';
+import '../test_helpers.dart';
+
+void main() {
+  group('WnMessageQuote', () {
+    testWidgets('renders author', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Alice', text: 'Hello'),
+        tester,
+      );
+
+      expect(find.text('Alice'), findsOneWidget);
+    });
+
+    testWidgets('renders content', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Alice', text: 'This is the reply content'),
+        tester,
+      );
+
+      expect(find.text('This is the reply content'), findsOneWidget);
+    });
+
+    testWidgets('does not render content text when content is empty', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Alice', text: ''),
+        tester,
+      );
+
+      final textWidgets = tester.widgetList<Text>(find.byType(Text));
+      expect(textWidgets.length, 1);
+      expect(textWidgets.first.data, 'Alice');
+    });
+
+    testWidgets('shows cancel button when onCancel is provided', (tester) async {
+      await mountWidget(
+        WnMessageQuote(author: 'Alice', text: 'Hello', onCancel: () {}),
+        tester,
+      );
+
+      expect(find.byKey(const Key('cancel_quote_button')), findsOneWidget);
+    });
+
+    testWidgets('hides cancel button when onCancel is null', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Alice', text: 'Hello'),
+        tester,
+      );
+
+      expect(find.byKey(const Key('cancel_quote_button')), findsNothing);
+    });
+
+    testWidgets('calls onCancel when cancel button is tapped', (tester) async {
+      var cancelCalled = false;
+      await mountWidget(
+        WnMessageQuote(
+          author: 'Alice',
+          text: 'Hello',
+          onCancel: () => cancelCalled = true,
+        ),
+        tester,
+      );
+
+      await tester.tap(find.byKey(const Key('cancel_quote_button')));
+      await tester.pumpAndSettle();
+
+      expect(cancelCalled, isTrue);
+    });
+
+    testWidgets('content text is max 2 lines with ellipsis', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Alice', text: 'Some content'),
+        tester,
+      );
+
+      final textWidget = tester.widget<Text>(find.text('Some content'));
+      expect((textWidget.maxLines, textWidget.overflow), (2, TextOverflow.ellipsis));
+    });
+
+    testWidgets('author name text is single line with ellipsis', (tester) async {
+      await mountWidget(
+        const WnMessageQuote(author: 'Author', text: 'Hello'),
+        tester,
+      );
+
+      final textWidget = tester.widget<Text>(find.text('Author'));
+      expect((textWidget.maxLines, textWidget.overflow), (1, TextOverflow.ellipsis));
+    });
+
+    group('quote bar', () {
+      testWidgets('renders quote bar', (tester) async {
+        await mountWidget(
+          const WnMessageQuote(author: 'Alice', text: 'Hello'),
+          tester,
+        );
+
+        expect(find.byKey(const Key('quote_bar')), findsOneWidget);
+      });
+    });
+
+    group('media', () {
+      testWidgets('shows thumbnail when image is provided', (tester) async {
+        await mountWidget(
+          WnMessageQuote(
+            author: 'Alice',
+            text: 'Hello',
+            image: testImageProvider,
+          ),
+          tester,
+        );
+
+        expect(find.byKey(const Key('quote_thumbnail')), findsOneWidget);
+      });
+
+      testWidgets('hides thumbnail when image is null', (tester) async {
+        await mountWidget(
+          const WnMessageQuote(author: 'Alice', text: 'Hello'),
+          tester,
+        );
+
+        expect(find.byKey(const Key('quote_thumbnail')), findsNothing);
+      });
+    });
+
+    group('onTap', () {
+      testWidgets('calls onTap when tapped', (tester) async {
+        var tapCalled = false;
+        await mountWidget(
+          WnMessageQuote(
+            author: 'Alice',
+            text: 'Hello',
+            onTap: () => tapCalled = true,
+          ),
+          tester,
+        );
+
+        await tester.tap(find.byKey(const Key('message_quote_tap_area')));
+        await tester.pumpAndSettle();
+
+        expect(tapCalled, isTrue);
+      });
+
+      testWidgets('no tap area key when onTap is null', (tester) async {
+        await mountWidget(
+          const WnMessageQuote(author: 'Alice', text: 'Hello'),
+          tester,
+        );
+
+        expect(find.byKey(const Key('message_quote_tap_area')), findsNothing);
+      });
+
+      testWidgets('works with both onTap and onCancel', (tester) async {
+        var tapCalled = false;
+        var cancelCalled = false;
+        await mountWidget(
+          WnMessageQuote(
+            author: 'Alice',
+            text: 'Hello',
+            onTap: () => tapCalled = true,
+            onCancel: () => cancelCalled = true,
+          ),
+          tester,
+        );
+
+        await tester.tap(find.byKey(const Key('cancel_quote_button')));
+        await tester.pumpAndSettle();
+        expect(cancelCalled, isTrue);
+        expect(tapCalled, isFalse);
+      });
+    });
+  });
+}

--- a/widgetbook/lib/components/message_quote.dart
+++ b/widgetbook/lib/components/message_quote.dart
@@ -1,0 +1,212 @@
+import 'package:flutter/material.dart';
+import 'package:whitenoise/theme.dart';
+import 'package:whitenoise/widgets/wn_message_quote.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+const _sampleImageUrl = 'https://www.whitenoise.chat/images/mask-man.webp';
+
+class WnMessageQuoteStory extends StatelessWidget {
+  const WnMessageQuoteStory({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+@widgetbook.UseCase(name: 'Message Quote', type: WnMessageQuoteStory)
+Widget wnMessageQuoteShowcase(BuildContext context) {
+  return Scaffold(
+    backgroundColor: context.colors.backgroundSecondary,
+    body: ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Text(
+          'Playground',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            color: context.colors.backgroundContentPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Use the knobs panel to customize this message quote.',
+          style: TextStyle(
+            fontSize: 14,
+            color: context.colors.backgroundContentSecondary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 300),
+            child: const _InteractiveMessageQuote(),
+          ),
+        ),
+        const SizedBox(height: 32),
+        Divider(color: context.colors.borderTertiary),
+        const SizedBox(height: 24),
+        _buildSection(
+          context,
+          'All Variants',
+          'Message Quote shows who was quoted and a snippet of the quoted text.',
+          [
+            const _QuoteExample(
+              label: 'Short message',
+              child: WnMessageQuote(
+                author: 'Wes Borland',
+                text: 'There may be something good in silence.',
+              ),
+            ),
+            const _QuoteExample(
+              label: 'Long message (2 lines max)',
+              child: WnMessageQuote(
+                author: 'Wes Borland',
+                text:
+                    "There may be something good in silence. It's a brand new thing. "
+                    'You can hear the funniest little discussions, if you keep turning '
+                    'the volume down. Shut yourself up, and listen out loud.',
+              ),
+            ),
+            const _QuoteExample(
+              label: 'Text only',
+              child: WnMessageQuote(author: 'Bob', text: 'Just some text'),
+            ),
+            _QuoteExample(
+              label: 'Media only',
+              child: WnMessageQuote(
+                author: 'Bob',
+                text: '',
+                image: const NetworkImage(_sampleImageUrl),
+              ),
+            ),
+            _QuoteExample(
+              label: 'Text and media',
+              child: WnMessageQuote(
+                author: 'Bob',
+                text: 'Check out this photo!',
+                image: const NetworkImage(_sampleImageUrl),
+              ),
+            ),
+            _QuoteExample(
+              label: 'Text and cancel button',
+              child: WnMessageQuote(
+                author: 'Alice',
+                text: 'Replying to this...',
+                onCancel: () {},
+              ),
+            ),
+            _QuoteExample(
+              label: 'Text, media and cancel button',
+              child: WnMessageQuote(
+                author: 'Alice',
+                text: 'Replying to this...',
+                image: const NetworkImage(_sampleImageUrl),
+                onCancel: () {},
+              ),
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+
+Widget _buildSection(
+  BuildContext context,
+  String title,
+  String description,
+  List<Widget> children,
+) {
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text(
+        title,
+        style: TextStyle(
+          fontSize: 18,
+          fontWeight: FontWeight.bold,
+          color: context.colors.backgroundContentPrimary,
+        ),
+      ),
+      const SizedBox(height: 4),
+      Text(
+        description,
+        style: TextStyle(
+          fontSize: 13,
+          color: context.colors.backgroundContentSecondary,
+        ),
+      ),
+      const SizedBox(height: 16),
+      Wrap(spacing: 24, runSpacing: 24, children: children),
+    ],
+  );
+}
+
+class _QuoteExample extends StatelessWidget {
+  const _QuoteExample({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+            color: context.colors.backgroundContentSecondary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 280),
+          child: child,
+        ),
+      ],
+    );
+  }
+}
+
+class _InteractiveMessageQuote extends StatelessWidget {
+  const _InteractiveMessageQuote();
+
+  @override
+  Widget build(BuildContext context) {
+    final author = context.knobs.string(
+      label: 'Author Name',
+      initialValue: 'Wes Borland',
+    );
+
+    final text = context.knobs.string(
+      label: 'Text',
+      initialValue:
+          "There may be something good in silence. It's a brand new thing.",
+    );
+
+    final showImage = context.knobs.boolean(
+      label: 'Show Image',
+      initialValue: false,
+    );
+
+    final showCancelButton = context.knobs.boolean(
+      label: 'Show Cancel Button',
+      initialValue: false,
+    );
+
+    return WnMessageQuote(
+      author: author,
+      text: text,
+      image: showImage ? const NetworkImage(_sampleImageUrl) : null,
+      onCancel: showCancelButton ? () {} : null,
+      onTap: () {},
+    );
+  }
+}

--- a/widgetbook/lib/main.directories.g.dart
+++ b/widgetbook/lib/main.directories.g.dart
@@ -32,6 +32,8 @@ import 'package:whitenoise_widgetbook/components/list.dart'
     as _whitenoise_widgetbook_components_list;
 import 'package:whitenoise_widgetbook/components/menu.dart'
     as _whitenoise_widgetbook_components_menu;
+import 'package:whitenoise_widgetbook/components/message_quote.dart'
+    as _whitenoise_widgetbook_components_message_quote;
 import 'package:whitenoise_widgetbook/components/spinner.dart'
     as _whitenoise_widgetbook_components_spinner;
 import 'package:whitenoise_widgetbook/components/structure.dart'
@@ -218,6 +220,16 @@ final directories = <_widgetbook.WidgetbookNode>[
           _widgetbook.WidgetbookUseCase(
             name: 'Menu Container',
             builder: _whitenoise_widgetbook_components_menu.wnMenuShowcase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'WnMessageQuoteStory',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Message Quote',
+            builder: _whitenoise_widgetbook_components_message_quote
+                .wnMessageQuoteShowcase,
           ),
         ],
       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
New widget with slate design for quotes (or replies previews).  

⚠️  I am not yet using it in chat screen intentionally. I will replace it in chat screen after my media PR is merged (I started replacing all the new widgets on my media branch but started snowballing)

Widgetbook story:
<img width="719" height="743" alt="Screenshot 2026-02-14 at 12 40 28 AM" src="https://github.com/user-attachments/assets/78385aa4-8eff-4099-8ad4-8ab8d926fee8" />



<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [X] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a quoted-message widget showing author, message text, optional thumbnail, cancel control, and tap interactions.
  * Component library updated with an interactive showcase and gallery of widget variants.

* **Tests**
  * Added comprehensive tests covering rendering, truncation, media display, tap/cancel behaviors, and interaction scenarios.
  * Added a reusable test image provider and improved test teardown to reset view state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->