### PR TITLE
feat: add 40px variant to WnInputFieldButton

### DIFF
--- a/lib/widgets/wn_copyable_field.dart
+++ b/lib/widgets/wn_copyable_field.dart
@@ -3,7 +3,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
-import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 import 'package:whitenoise/widgets/wn_input.dart';
 
@@ -40,7 +39,6 @@ class WnCopyableField extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colors = context.colors;
     final controller = useTextEditingController(text: _getDisplayValue());
 
     useEffect(() {
@@ -54,24 +52,10 @@ class WnCopyableField extends HookWidget {
       controller: controller,
       readOnly: true,
       size: WnInputSize.size44,
-      inlineAction: obscurable
-          ? GestureDetector(
-              key: const Key('visibility_toggle'),
-              onTap: onToggleVisibility,
-              child: Container(
-                width: 36.w,
-                height: 36.h,
-                color: Colors.transparent,
-                child: Center(
-                  child: WnIcon(
-                    obscured ? WnIcons.view : WnIcons.viewOff,
-                    size: 16.w,
-                    color: colors.backgroundContentPrimary,
-                  ),
-                ),
-              ),
-            )
-          : null,
+      inlineActionIcon: obscurable ? (obscured ? WnIcons.view : WnIcons.viewOff) : null,
+      inlineActionOnPressed: obscurable ? onToggleVisibility : null,
+      inlineActionFilled: false,
+      inlineActionKey: obscurable ? const Key('visibility_toggle') : null,
       trailingAction: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/widgets/wn_input.dart
+++ b/lib/widgets/wn_input.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart' show Gap;
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
+import 'package:whitenoise/widgets/wn_input_field_button.dart';
 
 enum WnInputSize {
   size44(44),
@@ -12,17 +13,9 @@ enum WnInputSize {
 
   const WnInputSize(this.height);
   final int height;
-}
 
-enum WnInputFieldButtonSize {
-  size36(36, 16),
-  size40(40, 18),
-  size48(48, 18)
-  ;
-
-  const WnInputFieldButtonSize(this.dimension, this.iconSize);
-  final int dimension;
-  final int iconSize;
+  WnInputFieldButtonSize get inlineActionButtonSize =>
+      this == WnInputSize.size44 ? WnInputFieldButtonSize.size36 : WnInputFieldButtonSize.size48;
 }
 
 class WnInput extends HookWidget {
@@ -41,7 +34,10 @@ class WnInput extends HookWidget {
     this.onChanged,
     this.textInputAction,
     this.leadingIcon,
-    this.inlineAction,
+    this.inlineActionIcon,
+    this.inlineActionOnPressed,
+    this.inlineActionFilled = true,
+    this.inlineActionKey,
     this.trailingAction,
     this.focusNode,
   });
@@ -59,9 +55,14 @@ class WnInput extends HookWidget {
   final ValueChanged<String>? onChanged;
   final TextInputAction? textInputAction;
   final Widget? leadingIcon;
-  final Widget? inlineAction;
+  final WnIcons? inlineActionIcon;
+  final VoidCallback? inlineActionOnPressed;
+  final bool inlineActionFilled;
+  final Key? inlineActionKey;
   final Widget? trailingAction;
   final FocusNode? focusNode;
+
+  bool get _hasInlineAction => inlineActionIcon != null;
 
   bool get _hasError => errorText != null;
 
@@ -161,9 +162,6 @@ class WnInput extends HookWidget {
   ) {
     final typography = context.typographyScaled;
     final fieldHeight = size.height.h;
-    final inlineActionSize = size == WnInputSize.size44
-        ? WnInputFieldButtonSize.size36.dimension
-        : WnInputFieldButtonSize.size48.dimension;
     final borderColor = _getBorderColor(colors, isFocused.value, isHovered.value);
 
     return MouseRegion(
@@ -228,13 +226,15 @@ class WnInput extends HookWidget {
                 ),
               ),
             ),
-            if (inlineAction != null) ...[
+            if (_hasInlineAction) ...[
               IgnorePointer(
-                ignoring: !enabled,
-                child: SizedBox(
-                  width: inlineActionSize.w,
-                  height: inlineActionSize.h,
-                  child: inlineAction,
+                ignoring: !enabled || inlineActionOnPressed == null,
+                child: WnInputFieldButton(
+                  key: inlineActionKey,
+                  icon: inlineActionIcon!,
+                  onPressed: inlineActionOnPressed ?? () {},
+                  buttonSize: size.inlineActionButtonSize,
+                  filled: inlineActionFilled,
                 ),
               ),
               Gap(4.w),
@@ -263,43 +263,6 @@ class WnInput extends HookWidget {
       child: Text(
         errorText!,
         style: typography.medium14.copyWith(color: colors.backgroundContentDestructive),
-      ),
-    );
-  }
-}
-
-class WnInputFieldButton extends StatelessWidget {
-  const WnInputFieldButton({
-    super.key,
-    required this.icon,
-    required this.onPressed,
-    this.buttonSize = WnInputFieldButtonSize.size48,
-  });
-
-  final WnIcons icon;
-  final VoidCallback onPressed;
-  final WnInputFieldButtonSize buttonSize;
-
-  @override
-  Widget build(BuildContext context) {
-    final colors = context.colors;
-
-    return GestureDetector(
-      onTap: onPressed,
-      child: Container(
-        width: buttonSize.dimension.w,
-        height: buttonSize.dimension.h,
-        decoration: BoxDecoration(
-          color: colors.fillTertiary,
-          borderRadius: BorderRadius.circular(8.r),
-        ),
-        child: Center(
-          child: WnIcon(
-            icon,
-            size: buttonSize.iconSize.w,
-            color: colors.backgroundContentPrimary,
-          ),
-        ),
       ),
     );
   }

--- a/lib/widgets/wn_input_field_button.dart
+++ b/lib/widgets/wn_input_field_button.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:whitenoise/theme.dart';
+import 'package:whitenoise/widgets/wn_icon.dart';
+
+enum WnInputFieldButtonSize {
+  size36(36, 16),
+  size40(40, 18),
+  size48(48, 18)
+  ;
+
+  const WnInputFieldButtonSize(this.dimension, this.iconSize);
+  final int dimension;
+  final int iconSize;
+}
+
+class WnInputFieldButton extends StatelessWidget {
+  const WnInputFieldButton({
+    super.key,
+    required this.icon,
+    required this.onPressed,
+    this.buttonSize = WnInputFieldButtonSize.size48,
+    this.filled = true,
+  });
+
+  final WnIcons icon;
+  final VoidCallback onPressed;
+  final WnInputFieldButtonSize buttonSize;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = context.colors;
+
+    return GestureDetector(
+      onTap: onPressed,
+      child: Container(
+        width: buttonSize.dimension.w,
+        height: buttonSize.dimension.h,
+        decoration: BoxDecoration(
+          color: filled ? colors.fillTertiary : Colors.transparent,
+          borderRadius: BorderRadius.circular(8.r),
+        ),
+        child: Center(
+          child: WnIcon(
+            icon,
+            size: buttonSize.iconSize.w,
+            color: colors.backgroundContentPrimary,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/wn_input_password.dart
+++ b/lib/widgets/wn_input_password.dart
@@ -5,6 +5,7 @@ import 'package:gap/gap.dart' show Gap;
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 import 'package:whitenoise/widgets/wn_input.dart';
+import 'package:whitenoise/widgets/wn_input_field_button.dart';
 
 class WnInputPassword extends HookWidget {
   const WnInputPassword({
@@ -186,61 +187,30 @@ class WnInputPassword extends HookWidget {
     ValueNotifier<bool> isVisible,
     bool isEmpty,
   ) {
-    final btnSize = size == WnInputSize.size44
-        ? WnInputFieldButtonSize.size36
-        : WnInputFieldButtonSize.size48;
-    final buttonWidth = btnSize.dimension.w;
-    final buttonHeight = btnSize.dimension.h;
-    final iconWrapperWidth = 36.w;
-    final iconWrapperHeight = 36.h;
-    final iconSize = btnSize.iconSize.w;
+    final btnSize = size.inlineActionButtonSize;
 
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
         if (onScan != null)
-          GestureDetector(
-            key: const Key('scan_button'),
-            onTap: enabled ? onScan : null,
-            child: Container(
-              width: buttonWidth,
-              height: buttonHeight,
-              color: Colors.transparent,
-              child: Center(
-                child: SizedBox(
-                  width: iconWrapperWidth,
-                  height: iconWrapperHeight,
-                  child: Center(
-                    child: WnIcon(
-                      WnIcons.scan,
-                      size: iconSize,
-                      color: colors.backgroundContentPrimary,
-                    ),
-                  ),
-                ),
-              ),
+          IgnorePointer(
+            ignoring: !enabled,
+            child: WnInputFieldButton(
+              key: const Key('scan_button'),
+              icon: WnIcons.scan,
+              onPressed: onScan!,
+              buttonSize: btnSize,
+              filled: false,
             ),
           ),
-        GestureDetector(
-          key: const Key('visibility_toggle'),
-          onTap: enabled ? () => isVisible.value = !isVisible.value : null,
-          child: Container(
-            width: buttonWidth,
-            height: buttonHeight,
-            color: Colors.transparent,
-            child: Center(
-              child: SizedBox(
-                width: iconWrapperWidth,
-                height: iconWrapperHeight,
-                child: Center(
-                  child: WnIcon(
-                    isVisible.value ? WnIcons.viewOff : WnIcons.view,
-                    size: iconSize,
-                    color: colors.backgroundContentPrimary,
-                  ),
-                ),
-              ),
-            ),
+        IgnorePointer(
+          ignoring: !enabled,
+          child: WnInputFieldButton(
+            key: const Key('visibility_toggle'),
+            icon: isVisible.value ? WnIcons.viewOff : WnIcons.view,
+            onPressed: () => isVisible.value = !isVisible.value,
+            buttonSize: btnSize,
+            filled: false,
           ),
         ),
       ],

--- a/test/widgets/wn_input_test.dart
+++ b/test/widgets/wn_input_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/theme/semantic_colors.dart' show SemanticColors;
 import 'package:whitenoise/widgets/wn_icon.dart' show WnIcon, WnIcons;
 import 'package:whitenoise/widgets/wn_input.dart';
+import 'package:whitenoise/widgets/wn_input_field_button.dart';
 import '../test_helpers.dart' show mountWidget;
 
 void main() {
@@ -289,20 +290,60 @@ void main() {
     });
 
     group('with inline action', () {
-      testWidgets('displays inline action when provided', (tester) async {
+      testWidgets('displays inline action when icon and callback provided', (tester) async {
         await mountWidget(
           WnInput(
             label: 'Label',
             placeholder: 'hint',
-            inlineAction: WnInputFieldButton(
-              key: const Key('inline_action'),
-              icon: WnIcons.search,
-              onPressed: () {},
-            ),
+            inlineActionIcon: WnIcons.search,
+            inlineActionOnPressed: () {},
           ),
           tester,
         );
-        expect(find.byKey(const Key('inline_action')), findsOneWidget);
+        expect(find.byType(WnInputFieldButton), findsOneWidget);
+      });
+
+      testWidgets('renders inline action even without callback', (tester) async {
+        await mountWidget(
+          const WnInput(
+            label: 'Label',
+            placeholder: 'hint',
+            inlineActionIcon: WnIcons.search,
+          ),
+          tester,
+        );
+        expect(find.byType(WnInputFieldButton), findsOneWidget);
+      });
+
+      testWidgets('renders unfilled inline action when inlineActionFilled is false', (
+        tester,
+      ) async {
+        await mountWidget(
+          WnInput(
+            label: 'Label',
+            placeholder: 'hint',
+            inlineActionIcon: WnIcons.search,
+            inlineActionOnPressed: () {},
+            inlineActionFilled: false,
+          ),
+          tester,
+        );
+        final button = tester.widget<WnInputFieldButton>(find.byType(WnInputFieldButton));
+        expect(button.filled, isFalse);
+      });
+
+      testWidgets('uses correct button size based on input size', (tester) async {
+        await mountWidget(
+          WnInput(
+            placeholder: 'hint',
+            size: WnInputSize.size44,
+            inlineActionIcon: WnIcons.search,
+            inlineActionOnPressed: () {},
+          ),
+          tester,
+        );
+        final button = tester.widget<WnInputFieldButton>(find.byType(WnInputFieldButton));
+        expect(button.buttonSize, equals(WnInputFieldButtonSize.size36));
       });
     });
 
@@ -381,6 +422,31 @@ void main() {
       final buttonSize = tester.getSize(find.byType(WnInputFieldButton));
       expect(buttonSize.width, equals(36.0));
       expect(buttonSize.height, equals(36.0));
+    });
+
+    testWidgets('defaults to filled style', (tester) async {
+      await mountWidget(
+        WnInputFieldButton(
+          icon: WnIcons.search,
+          onPressed: () {},
+        ),
+        tester,
+      );
+      final button = tester.widget<WnInputFieldButton>(find.byType(WnInputFieldButton));
+      expect(button.filled, isTrue);
+    });
+
+    testWidgets('renders with transparent background when filled is false', (tester) async {
+      await mountWidget(
+        WnInputFieldButton(
+          icon: WnIcons.search,
+          onPressed: () {},
+          filled: false,
+        ),
+        tester,
+      );
+      final button = tester.widget<WnInputFieldButton>(find.byType(WnInputFieldButton));
+      expect(button.filled, isFalse);
     });
   });
 

--- a/widgetbook/lib/components/inputs.dart
+++ b/widgetbook/lib/components/inputs.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 import 'package:whitenoise/widgets/wn_input.dart';
+import 'package:whitenoise/widgets/wn_input_field_button.dart';
 import 'package:whitenoise/widgets/wn_input_password.dart';
 import 'package:whitenoise/widgets/wn_input_text_area.dart';
 import 'package:widgetbook/widgetbook.dart';
@@ -291,32 +292,91 @@ Widget wnInputShowcase(BuildContext context) {
         const SizedBox(height: 32),
         _buildSection(
           context,
-          'Input Field Button Sizes',
-          'Input field buttons come in three sizes: 48px (default), 40px, and 36px (compact).',
+          'Inline Action Buttons',
+          'Inline action buttons auto-size based on the input size. '
+              'Size 56 inputs use 48px buttons, size 44 inputs use 36px buttons.',
           [
             _InputExample(
-              label: 'Button 48px (Default)',
+              label: 'Size 56 (48px button)',
               child: _StaticInput(
                 placeholder: 'Enter text...',
                 showInlineAction: true,
-                inlineActionButtonSize: WnInputFieldButtonSize.size48,
               ),
             ),
             _InputExample(
-              label: 'Button 40px',
-              child: _StaticInput(
-                placeholder: 'Enter text...',
-                showInlineAction: true,
-                inlineActionButtonSize: WnInputFieldButtonSize.size40,
-              ),
-            ),
-            _InputExample(
-              label: 'Button 36px (Compact)',
+              label: 'Size 44 (36px button)',
               child: _StaticInput(
                 placeholder: 'Enter text...',
                 size: WnInputSize.size44,
                 showInlineAction: true,
-                inlineActionButtonSize: WnInputFieldButtonSize.size36,
+              ),
+            ),
+            _InputExample(
+              label: 'Unfilled (transparent)',
+              child: _StaticInput(
+                placeholder: 'Enter text...',
+                showInlineAction: true,
+                inlineActionFilled: false,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 32),
+        _buildSection(
+          context,
+          'Standalone Button Sizes',
+          'WnInputFieldButton comes in 48px, 40px, and 36px, '
+              'each in filled or unfilled style.',
+          [
+            _InputExample(
+              label: 'Filled (48, 40, 36)',
+              child: Row(
+                children: [
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size48,
+                  ),
+                  const SizedBox(width: 8),
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size40,
+                  ),
+                  const SizedBox(width: 8),
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size36,
+                  ),
+                ],
+              ),
+            ),
+            _InputExample(
+              label: 'Unfilled (48, 40, 36)',
+              child: Row(
+                children: [
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size48,
+                    filled: false,
+                  ),
+                  const SizedBox(width: 8),
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size40,
+                    filled: false,
+                  ),
+                  const SizedBox(width: 8),
+                  WnInputFieldButton(
+                    icon: WnIcons.closeSmall,
+                    onPressed: () {},
+                    buttonSize: WnInputFieldButtonSize.size36,
+                    filled: false,
+                  ),
+                ],
               ),
             ),
           ],
@@ -439,8 +499,8 @@ class _StaticInput extends StatelessWidget {
     this.showLeadingIcon = false,
     this.leadingIconData,
     this.showInlineAction = false,
+    this.inlineActionFilled = true,
     this.showTrailingAction = false,
-    this.inlineActionButtonSize,
   });
 
   final String placeholder;
@@ -455,17 +515,11 @@ class _StaticInput extends StatelessWidget {
   final bool showLeadingIcon;
   final WnIcons? leadingIconData;
   final bool showInlineAction;
+  final bool inlineActionFilled;
   final bool showTrailingAction;
-  final WnInputFieldButtonSize? inlineActionButtonSize;
 
   @override
   Widget build(BuildContext context) {
-    final effectiveButtonSize =
-        inlineActionButtonSize ??
-        (size == WnInputSize.size44
-            ? WnInputFieldButtonSize.size36
-            : WnInputFieldButtonSize.size48);
-
     return WnInput(
       placeholder: placeholder,
       label: inputLabel,
@@ -485,13 +539,9 @@ class _StaticInput extends StatelessWidget {
               color: context.colors.backgroundContentSecondary,
             )
           : null,
-      inlineAction: showInlineAction
-          ? WnInputFieldButton(
-              icon: WnIcons.closeSmall,
-              onPressed: () {},
-              buttonSize: effectiveButtonSize,
-            )
-          : null,
+      inlineActionIcon: showInlineAction ? WnIcons.closeSmall : null,
+      inlineActionOnPressed: showInlineAction ? () {} : null,
+      inlineActionFilled: inlineActionFilled,
       trailingAction: showTrailingAction
           ? WnInputTrailingButton(
               icon: WnIcons.scan,
@@ -517,13 +567,14 @@ class _InteractiveInput extends StatelessWidget {
       initialOption: WnInputSize.size56,
       labelBuilder: (value) => value == WnInputSize.size56 ? '56px' : '44px',
     );
-    final inlineButtonSize = this.context.knobs.object
-        .dropdown<WnInputFieldButtonSize>(
-          label: 'Inline Button Size',
-          options: WnInputFieldButtonSize.values,
-          initialOption: WnInputFieldButtonSize.size48,
-          labelBuilder: (value) => '${value.dimension}px',
-        );
+    final showInlineAction = this.context.knobs.boolean(
+      label: 'Show Inline Action',
+      initialValue: false,
+    );
+    final inlineActionFilled = this.context.knobs.boolean(
+      label: 'Inline Action Filled',
+      initialValue: true,
+    );
 
     return WnInput(
       placeholder: this.context.knobs.string(
@@ -566,17 +617,9 @@ class _InteractiveInput extends StatelessWidget {
               color: colors.backgroundContentSecondary,
             )
           : null,
-      inlineAction:
-          this.context.knobs.boolean(
-            label: 'Show Inline Action',
-            initialValue: false,
-          )
-          ? WnInputFieldButton(
-              icon: WnIcons.closeSmall,
-              onPressed: () {},
-              buttonSize: inlineButtonSize,
-            )
-          : null,
+      inlineActionIcon: showInlineAction ? WnIcons.closeSmall : null,
+      inlineActionOnPressed: showInlineAction ? () {} : null,
+      inlineActionFilled: inlineActionFilled,
       trailingAction:
           this.context.knobs.boolean(
             label: 'Show Trailing Action',


### PR DESCRIPTION
## Summary

Closes #276

### New in this PR
- Add `WnInputFieldButtonSize` enum with three variants (`size36`, `size40`, `size48`), each encoding both button dimension and icon size per the Figma spec
- Replace the `WnInputSize`-based `size` parameter on `WnInputFieldButton` with a dedicated `buttonSize` parameter (`WnInputFieldButtonSize`)
- Add `filled` parameter to `WnInputFieldButton` (default `true`) to support both filled and transparent styles

### Refactors (addressing review feedback)
- Extract `WnInputFieldButton` and `WnInputFieldButtonSize` into dedicated `wn_input_field_button.dart` file
- Replace `WnInput.inlineAction: Widget?` with `inlineActionIcon`, `inlineActionOnPressed`, `inlineActionFilled`, and `inlineActionKey` — the input now manages button sizing internally based on `WnInputSize`
- Add `WnInputSize.inlineActionButtonSize` getter to centralize the size44→size36, size56→size48 mapping
- Refactor `WnInputPassword` inline actions (scan, visibility toggle) to use `WnInputFieldButton(filled: false)` instead of manual `GestureDetector`/`Container`
- Update `WnCopyableField` to use the new `WnInput` inline action API

### Tests & widgetbook
- Add tests verifying all three button size variants, filled/unfilled styles, auto-sizing based on input size
- Update widgetbook with "Inline Action Buttons" and "Standalone Button Sizes" sections showcasing all variants, plus interactive `filled` knob

### Figma spec

| Size | Button dimension | Icon size | Used in |
|------|-----------------|-----------|---------|
| `size36` | 36x36 | 16px | 44px input fields |
| `size40` | 40x40 | 18px | 56px input fields |
| `size48` | 48x48 | 18px | 56px input fields (default) |