### PR TITLE
Reaction style

### DIFF
--- a/lib/widgets/wn_reaction.dart
+++ b/lib/widgets/wn_reaction.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:gap/gap.dart';
+import 'package:whitenoise/theme.dart';
+
+enum WnReactionType { incoming, outgoing }
+
+class WnReaction extends HookWidget {
+  final String emoji;
+  final int? count;
+  final bool isSelected;
+  final WnReactionType type;
+  final VoidCallback? onTap;
+
+  const WnReaction({
+    super.key,
+    required this.emoji,
+    this.count,
+    this.isSelected = false,
+    this.type = WnReactionType.incoming,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final isHovered = useState(false);
+    final colors = context.colors;
+    final reactionColors = type == WnReactionType.outgoing
+        ? colors.reaction.outgoing
+        : colors.reaction.incoming;
+
+    final backgroundColor = isHovered.value
+        ? reactionColors.fillHover
+        : isSelected
+        ? reactionColors.fillSelected
+        : reactionColors.fill;
+    final textColor = isHovered.value
+        ? reactionColors.contentHover
+        : isSelected
+        ? reactionColors.contentSelected
+        : reactionColors.content;
+
+    final showCount = count != null && count! > 1;
+    final displayCount = count != null && count! > 99 ? '99+' : count?.toString();
+
+    final pill = Container(
+      padding: EdgeInsets.fromLTRB(6.w, 4.h, showCount ? 7.w : 6.w, 4.h),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(8.r),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            width: 16.w,
+            height: 16.h,
+            child: Center(
+              child: Text(
+                emoji,
+                style: TextStyle(fontSize: 16.sp, height: 1),
+              ),
+            ),
+          ),
+          if (showCount) ...[
+            Gap(2.w),
+            Text(
+              displayCount!,
+              style: context.typographyScaled.semiBold12.copyWith(color: textColor),
+            ),
+          ],
+        ],
+      ),
+    );
+
+    return MouseRegion(
+      onEnter: (_) => isHovered.value = true,
+      onExit: (_) => isHovered.value = false,
+      child: onTap != null ? GestureDetector(onTap: onTap, child: pill) : pill,
+    );
+  }
+}

--- a/test/widgets/wn_reaction_test.dart
+++ b/test/widgets/wn_reaction_test.dart
@@ -1,0 +1,174 @@
+import 'package:flutter/gestures.dart' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/theme/semantic_colors.dart';
+import 'package:whitenoise/widgets/wn_reaction.dart';
+import '../test_helpers.dart';
+
+Color _pillColor(WidgetTester tester) {
+  final container = tester.widget<Container>(
+    find.descendant(of: find.byType(WnReaction), matching: find.byType(Container)),
+  );
+  return (container.decoration! as BoxDecoration).color!;
+}
+
+void main() {
+  group('WnReaction', () {
+    testWidgets('renders emoji', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍'), tester);
+
+      expect(find.text('👍'), findsOneWidget);
+    });
+
+    testWidgets('does not show count when count is null', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍'), tester);
+
+      expect(find.text('👍'), findsOneWidget);
+      expect(find.text('1'), findsNothing);
+    });
+
+    testWidgets('does not show count when count is 1', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 1), tester);
+
+      expect(find.text('👍'), findsOneWidget);
+      expect(find.text('1'), findsNothing);
+    });
+
+    testWidgets('shows count when count is greater than 1', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 5), tester);
+
+      expect(find.text('👍'), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+    });
+
+    testWidgets('shows double digit count', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 42), tester);
+
+      expect(find.text('42'), findsOneWidget);
+    });
+
+    testWidgets('shows 99+ for counts over 99', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 150), tester);
+
+      expect(find.text('99+'), findsOneWidget);
+      expect(find.text('150'), findsNothing);
+    });
+
+    testWidgets('shows 99+ for count of exactly 100', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 100), tester);
+
+      expect(find.text('99+'), findsOneWidget);
+    });
+
+    testWidgets('shows 99 for count of exactly 99', (tester) async {
+      await mountWidget(const WnReaction(emoji: '👍', count: 99), tester);
+
+      expect(find.text('99'), findsOneWidget);
+    });
+
+    group('interaction', () {
+      testWidgets('calls onTap when tapped', (tester) async {
+        var tapped = false;
+        await mountWidget(WnReaction(emoji: '👍', onTap: () => tapped = true), tester);
+
+        await tester.tap(find.text('👍'));
+        await tester.pump();
+
+        expect(tapped, isTrue);
+      });
+
+      testWidgets('does not crash when onTap is null and tapped', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍'), tester);
+
+        await tester.tap(find.text('👍'));
+        await tester.pump();
+
+        expect(find.text('👍'), findsOneWidget);
+      });
+    });
+
+    group('fill colors', () {
+      final incoming = SemanticColors.light.reaction.incoming;
+      final outgoing = SemanticColors.light.reaction.outgoing;
+
+      testWidgets('incoming default', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍'), tester);
+        expect(_pillColor(tester), incoming.fill);
+      });
+
+      testWidgets('outgoing default', (tester) async {
+        await mountWidget(
+          const WnReaction(emoji: '👍', type: WnReactionType.outgoing),
+          tester,
+        );
+        expect(_pillColor(tester), outgoing.fill);
+      });
+
+      testWidgets('incoming selected', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍', isSelected: true), tester);
+        expect(_pillColor(tester), incoming.fillSelected);
+      });
+
+      testWidgets('outgoing selected', (tester) async {
+        await mountWidget(
+          const WnReaction(emoji: '👍', type: WnReactionType.outgoing, isSelected: true),
+          tester,
+        );
+        expect(_pillColor(tester), outgoing.fillSelected);
+      });
+
+      testWidgets('incoming hover', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍'), tester);
+
+        final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(tester.getCenter(find.byType(WnReaction)));
+        await tester.pump();
+
+        expect(_pillColor(tester), incoming.fillHover);
+      });
+
+      testWidgets('outgoing hover', (tester) async {
+        await mountWidget(
+          const WnReaction(emoji: '👍', type: WnReactionType.outgoing),
+          tester,
+        );
+
+        final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(tester.getCenter(find.byType(WnReaction)));
+        await tester.pump();
+
+        expect(_pillColor(tester), outgoing.fillHover);
+      });
+
+      testWidgets('hover takes priority over selected', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍', isSelected: true), tester);
+
+        final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: Offset.zero);
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(tester.getCenter(find.byType(WnReaction)));
+        await tester.pump();
+
+        expect(_pillColor(tester), incoming.fillHover);
+      });
+
+      testWidgets('reverts on mouse exit', (tester) async {
+        await mountWidget(const WnReaction(emoji: '👍'), tester);
+
+        final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await gesture.addPointer(location: const Offset(-100, -100));
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(tester.getCenter(find.byType(WnReaction)));
+        await tester.pump();
+        await gesture.moveTo(const Offset(-100, -100));
+        await tester.pump();
+
+        expect(_pillColor(tester), incoming.fill);
+      });
+    });
+  });
+}

--- a/widgetbook/lib/components/reaction.dart
+++ b/widgetbook/lib/components/reaction.dart
@@ -1,0 +1,227 @@
+import 'package:flutter/material.dart';
+import 'package:whitenoise/theme.dart';
+import 'package:whitenoise/widgets/wn_reaction.dart';
+import 'package:widgetbook/widgetbook.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+class WnReactionStory extends StatelessWidget {
+  const WnReactionStory({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+const _counts = [1, 2, 21, 100];
+const _countLabels = ['1', '2', '21', '100'];
+
+@widgetbook.UseCase(name: 'Reaction', type: WnReactionStory)
+Widget wnReactionShowcase(BuildContext context) {
+  final colors = context.colors;
+  final labelStyle = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.w500,
+    color: colors.backgroundContentSecondary,
+  );
+
+  return Scaffold(
+    backgroundColor: colors.backgroundPrimary,
+    body: ListView(
+      padding: const EdgeInsets.all(24),
+      children: [
+        Text(
+          'Playground',
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w600,
+            color: colors.backgroundContentPrimary,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Use the knobs panel to customize this reaction.',
+          style: TextStyle(
+            fontSize: 14,
+            color: colors.backgroundContentSecondary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Align(
+          alignment: Alignment.centerLeft,
+          child: _InteractiveReaction(context: context),
+        ),
+        const SizedBox(height: 32),
+        Divider(color: colors.borderTertiary),
+        const SizedBox(height: 24),
+        Text(
+          'All Variants',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: colors.backgroundContentPrimary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Columns show count variants. Rows show type and selection state. Hover to see hover colors.',
+          style: TextStyle(
+            fontSize: 13,
+            color: colors.backgroundContentSecondary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Table(
+            defaultColumnWidth: const IntrinsicColumnWidth(),
+            defaultVerticalAlignment: TableCellVerticalAlignment.middle,
+            children: [
+              TableRow(
+                children: [
+                  const SizedBox.shrink(),
+                  for (final label in _countLabels)
+                    Padding(
+                      padding: const EdgeInsets.only(left: 16, bottom: 12),
+                      child: Text(label, style: labelStyle),
+                    ),
+                ],
+              ),
+              _buildRow(
+                'Incoming Default',
+                WnReactionType.incoming,
+                false,
+                labelStyle,
+              ),
+              _buildRow(
+                'Incoming Selected',
+                WnReactionType.incoming,
+                true,
+                labelStyle,
+              ),
+              _buildRow(
+                'Outgoing Default',
+                WnReactionType.outgoing,
+                false,
+                labelStyle,
+              ),
+              _buildRow(
+                'Outgoing Selected',
+                WnReactionType.outgoing,
+                true,
+                labelStyle,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 32),
+        Divider(color: colors.borderTertiary),
+        const SizedBox(height: 24),
+        Text(
+          'Different Emojis',
+          style: TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: colors.backgroundContentPrimary,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Various emoji reactions.',
+          style: TextStyle(
+            fontSize: 13,
+            color: colors.backgroundContentSecondary,
+          ),
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            WnReaction(
+              emoji: '😀',
+              count: 5,
+              type: WnReactionType.incoming,
+              onTap: () {},
+            ),
+            WnReaction(
+              emoji: '❤️',
+              count: 3,
+              type: WnReactionType.incoming,
+              onTap: () {},
+            ),
+            WnReaction(
+              emoji: '😂',
+              count: 2,
+              type: WnReactionType.incoming,
+              onTap: () {},
+            ),
+            WnReaction(
+              emoji: '🔥',
+              type: WnReactionType.incoming,
+              onTap: () {},
+            ),
+          ],
+        ),
+      ],
+    ),
+  );
+}
+
+TableRow _buildRow(
+  String label,
+  WnReactionType type,
+  bool isSelected,
+  TextStyle labelStyle,
+) {
+  return TableRow(
+    children: [
+      Padding(
+        padding: const EdgeInsets.only(right: 16, bottom: 8),
+        child: Text(label, style: labelStyle),
+      ),
+      for (final count in _counts)
+        Padding(
+          padding: const EdgeInsets.only(left: 16, bottom: 8),
+          child: WnReaction(
+            emoji: '😀',
+            count: count,
+            isSelected: isSelected,
+            type: type,
+            onTap: () {},
+          ),
+        ),
+    ],
+  );
+}
+
+class _InteractiveReaction extends StatelessWidget {
+  const _InteractiveReaction({required this.context});
+
+  final BuildContext context;
+
+  @override
+  Widget build(BuildContext context) {
+    final type = this.context.knobs.object.dropdown<WnReactionType>(
+      label: 'Type',
+      options: WnReactionType.values,
+      initialOption: WnReactionType.incoming,
+      labelBuilder: (value) => value.name,
+    );
+
+    final emoji = this.context.knobs.string(label: 'Emoji', initialValue: '😀');
+    final count = this.context.knobs.int.input(label: 'Count', initialValue: 1);
+    final isSelected = this.context.knobs.boolean(
+      label: 'Is Selected',
+      initialValue: false,
+    );
+
+    return WnReaction(
+      emoji: emoji,
+      count: count > 0 ? count : null,
+      isSelected: isSelected,
+      type: type,
+      onTap: () {},
+    );
+  }
+}

--- a/widgetbook/lib/main.directories.g.dart
+++ b/widgetbook/lib/main.directories.g.dart
@@ -34,6 +34,8 @@ import 'package:whitenoise_widgetbook/components/menu.dart'
     as _whitenoise_widgetbook_components_menu;
 import 'package:whitenoise_widgetbook/components/message_quote.dart'
     as _whitenoise_widgetbook_components_message_quote;
+import 'package:whitenoise_widgetbook/components/reaction.dart'
+    as _whitenoise_widgetbook_components_reaction;
 import 'package:whitenoise_widgetbook/components/spinner.dart'
     as _whitenoise_widgetbook_components_spinner;
 import 'package:whitenoise_widgetbook/components/structure.dart'
@@ -252,6 +254,16 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'Profile Switcher Item',
             builder: _whitenoise_widgetbook_components_wn_profile_switcher_item
                 .wnProfileSwitcherItemShowcase,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'WnReactionStory',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'Reaction',
+            builder:
+                _whitenoise_widgetbook_components_reaction.wnReactionShowcase,
           ),
         ],
       ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

New widget with slate design for reactions.

⚠️  Same warning as #260: I am not yet using it in chat screen intentionally. I will replace it in chat screen after my media PR is merged (I started replacing all the new widgets on my media branch but started snowballing)

Widgetbook
<img width="500" alt="Reactions story" src="https://github.com/user-attachments/assets/fc3c909a-5804-4396-9d19-8da03fa050de" />



## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a compact reaction pill UI (emoji + optional count, shows "99+" for large counts), incoming/outgoing styles, selectable and hoverable states, and a public API for using the widget and reaction type.

* **Tests**
  * Added comprehensive widget tests for rendering, count rules, tap/hover interactions, and visual theming across states.

* **Documentation**
  * Added an interactive showcase demonstrating all variants with live controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->