### PR TITLE
Fix OS back button closing app from chat screen

### DIFF
--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -1037,7 +1037,7 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String addToGroupConfirmation(String userName, String groupName) {
-    return '¿Añadir a $userName a $groupName?';
+    return '¿Añadir $userName a $groupName?';
   }
 
   @override

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -212,79 +212,85 @@ class ChatScreen extends HookConsumerWidget {
       );
     }
 
-    return GestureDetector(
-      onTap: () => FocusScope.of(context).unfocus(),
-      child: Scaffold(
-        backgroundColor: colors.backgroundPrimary,
-        body: Column(
-          children: [
-            Expanded(
-              child: Stack(
-                children: [
-                  messageListContent,
-                  WnScrollEdgeEffect.canvasTop(
-                    color: colors.backgroundPrimary,
-                    height: slateTopPadding,
-                  ),
-                  WnScrollEdgeEffect.canvasBottom(
-                    color: colors.backgroundPrimary,
-                    height: 20.h,
-                  ),
-                  if (noticeMessage.value != null)
-                    Positioned(
-                      top: safeAreaTop,
-                      left: 0,
-                      right: 0,
-                      child: WnSystemNotice(
-                        key: ValueKey(noticeMessage.value),
-                        title: noticeMessage.value!,
-                        type: WnSystemNoticeType.error,
-                        onDismiss: dismissNotice,
+    return PopScope(
+      canPop: false,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop) Routes.goToChatList(context);
+      },
+      child: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: Scaffold(
+          backgroundColor: colors.backgroundPrimary,
+          body: Column(
+            children: [
+              Expanded(
+                child: Stack(
+                  children: [
+                    messageListContent,
+                    WnScrollEdgeEffect.canvasTop(
+                      color: colors.backgroundPrimary,
+                      height: slateTopPadding,
+                    ),
+                    WnScrollEdgeEffect.canvasBottom(
+                      color: colors.backgroundPrimary,
+                      height: 20.h,
+                    ),
+                    if (noticeMessage.value != null)
+                      Positioned(
+                        top: safeAreaTop,
+                        left: 0,
+                        right: 0,
+                        child: WnSystemNotice(
+                          key: ValueKey(noticeMessage.value),
+                          title: noticeMessage.value!,
+                          type: WnSystemNoticeType.error,
+                          onDismiss: dismissNotice,
+                        ),
+                      ),
+                    SafeArea(
+                      bottom: false,
+                      child: WnSlate(
+                        header: WnSlateChatHeader(
+                          displayName: chatProfile.data?.displayName ?? '',
+                          avatarColor: chatProfile.data?.color ?? AvatarColor.neutral,
+                          pictureUrl: chatProfile.data?.pictureUrl,
+                          onBack: () => Routes.goToChatList(context),
+                          onAvatarTap: () {
+                            final otherPubkey = chatProfile.data?.otherMemberPubkey;
+                            if (otherPubkey != null) {
+                              Routes.pushToChatInfo(context, otherPubkey);
+                            } else {
+                              Routes.pushToGroupInfo(context, groupId);
+                            }
+                          },
+                        ),
                       ),
                     ),
-                  SafeArea(
-                    bottom: false,
-                    child: WnSlate(
-                      header: WnSlateChatHeader(
-                        displayName: chatProfile.data?.displayName ?? '',
-                        avatarColor: chatProfile.data?.color ?? AvatarColor.neutral,
-                        pictureUrl: chatProfile.data?.pictureUrl,
-                        onBack: () => Routes.goToChatList(context),
-                        onAvatarTap: () {
-                          final otherPubkey = chatProfile.data?.otherMemberPubkey;
-                          if (otherPubkey != null) {
-                            Routes.pushToChatInfo(context, otherPubkey);
-                          } else {
-                            Routes.pushToGroupInfo(context, groupId);
-                          }
-                        },
+                    if (chatScroll.isScrollDownButtonVisible)
+                      Positioned(
+                        bottom: 8.h,
+                        right: 16.w,
+                        child: ChatScrollDownButton(
+                          show: true,
+                          onTap: chatScroll.scrollToBottom,
+                        ),
                       ),
-                    ),
-                  ),
-                  if (chatScroll.isScrollDownButtonVisible)
-                    Positioned(
-                      bottom: 8.h,
-                      right: 16.w,
-                      child: ChatScrollDownButton(
-                        show: true,
-                        onTap: chatScroll.scrollToBottom,
-                      ),
-                    ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            SafeArea(
-              top: false,
-              child: _ChatInput(
-                input: input,
-                mediaUpload: mediaUpload,
-                currentUserPubkey: pubkey,
-                onSend: sendMessage,
-                onError: showNotice,
-                getChatMessageQuote: getChatMessageQuote,
+              SafeArea(
+                top: false,
+                child: _ChatInput(
+                  input: input,
+                  mediaUpload: mediaUpload,
+                  currentUserPubkey: pubkey,
+                  onSend: sendMessage,
+                  onError: showNotice,
+                  getChatMessageQuote: getChatMessageQuote,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/test/screens/chat_screen_test.dart
+++ b/test/screens/chat_screen_test.dart
@@ -322,6 +322,13 @@ void main() {
         expect(find.byType(ChatListScreen), findsOneWidget);
       });
 
+      testWidgets('OS back navigates to chat list', (tester) async {
+        await pumpChatScreen(tester);
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+        expect(find.byType(ChatListScreen), findsOneWidget);
+      });
+
       testWidgets('avatar navigates to group info screen for group chat', (tester) async {
         await pumpChatScreen(tester);
         await tester.tap(find.byKey(const Key('header_avatar_tap_area')));


### PR DESCRIPTION
## Summary

- Wraps `ChatScreen` in `PopScope(canPop: false)` so the Android OS back button is intercepted and redirected to `goToChatList()` instead of calling `Navigator.pop()` on a root route (which closed the app)
- Adds a test that simulates the OS back gesture via `tester.binding.handlePopRoute()` and asserts the chat list is shown

## Root cause

The chat screen is navigated to via `GoRouter.go()` (stack replacement), so it sits at the root of the navigation stack with nothing to pop back to. The in-app back button already correctly called `Routes.goToChatList()`, but the OS back button had no handler and defaulted to `Navigator.pop()` on a root route, closing the app.

## Notes

- iOS swipe-back gesture is a separate issue tracked in #352
- The fix is Android-only in practice; `PopScope` does not affect iOS since the app uses `CustomTransitionPage` with a no-op transitions builder, which means the iOS edge-swipe gesture recognizer is never installed app-wide

Fixes #334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System notices now display at the top of the chat screen when triggered, keeping users informed of important updates with easy dismiss functionality.

* **Improvements**
  * Refined back navigation behavior when leaving the chat screen for a more seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->