### PR TITLE
Remove chat filter pills from search header

### DIFF
--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -19,7 +19,7 @@ import 'package:whitenoise/widgets/wn_slate.dart';
 import 'package:whitenoise/widgets/wn_system_notice.dart';
 
 const _slateHeight = 80;
-const _searchAndFiltersHeight = 108;
+const _searchAndFiltersHeight = 68;
 
 class ChatListScreen extends HookConsumerWidget {
   const ChatListScreen({super.key});

--- a/lib/widgets/wn_search_and_filters.dart
+++ b/lib/widgets/wn_search_and_filters.dart
@@ -2,25 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:whitenoise/l10n/l10n.dart';
-import 'package:whitenoise/widgets/wn_filter_chip.dart';
 import 'package:whitenoise/widgets/wn_search_field.dart';
-
-enum ChatFilter { chats, archive }
 
 class WnSearchAndFilters extends HookWidget {
   const WnSearchAndFilters({
     super.key,
     this.onSearchChanged,
-    this.onFilterChanged,
   });
 
   final ValueChanged<String>? onSearchChanged;
-  final ValueChanged<ChatFilter>? onFilterChanged;
 
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
-    final selectedFilter = useState(ChatFilter.chats);
     final searchController = useTextEditingController();
 
     final onSearchChangedRef = useRef(onSearchChanged);
@@ -35,11 +29,6 @@ class WnSearchAndFilters extends HookWidget {
       return () => searchController.removeListener(listener);
     }, [searchController]);
 
-    void handleFilterSelected(ChatFilter filter) {
-      selectedFilter.value = filter;
-      onFilterChanged?.call(filter);
-    }
-
     return Padding(
       padding: EdgeInsets.only(top: 16.h),
       child: Column(
@@ -50,25 +39,6 @@ class WnSearchAndFilters extends HookWidget {
           WnSearchField(
             placeholder: l10n.search,
             controller: searchController,
-          ),
-          SizedBox(height: 8.h),
-          Row(
-            key: const Key('filter_chips_row'),
-            children: [
-              WnFilterChip(
-                key: const Key('filter_chip_chats'),
-                label: l10n.filterChats,
-                selected: selectedFilter.value == ChatFilter.chats,
-                onSelected: (_) => handleFilterSelected(ChatFilter.chats),
-              ),
-              SizedBox(width: 6.w),
-              WnFilterChip(
-                key: const Key('filter_chip_archive'),
-                label: l10n.filterArchive,
-                selected: selectedFilter.value == ChatFilter.archive,
-                onSelected: (_) => handleFilterSelected(ChatFilter.archive),
-              ),
-            ],
           ),
         ],
       ),

--- a/test/widgets/wn_search_and_filters_test.dart
+++ b/test/widgets/wn_search_and_filters_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart' show Key, TextField;
 import 'package:flutter_test/flutter_test.dart';
-import 'package:whitenoise/widgets/wn_filter_chip.dart';
 import 'package:whitenoise/widgets/wn_search_and_filters.dart';
 import 'package:whitenoise/widgets/wn_search_field.dart';
 import '../test_helpers.dart' show mountWidget;
@@ -18,49 +17,9 @@ void main() {
         expect(find.text('Search'), findsOneWidget);
       });
 
-      testWidgets('renders two filter chips', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-        expect(find.byType(WnFilterChip), findsNWidgets(2));
-      });
-
-      testWidgets('renders Chats filter chip', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-        expect(find.text('Chats'), findsOneWidget);
-      });
-
-      testWidgets('renders Archive filter chip', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-        expect(find.text('Archive'), findsOneWidget);
-      });
-
-      testWidgets('renders filter chips row', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-        expect(find.byKey(const Key('filter_chips_row')), findsOneWidget);
-      });
-
       testWidgets('renders search and filters container', (tester) async {
         await mountWidget(const WnSearchAndFilters(), tester);
         expect(find.byKey(const Key('search_and_filters')), findsOneWidget);
-      });
-    });
-
-    group('default state', () {
-      testWidgets('Chats filter is selected by default', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        final chatsChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_chats')),
-        );
-        expect(chatsChip.selected, isTrue);
-      });
-
-      testWidgets('Archive filter is not selected by default', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        final archiveChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_archive')),
-        );
-        expect(archiveChip.selected, isFalse);
       });
     });
 
@@ -82,96 +41,6 @@ void main() {
         await tester.enterText(find.byType(TextField), 'hello');
         await tester.pump();
         expect(find.text('hello'), findsOneWidget);
-      });
-    });
-
-    group('filter selection', () {
-      testWidgets('tapping Archive selects it and deselects Chats', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        await tester.tap(find.byKey(const Key('filter_chip_archive')));
-        await tester.pump();
-
-        final archiveChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_archive')),
-        );
-        final chatsChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_chats')),
-        );
-        expect(archiveChip.selected, isTrue);
-        expect(chatsChip.selected, isFalse);
-      });
-
-      testWidgets('tapping Chats when Archive is selected switches back', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        await tester.tap(find.byKey(const Key('filter_chip_archive')));
-        await tester.pump();
-
-        await tester.tap(find.byKey(const Key('filter_chip_chats')));
-        await tester.pump();
-
-        final chatsChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_chats')),
-        );
-        final archiveChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_archive')),
-        );
-        expect(chatsChip.selected, isTrue);
-        expect(archiveChip.selected, isFalse);
-      });
-
-      testWidgets('tapping already selected Chats keeps it selected', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        await tester.tap(find.byKey(const Key('filter_chip_chats')));
-        await tester.pump();
-
-        final chatsChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_chats')),
-        );
-        expect(chatsChip.selected, isTrue);
-      });
-    });
-
-    group('filter callback', () {
-      testWidgets('calls onFilterChanged with archive when Archive is tapped', (tester) async {
-        ChatFilter? filterValue;
-        await mountWidget(
-          WnSearchAndFilters(onFilterChanged: (filter) => filterValue = filter),
-          tester,
-        );
-
-        await tester.tap(find.byKey(const Key('filter_chip_archive')));
-        await tester.pump();
-        expect(filterValue, ChatFilter.archive);
-      });
-
-      testWidgets('calls onFilterChanged with chats when Chats is tapped', (tester) async {
-        ChatFilter? filterValue;
-        await mountWidget(
-          WnSearchAndFilters(onFilterChanged: (filter) => filterValue = filter),
-          tester,
-        );
-
-        await tester.tap(find.byKey(const Key('filter_chip_archive')));
-        await tester.pump();
-
-        await tester.tap(find.byKey(const Key('filter_chip_chats')));
-        await tester.pump();
-        expect(filterValue, ChatFilter.chats);
-      });
-
-      testWidgets('does not crash when onFilterChanged is null', (tester) async {
-        await mountWidget(const WnSearchAndFilters(), tester);
-
-        await tester.tap(find.byKey(const Key('filter_chip_archive')));
-        await tester.pump();
-
-        final archiveChip = tester.widget<WnFilterChip>(
-          find.byKey(const Key('filter_chip_archive')),
-        );
-        expect(archiveChip.selected, isTrue);
       });
     });
   });


### PR DESCRIPTION
## Summary

- Remove the Chats/Archive filter chip pills from the pull-down search header on the chat list screen — they aren't wired up to anything and won't be before release
- Reduce the search header height from 108 to 68 to account for the removed filter row
- Keep the `WnFilterChip` widget and its tests intact for future use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced the height of the search and filters header to create a more compact and space-efficient interface layout.

* **Bug Fixes**
  * Removed chat filtering options (Chats and Archive filters) from the interface. Users can continue to search for and access all conversations using the core search functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->