### PR TITLE
fix: remove manual scroll-to-bottom on signup screen keyboard open

### DIFF
--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,12 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart'
-    show
-        HookWidget,
-        useAnimationController,
-        useEffect,
-        useScrollController,
-        useState,
-        useTextEditingController;
+    show HookWidget, useAnimationController, useEffect, useState, useTextEditingController;
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart' show Gap;
 import 'package:hooks_riverpod/hooks_riverpod.dart' show HookConsumerWidget, WidgetRef;
@@ -35,7 +29,6 @@ class SignupScreen extends HookConsumerWidget {
     final colors = context.colors;
     final displayNameController = useTextEditingController();
     final bioController = useTextEditingController();
-    final scrollController = useScrollController();
     final (:state, :submit, :onImageSelected, :clearErrors) = useSignup(
       () => ref.read(authProvider.notifier).signup(),
     );
@@ -67,20 +60,6 @@ class SignupScreen extends HookConsumerWidget {
         showCarousel.value = false;
       });
     }
-
-    final keyboardHeight = MediaQuery.viewInsetsOf(context).bottom;
-    useEffect(() {
-      if (keyboardHeight > 0 && scrollController.hasClients) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          scrollController.animateTo(
-            scrollController.position.maxScrollExtent,
-            duration: const Duration(milliseconds: 350),
-            curve: Curves.easeOutCubic,
-          );
-        });
-      }
-      return null;
-    }, [keyboardHeight]);
 
     useEffect(() {
       if (imagePickerError != null) {
@@ -169,7 +148,6 @@ class SignupScreen extends HookConsumerWidget {
                                   )
                                 : null,
                             child: SingleChildScrollView(
-                              controller: scrollController,
                               child: Padding(
                                 padding: EdgeInsets.fromLTRB(14.w, 0, 14.w, 14.h),
                                 child: Column(

--- a/test/screens/signup_screen_test.dart
+++ b/test/screens/signup_screen_test.dart
@@ -196,7 +196,7 @@ void main() {
 
     group('keyboard', () {
       testWidgets(
-        'scrolls to bottom when keyboard appears',
+        'inputs remain visible when keyboard appears',
         (tester) async {
           tester.view.physicalSize = const Size(390, 550);
           tester.view.devicePixelRatio = 1.0;
@@ -223,14 +223,14 @@ void main() {
           Routes.pushToSignup(tester.element(find.byType(Scaffold)));
           await tester.pumpAndSettle();
 
-          final signUpButtonFinder = find.text('Sign Up');
-          expect(signUpButtonFinder, findsOneWidget);
+          expect(find.text('Choose a name'), findsOneWidget);
+          expect(find.text('Sign Up'), findsOneWidget);
 
           tester.view.viewInsets = const FakeViewPadding(bottom: 300);
           await tester.pump();
           await tester.pump(const Duration(milliseconds: 400));
 
-          expect(signUpButtonFinder, findsOneWidget);
+          expect(find.text('Choose a name'), findsOneWidget);
 
           addTearDown(() => tester.view.resetViewInsets());
         },


### PR DESCRIPTION
## Summary

- Removes the `useEffect` that called `scrollController.animateTo(maxScrollExtent)` when the keyboard appeared, which was scrolling past the name input field and hiding it from view
- Removes the now-unused `scrollController` and its import
- Updates the keyboard test to verify inputs remain visible rather than validating the buggy scroll-to-bottom behavior

Flutter's `Scaffold` with `resizeToAvoidBottomInset: true` (the default) combined with built-in focus management already handles scrolling the focused field into view natively — the manual override was fighting against this.

Closes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined keyboard behavior on the signup screen to ensure input fields remain visible when the keyboard appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->