### PR TITLE
Fix slate shrinking on feedback system notice

### DIFF
--- a/lib/widgets/wn_slate.dart
+++ b/lib/widgets/wn_slate.dart
@@ -100,8 +100,7 @@ class WnSlate extends HookWidget {
     final content = Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (systemNotice != null)
-          if (shrinkWrapContent) systemNotice! else Flexible(child: systemNotice!),
+        if (systemNotice != null) systemNotice!,
         if (header != null) header!,
         if (childWidget != null)
           if (shrinkWrapContent) childWidget else Flexible(child: childWidget),

--- a/test/widgets/wn_slate_test.dart
+++ b/test/widgets/wn_slate_test.dart
@@ -98,6 +98,26 @@ void main() {
 
         expect(find.byType(WnSlate), findsOneWidget);
       });
+
+      group('without shrinkWrapContent', () {
+        testWidgets('child uses all available space left after system notice', (tester) async {
+          await mountWidget(
+            SizedBox(
+              height: 500.h,
+              child: const WnSlate(
+                systemNotice: SizedBox(height: 40, key: Key('system_notice')),
+                child: SizedBox.expand(key: Key('child')),
+              ),
+            ),
+            tester,
+          );
+
+          final noticeHeight = tester.getSize(find.byKey(const Key('system_notice'))).height;
+          final childHeight = tester.getSize(find.byKey(const Key('child'))).height;
+          expect(noticeHeight, 40);
+          expect(childHeight, greaterThanOrEqualTo(450));
+        });
+      });
     });
 
     group('footer', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
On share profile screen, developer settings screen adn mroe screens, when the feedback system notice appeared, the slate shrunk. 

**Video of the bug:** 🐛 

https://github.com/user-attachments/assets/a277cfa1-2f10-4b5b-bc88-576b3b864b4f


Just by removing a flexible that was wrapping the system notice in that case, it seems to be fixed, now it looks like this

**Video now fixed**

https://github.com/user-attachments/assets/bfbaf9fb-5dcc-4cca-bc24-4afc94f551f5




<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified system notice rendering so it displays consistently and preserves its intended height across different layout scenarios.

* **Tests**
  * Added tests verifying system notice height and layout behavior both with and without shrink-wrapping, ensuring child content sizing remains correct in constrained containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->