### PR TITLE
Prevent multiple DM chats with same peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add to group button in chat info screen navigates to add to group screen [PR #355](https://github.com/marmot-protocol/whitenoise/pull/355)
 - Invite to White Noise [PR #354](https://github.com/marmot-protocol/whitenoise/pull/354)
 - Add missing translations for switch profile screen [PR #368](https://github.com/marmot-protocol/whitenoise/pull/368)
+- Prevent multiple DM chats with same peer [PR #371](https://github.com/marmot-protocol/whitenoise/pull/371)
 
 ### Changed
 

--- a/lib/hooks/use_start_dm.dart
+++ b/lib/hooks/use_start_dm.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:logging/logging.dart';
+import 'package:whitenoise/src/rust/api/account_groups.dart' as account_groups_api;
+import 'package:whitenoise/src/rust/api/groups.dart' as groups_api;
+
+final _logger = Logger('useStartDm');
+
+typedef StartDmState = ({
+  bool isLoading,
+  Future<String> Function() startDm,
+});
+
+StartDmState useStartDm({
+  required String accountPubkey,
+  required String peerPubkey,
+}) {
+  final isLoading = useState(false);
+
+  Future<String> startDm() async {
+    isLoading.value = true;
+    try {
+      final existingGroupId = await account_groups_api.getDmGroupWithPeer(
+        accountPubkey: accountPubkey,
+        peerPubkey: peerPubkey,
+      );
+
+      if (existingGroupId != null) {
+        return existingGroupId;
+      }
+
+      final group = await groups_api.createGroup(
+        creatorPubkey: accountPubkey,
+        memberPubkeys: [peerPubkey],
+        adminPubkeys: [accountPubkey],
+        groupName: '',
+        groupDescription: '',
+        groupType: groups_api.GroupType.directMessage,
+      );
+      return group.mlsGroupId;
+    } catch (e) {
+      _logger.severe('Failed to start DM: $e');
+      rethrow;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  return (
+    isLoading: isLoading.value,
+    startDm: startDm,
+  );
+}

--- a/lib/screens/group_member_screen.dart
+++ b/lib/screens/group_member_screen.dart
@@ -6,12 +6,12 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:whitenoise/hooks/use_follow_actions.dart';
 import 'package:whitenoise/hooks/use_group_members.dart';
+import 'package:whitenoise/hooks/use_start_dm.dart';
 import 'package:whitenoise/hooks/use_system_notice.dart';
 import 'package:whitenoise/hooks/use_user_metadata.dart';
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
 import 'package:whitenoise/routes.dart';
-import 'package:whitenoise/src/rust/api/groups.dart' as groups_api;
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/utils/metadata.dart' show presentName;
 import 'package:whitenoise/widgets/wn_button.dart';
@@ -67,7 +67,10 @@ class GroupMemberScreen extends HookConsumerWidget {
       userPubkey: memberPubkey,
     );
 
-    final isSendingMessage = useState(false);
+    final dmState = useStartDm(
+      accountPubkey: accountPubkey,
+      peerPubkey: memberPubkey,
+    );
 
     useEffect(() {
       if (membersState.error != null) {
@@ -89,27 +92,15 @@ class GroupMemberScreen extends HookConsumerWidget {
     final roleLabel = isMemberAdmin ? context.l10n.adminBadge : context.l10n.memberBadge;
 
     Future<void> handleSendMessage() async {
-      isSendingMessage.value = true;
       try {
-        final group = await groups_api.createGroup(
-          creatorPubkey: accountPubkey,
-          memberPubkeys: [memberPubkey],
-          adminPubkeys: [accountPubkey],
-          groupName: '',
-          groupDescription: '',
-          groupType: groups_api.GroupType.directMessage,
-        );
+        final groupId = await dmState.startDm();
         if (context.mounted) {
-          Routes.goToChat(context, group.mlsGroupId);
+          Routes.goToChat(context, groupId);
         }
       } catch (e) {
         _logger.severe('Failed to start chat: $e');
         if (context.mounted) {
           showErrorNotice(context.l10n.failedToStartChat);
-        }
-      } finally {
-        if (context.mounted) {
-          isSendingMessage.value = false;
         }
       }
     }
@@ -229,7 +220,7 @@ class GroupMemberScreen extends HookConsumerWidget {
                               type: WnButtonType.outline,
                               size: WnButtonSize.medium,
                               trailingIcon: WnIcons.newChat,
-                              loading: isSendingMessage.value,
+                              loading: dmState.isLoading,
                               onPressed: handleSendMessage,
                             ),
                           ),

--- a/lib/screens/start_chat_screen.dart
+++ b/lib/screens/start_chat_screen.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:gap/gap.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:whitenoise/hooks/use_follow_actions.dart';
+import 'package:whitenoise/hooks/use_start_dm.dart';
 import 'package:whitenoise/hooks/use_system_notice.dart';
 import 'package:whitenoise/hooks/use_user_has_key_package.dart';
 import 'package:whitenoise/hooks/use_user_metadata.dart';
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
 import 'package:whitenoise/routes.dart';
-import 'package:whitenoise/src/rust/api/groups.dart' as groups_api;
 import 'package:whitenoise/src/rust/api/metadata.dart' show FlutterMetadata;
 import 'package:whitenoise/src/rust/api/users.dart' show KeyPackageStatus;
 import 'package:whitenoise/theme.dart';
@@ -40,7 +39,6 @@ class StartChatScreen extends HookConsumerWidget {
 
     final metadataSnapshot = useUserMetadata(context, userPubkey);
     final keyPackageSnapshot = useUserHasKeyPackage(userPubkey);
-    final isStartingChat = useState(false);
     final (
       :noticeMessage,
       :noticeType,
@@ -54,6 +52,11 @@ class StartChatScreen extends HookConsumerWidget {
       userPubkey: userPubkey,
     );
 
+    final dmState = useStartDm(
+      accountPubkey: accountPubkey,
+      peerPubkey: userPubkey,
+    );
+
     final fetchedMetadata = metadataSnapshot.data;
     final hasContent = fetchedMetadata != null && presentName(fetchedMetadata) != null;
     final metadata = hasContent ? fetchedMetadata : (initialMetadata ?? fetchedMetadata);
@@ -65,29 +68,15 @@ class StartChatScreen extends HookConsumerWidget {
     final keyPackageStatus = keyPackageSnapshot.data;
 
     Future<void> startChat() async {
-      isStartingChat.value = true;
-
       try {
-        final group = await groups_api.createGroup(
-          creatorPubkey: accountPubkey,
-          memberPubkeys: [userPubkey],
-          adminPubkeys: [accountPubkey],
-          groupName: '',
-          groupDescription: '',
-          groupType: groups_api.GroupType.directMessage,
-        );
-
+        final groupId = await dmState.startDm();
         if (context.mounted) {
-          Routes.goToChat(context, group.mlsGroupId);
+          Routes.goToChat(context, groupId);
         }
       } catch (e) {
         _logger.severe('Failed to start chat: $e');
         if (context.mounted) {
           showErrorNotice(context.l10n.failedToStartChat);
-        }
-      } finally {
-        if (context.mounted) {
-          isStartingChat.value = false;
         }
       }
     }
@@ -203,7 +192,7 @@ class StartChatScreen extends HookConsumerWidget {
                               text: context.l10n.sendMessage,
                               size: WnButtonSize.medium,
                               trailingIcon: WnIcons.newChat,
-                              loading: isStartingChat.value,
+                              loading: dmState.isLoading,
                               onPressed: startChat,
                             ),
                           ),

--- a/lib/src/rust/api/account_groups.dart
+++ b/lib/src/rust/api/account_groups.dart
@@ -38,6 +38,14 @@ Future<AccountGroup> getAccountGroup({
   mlsGroupId: mlsGroupId,
 );
 
+Future<String?> getDmGroupWithPeer({
+  required String accountPubkey,
+  required String peerPubkey,
+}) => RustLib.instance.api.crateApiAccountGroupsGetDmGroupWithPeer(
+  accountPubkey: accountPubkey,
+  peerPubkey: peerPubkey,
+);
+
 /// Marks a message as read for the given account.
 ///
 /// Updates the `last_read_message_id` for the account-group pair containing

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -83,7 +83,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 1927237409;
+  int get rustContentHash => 424286752;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_whitenoise',
@@ -225,6 +225,11 @@ abstract class RustLibApi extends BaseApi {
   });
 
   Future<String> crateApiUtilsGetDefaultBlossomServerUrl();
+
+  Future<String?> crateApiAccountGroupsGetDmGroupWithPeer({
+    required String accountPubkey,
+    required String peerPubkey,
+  });
 
   Future<Group> crateApiGroupsGetGroup({
     required String accountPubkey,
@@ -1699,6 +1704,40 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<String?> crateApiAccountGroupsGetDmGroupWithPeer({
+    required String accountPubkey,
+    required String peerPubkey,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(accountPubkey, serializer);
+          sse_encode_String(peerPubkey, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 34,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_opt_String,
+          decodeErrorData: sse_decode_api_error,
+        ),
+        constMeta: kCrateApiAccountGroupsGetDmGroupWithPeerConstMeta,
+        argValues: [accountPubkey, peerPubkey],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiAccountGroupsGetDmGroupWithPeerConstMeta => const TaskConstMeta(
+    debugName: 'get_dm_group_with_peer',
+    argNames: ['accountPubkey', 'peerPubkey'],
+  );
+
+  @override
   Future<Group> crateApiGroupsGetGroup({
     required String accountPubkey,
     required String groupId,
@@ -1712,7 +1751,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 34,
+            funcId: 35,
             port: port_,
           );
         },
@@ -1746,7 +1785,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 35,
+            funcId: 36,
             port: port_,
           );
         },
@@ -1780,7 +1819,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 36,
+            funcId: 37,
             port: port_,
           );
         },
@@ -1814,7 +1853,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 37,
+            funcId: 38,
             port: port_,
           );
         },
@@ -1848,7 +1887,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 38,
+            funcId: 39,
             port: port_,
           );
         },
@@ -1882,7 +1921,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 39,
+            funcId: 40,
             port: port_,
           );
         },
@@ -1916,7 +1955,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 40,
+            funcId: 41,
             port: port_,
           );
         },
@@ -1946,7 +1985,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 41,
+            funcId: 42,
             port: port_,
           );
         },
@@ -1980,7 +2019,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 42,
+            funcId: 43,
             port: port_,
           );
         },
@@ -2014,7 +2053,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 43,
+            funcId: 44,
             port: port_,
           );
         },
@@ -2048,7 +2087,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 44,
+            funcId: 45,
             port: port_,
           );
         },
@@ -2082,7 +2121,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 45,
+            funcId: 46,
             port: port_,
           );
         },
@@ -2121,7 +2160,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 46,
+            funcId: 47,
             port: port_,
           );
         },
@@ -2148,7 +2187,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(npub, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 47)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 48)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2178,7 +2217,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 48,
+            funcId: 49,
             port: port_,
           );
         },
@@ -2212,7 +2251,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 49,
+            funcId: 50,
             port: port_,
           );
         },
@@ -2238,7 +2277,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 50)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2263,7 +2302,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 51)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2288,7 +2327,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 52)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2313,7 +2352,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 53)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2338,7 +2377,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 54)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2363,7 +2402,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 55)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2388,7 +2427,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 56)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2413,7 +2452,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 57)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2442,7 +2481,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             language,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 58)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2466,7 +2505,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 59)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 60)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -2499,7 +2538,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 60,
+            funcId: 61,
             port: port_,
           );
         },
@@ -2529,7 +2568,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 61,
+            funcId: 62,
             port: port_,
           );
         },
@@ -2561,7 +2600,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 62,
+            funcId: 63,
             port: port_,
           );
         },
@@ -2619,7 +2658,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 63,
+            funcId: 64,
             port: port_,
           );
         },
@@ -2667,7 +2706,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 64,
+            funcId: 65,
             port: port_,
           );
         },
@@ -2700,7 +2739,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 65,
+            funcId: 66,
             port: port_,
           );
         },
@@ -2732,7 +2771,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 66,
+            funcId: 67,
             port: port_,
           );
         },
@@ -2766,7 +2805,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 67,
+            funcId: 68,
             port: port_,
           );
         },
@@ -2796,7 +2835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 68,
+            funcId: 69,
             port: port_,
           );
         },
@@ -2830,7 +2869,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 69,
+            funcId: 70,
             port: port_,
           );
         },
@@ -2857,7 +2896,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
           sse_encode_String(hexPubkey, serializer);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 70)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 71)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -2887,7 +2926,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 71,
+            funcId: 72,
             port: port_,
           );
         },
@@ -2944,7 +2983,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 72,
+            funcId: 73,
             port: port_,
           );
         },
@@ -2987,7 +3026,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 73,
+            funcId: 74,
             port: port_,
           );
         },
@@ -3017,7 +3056,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 74,
+            funcId: 75,
             port: port_,
           );
         },
@@ -3047,7 +3086,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 75,
+            funcId: 76,
             port: port_,
           );
         },
@@ -3078,7 +3117,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 76,
+            funcId: 77,
             port: port_,
           );
         },
@@ -3118,7 +3157,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 77,
+            funcId: 78,
             port: port_,
           );
         },
@@ -3154,7 +3193,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 78,
+            funcId: 79,
             port: port_,
           );
         },
@@ -3194,7 +3233,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 79,
+            funcId: 80,
             port: port_,
           );
         },
@@ -3235,7 +3274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 80,
+              funcId: 81,
               port: port_,
             );
           },
@@ -3286,7 +3325,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 81,
+            funcId: 82,
             port: port_,
           );
         },
@@ -3322,7 +3361,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 82,
+            funcId: 83,
             port: port_,
           );
         },
@@ -3355,7 +3394,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 83,
+            funcId: 84,
             port: port_,
           );
         },
@@ -3390,7 +3429,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 84,
+              funcId: 85,
               port: port_,
             );
           },
@@ -3427,7 +3466,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 85,
+              funcId: 86,
               port: port_,
             );
           },
@@ -3461,7 +3500,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 86,
+              funcId: 87,
               port: port_,
             );
           },
@@ -3493,7 +3532,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 87,
+            funcId: 88,
             port: port_,
           );
         },
@@ -3520,7 +3559,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 88)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3545,7 +3584,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 89)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3570,7 +3609,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       SyncTask(
         callFfi: () {
           final serializer = SseSerializer(generalizedFrbRustBinding);
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 90)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
         },
         codec: SseCodec(
           decodeSuccessData:
@@ -3599,7 +3638,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             themeMode,
             serializer,
           );
-          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 91)!;
+          return pdeCallFfi(generalizedFrbRustBinding, serializer, funcId: 92)!;
         },
         codec: SseCodec(
           decodeSuccessData: sse_decode_String,
@@ -3631,7 +3670,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -3665,7 +3704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 93,
+            funcId: 94,
             port: port_,
           );
         },
@@ -3698,7 +3737,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3731,7 +3770,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3769,7 +3808,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3805,7 +3844,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -3843,7 +3882,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 98,
+            funcId: 99,
             port: port_,
           );
         },
@@ -3877,7 +3916,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 99,
+            funcId: 100,
             port: port_,
           );
         },
@@ -3911,7 +3950,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 100,
+            funcId: 101,
             port: port_,
           );
         },
@@ -3950,7 +3989,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 101,
+            funcId: 102,
             port: port_,
           );
         },

--- a/rust/src/api/account_groups.rs
+++ b/rust/src/api/account_groups.rs
@@ -129,6 +129,19 @@ pub async fn get_account_group(
     Ok(ag.into())
 }
 
+#[frb]
+pub async fn get_dm_group_with_peer(
+    account_pubkey: String,
+    peer_pubkey: String,
+) -> Result<Option<String>, ApiError> {
+    let whitenoise = Whitenoise::get_instance()?;
+    let pubkey = PublicKey::parse(&account_pubkey)?;
+    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let peer = PublicKey::parse(&peer_pubkey)?;
+    let group_id = whitenoise.get_dm_group_with_peer(&account, &peer).await?;
+    Ok(group_id.map(|id| group_id_to_string(&id)))
+}
+
 /// Marks a message as read for the given account.
 ///
 /// Updates the `last_read_message_id` for the account-group pair containing

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 1927237409;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 424286752;
 
 // Section: executor
 
@@ -1363,6 +1363,47 @@ fn wire__crate__api__utils__get_default_blossom_server_url_impl(
                         Result::<_, ()>::Ok(crate::api::utils::get_default_blossom_server_url())?;
                     Ok(output_ok)
                 })())
+            }
+        },
+    )
+}
+fn wire__crate__api__account_groups__get_dm_group_with_peer_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "get_dm_group_with_peer",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_account_pubkey = <String>::sse_decode(&mut deserializer);
+            let api_peer_pubkey = <String>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::error::ApiError>(
+                    (move || async move {
+                        let output_ok = crate::api::account_groups::get_dm_group_with_peer(
+                            api_account_pubkey,
+                            api_peer_pubkey,
+                        )
+                        .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
             }
         },
     )
@@ -5857,164 +5898,172 @@ fn pde_ffi_dispatcher_primary_impl(
             rust_vec_len,
             data_len,
         ),
-        34 => wire__crate__api__groups__get_group_impl(port, ptr, rust_vec_len, data_len),
-        35 => {
+        34 => wire__crate__api__account_groups__get_dm_group_with_peer_impl(
+            port,
+            ptr,
+            rust_vec_len,
+            data_len,
+        ),
+        35 => wire__crate__api__groups__get_group_impl(port, ptr, rust_vec_len, data_len),
+        36 => {
             wire__crate__api__groups__get_group_image_path_impl(port, ptr, rust_vec_len, data_len)
         }
-        36 => {
+        37 => {
             wire__crate__api__groups__get_group_information_impl(port, ptr, rust_vec_len, data_len)
         }
-        37 => wire__crate__api__groups__get_groups_informations_impl(
+        38 => wire__crate__api__groups__get_groups_informations_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        38 => wire__crate__api__users__get_user_impl(port, ptr, rust_vec_len, data_len),
-        39 => wire__crate__api__groups__group_admins_impl(port, ptr, rust_vec_len, data_len),
-        40 => wire__crate__api__groups__group_group_type_impl(port, ptr, rust_vec_len, data_len),
-        41 => wire__crate__api__utils__group_id_from_string_impl(port, ptr, rust_vec_len, data_len),
-        42 => wire__crate__api__utils__group_id_to_string_impl(port, ptr, rust_vec_len, data_len),
-        43 => wire__crate__api__groups__group_is_direct_message_type_impl(
+        39 => wire__crate__api__users__get_user_impl(port, ptr, rust_vec_len, data_len),
+        40 => wire__crate__api__groups__group_admins_impl(port, ptr, rust_vec_len, data_len),
+        41 => wire__crate__api__groups__group_group_type_impl(port, ptr, rust_vec_len, data_len),
+        42 => wire__crate__api__utils__group_id_from_string_impl(port, ptr, rust_vec_len, data_len),
+        43 => wire__crate__api__utils__group_id_to_string_impl(port, ptr, rust_vec_len, data_len),
+        44 => wire__crate__api__groups__group_is_direct_message_type_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        44 => wire__crate__api__groups__group_is_group_type_impl(port, ptr, rust_vec_len, data_len),
-        45 => wire__crate__api__groups__group_members_impl(port, ptr, rust_vec_len, data_len),
-        46 => wire__crate__api__groups__group_update_group_data_impl(
+        45 => wire__crate__api__groups__group_is_group_type_impl(port, ptr, rust_vec_len, data_len),
+        46 => wire__crate__api__groups__group_members_impl(port, ptr, rust_vec_len, data_len),
+        47 => wire__crate__api__groups__group_update_group_data_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        48 => wire__crate__api__initialize_whitenoise_impl(port, ptr, rust_vec_len, data_len),
-        49 => wire__crate__api__accounts__is_following_user_impl(port, ptr, rust_vec_len, data_len),
-        60 => wire__crate__api__drafts__load_draft_impl(port, ptr, rust_vec_len, data_len),
-        61 => wire__crate__api__accounts__login_cancel_impl(port, ptr, rust_vec_len, data_len),
-        62 => wire__crate__api__signer__login_external_signer_publish_default_relays_impl(
+        49 => wire__crate__api__initialize_whitenoise_impl(port, ptr, rust_vec_len, data_len),
+        50 => wire__crate__api__accounts__is_following_user_impl(port, ptr, rust_vec_len, data_len),
+        61 => wire__crate__api__drafts__load_draft_impl(port, ptr, rust_vec_len, data_len),
+        62 => wire__crate__api__accounts__login_cancel_impl(port, ptr, rust_vec_len, data_len),
+        63 => wire__crate__api__signer__login_external_signer_publish_default_relays_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        63 => wire__crate__api__signer__login_external_signer_start_impl(
+        64 => wire__crate__api__signer__login_external_signer_start_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        64 => wire__crate__api__signer__login_external_signer_with_custom_relay_impl(
+        65 => wire__crate__api__signer__login_external_signer_with_custom_relay_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        65 => wire__crate__api__accounts__login_publish_default_relays_impl(
+        66 => wire__crate__api__accounts__login_publish_default_relays_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        66 => wire__crate__api__accounts__login_start_impl(port, ptr, rust_vec_len, data_len),
-        67 => wire__crate__api__accounts__login_with_custom_relay_impl(
+        67 => wire__crate__api__accounts__login_start_impl(port, ptr, rust_vec_len, data_len),
+        68 => wire__crate__api__accounts__login_with_custom_relay_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        68 => wire__crate__api__accounts__logout_impl(port, ptr, rust_vec_len, data_len),
-        69 => wire__crate__api__account_groups__mark_message_read_impl(
+        69 => wire__crate__api__accounts__logout_impl(port, ptr, rust_vec_len, data_len),
+        70 => wire__crate__api__account_groups__mark_message_read_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        71 => wire__crate__api__accounts__publish_account_key_package_impl(
+        72 => wire__crate__api__accounts__publish_account_key_package_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        72 => wire__crate__api__signer__register_external_signer_impl(
+        73 => wire__crate__api__signer__register_external_signer_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        73 => wire__crate__api__relays__relay_type_inbox_impl(port, ptr, rust_vec_len, data_len),
-        74 => {
+        74 => wire__crate__api__relays__relay_type_inbox_impl(port, ptr, rust_vec_len, data_len),
+        75 => {
             wire__crate__api__relays__relay_type_key_package_impl(port, ptr, rust_vec_len, data_len)
         }
-        75 => wire__crate__api__relays__relay_type_nip65_impl(port, ptr, rust_vec_len, data_len),
-        76 => {
+        76 => wire__crate__api__relays__relay_type_nip65_impl(port, ptr, rust_vec_len, data_len),
+        77 => {
             wire__crate__api__utils__relay_url_from_string_impl(port, ptr, rust_vec_len, data_len)
         }
-        77 => {
+        78 => {
             wire__crate__api__accounts__remove_account_relay_impl(port, ptr, rust_vec_len, data_len)
         }
-        78 => wire__crate__api__groups__remove_members_from_group_impl(
+        79 => wire__crate__api__groups__remove_members_from_group_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        79 => wire__crate__api__drafts__save_draft_impl(port, ptr, rust_vec_len, data_len),
-        80 => wire__crate__api__user_search__search_users_impl(port, ptr, rust_vec_len, data_len),
-        81 => wire__crate__api__messages__send_message_to_group_impl(
+        80 => wire__crate__api__drafts__save_draft_impl(port, ptr, rust_vec_len, data_len),
+        81 => wire__crate__api__user_search__search_users_impl(port, ptr, rust_vec_len, data_len),
+        82 => wire__crate__api__messages__send_message_to_group_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        82 => {
+        83 => {
             wire__crate__api__chat_list__set_chat_pin_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        83 => {
+        84 => {
             wire__crate__api__utils__string_from_relay_url_impl(port, ptr, rust_vec_len, data_len)
         }
-        84 => wire__crate__api__chat_list__subscribe_to_chat_list_impl(
+        85 => wire__crate__api__chat_list__subscribe_to_chat_list_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        85 => wire__crate__api__messages__subscribe_to_group_messages_impl(
+        86 => wire__crate__api__messages__subscribe_to_group_messages_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        86 => wire__crate__api__notifications__subscribe_to_notifications_impl(
+        87 => wire__crate__api__notifications__subscribe_to_notifications_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        87 => wire__crate__api__utils__tag_from_vec_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__accounts__unfollow_user_impl(port, ptr, rust_vec_len, data_len),
-        93 => wire__crate__api__accounts__update_account_metadata_impl(
+        88 => wire__crate__api__utils__tag_from_vec_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__accounts__unfollow_user_impl(port, ptr, rust_vec_len, data_len),
+        94 => wire__crate__api__accounts__update_account_metadata_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        94 => wire__crate__api__update_language_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__update_theme_mode_impl(port, ptr, rust_vec_len, data_len),
-        96 => wire__crate__api__accounts__upload_account_profile_picture_impl(
+        95 => wire__crate__api__update_language_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__update_theme_mode_impl(port, ptr, rust_vec_len, data_len),
+        97 => wire__crate__api__accounts__upload_account_profile_picture_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        97 => {
+        98 => {
             wire__crate__api__media_files__upload_chat_media_impl(port, ptr, rust_vec_len, data_len)
         }
-        98 => wire__crate__api__groups__upload_group_image_impl(port, ptr, rust_vec_len, data_len),
-        99 => wire__crate__api__users__user_has_key_package_impl(port, ptr, rust_vec_len, data_len),
-        100 => wire__crate__api__users__user_metadata_impl(port, ptr, rust_vec_len, data_len),
-        101 => wire__crate__api__users__user_relays_impl(port, ptr, rust_vec_len, data_len),
+        99 => wire__crate__api__groups__upload_group_image_impl(port, ptr, rust_vec_len, data_len),
+        100 => {
+            wire__crate__api__users__user_has_key_package_impl(port, ptr, rust_vec_len, data_len)
+        }
+        101 => wire__crate__api__users__user_metadata_impl(port, ptr, rust_vec_len, data_len),
+        102 => wire__crate__api__users__user_relays_impl(port, ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -6027,22 +6076,22 @@ fn pde_ffi_dispatcher_sync_impl(
 ) -> flutter_rust_bridge::for_generated::WireSyncRust2DartSse {
     // Codec=Pde (Serialization + dispatch), see doc to use other codecs
     match func_id {
-        47 => wire__crate__api__utils__hex_pubkey_from_npub_impl(ptr, rust_vec_len, data_len),
-        50 => wire__crate__api__utils__language_english_impl(ptr, rust_vec_len, data_len),
-        51 => wire__crate__api__utils__language_french_impl(ptr, rust_vec_len, data_len),
-        52 => wire__crate__api__utils__language_german_impl(ptr, rust_vec_len, data_len),
-        53 => wire__crate__api__utils__language_italian_impl(ptr, rust_vec_len, data_len),
-        54 => wire__crate__api__utils__language_portuguese_impl(ptr, rust_vec_len, data_len),
-        55 => wire__crate__api__utils__language_russian_impl(ptr, rust_vec_len, data_len),
-        56 => wire__crate__api__utils__language_spanish_impl(ptr, rust_vec_len, data_len),
-        57 => wire__crate__api__utils__language_system_impl(ptr, rust_vec_len, data_len),
-        58 => wire__crate__api__utils__language_to_string_impl(ptr, rust_vec_len, data_len),
-        59 => wire__crate__api__utils__language_turkish_impl(ptr, rust_vec_len, data_len),
-        70 => wire__crate__api__utils__npub_from_hex_pubkey_impl(ptr, rust_vec_len, data_len),
-        88 => wire__crate__api__utils__theme_mode_dark_impl(ptr, rust_vec_len, data_len),
-        89 => wire__crate__api__utils__theme_mode_light_impl(ptr, rust_vec_len, data_len),
-        90 => wire__crate__api__utils__theme_mode_system_impl(ptr, rust_vec_len, data_len),
-        91 => wire__crate__api__utils__theme_mode_to_string_impl(ptr, rust_vec_len, data_len),
+        48 => wire__crate__api__utils__hex_pubkey_from_npub_impl(ptr, rust_vec_len, data_len),
+        51 => wire__crate__api__utils__language_english_impl(ptr, rust_vec_len, data_len),
+        52 => wire__crate__api__utils__language_french_impl(ptr, rust_vec_len, data_len),
+        53 => wire__crate__api__utils__language_german_impl(ptr, rust_vec_len, data_len),
+        54 => wire__crate__api__utils__language_italian_impl(ptr, rust_vec_len, data_len),
+        55 => wire__crate__api__utils__language_portuguese_impl(ptr, rust_vec_len, data_len),
+        56 => wire__crate__api__utils__language_russian_impl(ptr, rust_vec_len, data_len),
+        57 => wire__crate__api__utils__language_spanish_impl(ptr, rust_vec_len, data_len),
+        58 => wire__crate__api__utils__language_system_impl(ptr, rust_vec_len, data_len),
+        59 => wire__crate__api__utils__language_to_string_impl(ptr, rust_vec_len, data_len),
+        60 => wire__crate__api__utils__language_turkish_impl(ptr, rust_vec_len, data_len),
+        71 => wire__crate__api__utils__npub_from_hex_pubkey_impl(ptr, rust_vec_len, data_len),
+        89 => wire__crate__api__utils__theme_mode_dark_impl(ptr, rust_vec_len, data_len),
+        90 => wire__crate__api__utils__theme_mode_light_impl(ptr, rust_vec_len, data_len),
+        91 => wire__crate__api__utils__theme_mode_system_impl(ptr, rust_vec_len, data_len),
+        92 => wire__crate__api__utils__theme_mode_to_string_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }

--- a/test/hooks/use_start_dm_test.dart
+++ b/test/hooks/use_start_dm_test.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/hooks/use_start_dm.dart';
+import 'package:whitenoise/src/rust/api/groups.dart';
+import 'package:whitenoise/src/rust/frb_generated.dart';
+
+import '../mocks/mock_wn_api.dart';
+import '../test_helpers.dart';
+
+const _accountPubkey = testPubkeyA;
+const _peerPubkey = testPubkeyB;
+const _existingGroupId = testGroupId;
+const _newGroupId = otherTestGroupId;
+
+class _MockApi extends MockWnApi {
+  String? dmGroupWithPeerResult;
+  Exception? dmGroupWithPeerError;
+  Completer<String?>? dmGroupWithPeerCompleter;
+  int dmGroupWithPeerCallCount = 0;
+
+  Group? createdGroup;
+  Exception? createGroupError;
+  Completer<Group>? createGroupCompleter;
+  final createGroupCalls =
+      <({String creatorPubkey, List<String> memberPubkeys, GroupType groupType})>[];
+
+  @override
+  Future<String?> crateApiAccountGroupsGetDmGroupWithPeer({
+    required String accountPubkey,
+    required String peerPubkey,
+  }) async {
+    dmGroupWithPeerCallCount++;
+    if (dmGroupWithPeerCompleter != null) return dmGroupWithPeerCompleter!.future;
+    if (dmGroupWithPeerError != null) throw dmGroupWithPeerError!;
+    return dmGroupWithPeerResult;
+  }
+
+  @override
+  Future<Group> crateApiGroupsCreateGroup({
+    required String creatorPubkey,
+    required List<String> memberPubkeys,
+    required List<String> adminPubkeys,
+    required String groupName,
+    required String groupDescription,
+    required GroupType groupType,
+  }) async {
+    createGroupCalls.add((
+      creatorPubkey: creatorPubkey,
+      memberPubkeys: memberPubkeys,
+      groupType: groupType,
+    ));
+    if (createGroupCompleter != null) return createGroupCompleter!.future;
+    if (createGroupError != null) throw createGroupError!;
+    return createdGroup ??
+        Group(
+          mlsGroupId: _newGroupId,
+          nostrGroupId: testNostrGroupId,
+          name: '',
+          description: '',
+          adminPubkeys: const [],
+          epoch: BigInt.zero,
+          state: GroupState.active,
+        );
+  }
+
+  @override
+  void reset() {
+    super.reset();
+    dmGroupWithPeerResult = null;
+    dmGroupWithPeerError = null;
+    dmGroupWithPeerCompleter = null;
+    dmGroupWithPeerCallCount = 0;
+    createdGroup = null;
+    createGroupError = null;
+    createGroupCompleter = null;
+    createGroupCalls.clear();
+  }
+}
+
+final _api = _MockApi();
+
+void main() {
+  setUpAll(() => RustLib.initMock(api: _api));
+  setUp(() => _api.reset());
+
+  group('useStartDm', () {
+    testWidgets('initial state has isLoading false', (tester) async {
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      final state = getResult();
+      expect(state.isLoading, isFalse);
+    });
+
+    testWidgets('returns existing DM groupId when DM already exists', (tester) async {
+      _api.dmGroupWithPeerResult = _existingGroupId;
+
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      final state = getResult();
+      final groupId = await state.startDm();
+
+      expect(groupId, _existingGroupId);
+      expect(_api.createGroupCalls, isEmpty);
+      expect(_api.dmGroupWithPeerCallCount, 1);
+    });
+
+    testWidgets('creates new DM when no existing DM found', (tester) async {
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      final state = getResult();
+      final groupId = await state.startDm();
+
+      expect(groupId, _newGroupId);
+      expect(_api.createGroupCalls.length, 1);
+      expect(_api.createGroupCalls[0].creatorPubkey, _accountPubkey);
+      expect(_api.createGroupCalls[0].memberPubkeys, [_peerPubkey]);
+      expect(_api.createGroupCalls[0].groupType, GroupType.directMessage);
+    });
+
+    testWidgets('rethrows error when getDmGroupWithPeer fails', (tester) async {
+      _api.dmGroupWithPeerError = Exception('Network error');
+
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      final state = getResult();
+      expect(() => state.startDm(), throwsException);
+    });
+
+    testWidgets('rethrows error when createGroup fails', (tester) async {
+      _api.createGroupError = Exception('Network error');
+
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      final state = getResult();
+      expect(() => state.startDm(), throwsException);
+    });
+
+    testWidgets('sets isLoading during startDm execution', (tester) async {
+      _api.dmGroupWithPeerCompleter = Completer();
+
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      expect(getResult().isLoading, isFalse);
+
+      final future = getResult().startDm();
+      await tester.pump();
+
+      expect(getResult().isLoading, isTrue);
+
+      _api.dmGroupWithPeerCompleter!.complete(null);
+      await future;
+      await tester.pump();
+
+      expect(getResult().isLoading, isFalse);
+    });
+
+    testWidgets('resets isLoading on error', (tester) async {
+      _api.dmGroupWithPeerError = Exception('fail');
+
+      final getResult = await mountHook(
+        tester,
+        () => useStartDm(accountPubkey: _accountPubkey, peerPubkey: _peerPubkey),
+      );
+
+      try {
+        await getResult().startDm();
+      } catch (_) {}
+      await tester.pump();
+
+      expect(getResult().isLoading, isFalse);
+    });
+  });
+}

--- a/test/mocks/mock_wn_api.dart
+++ b/test/mocks/mock_wn_api.dart
@@ -216,6 +216,21 @@ class MockWnApi implements RustLibApi {
   }
 
   @override
+  Future<List<ChatSummary>> crateApiChatListGetChatList({
+    required String accountPubkey,
+  }) async {
+    return [];
+  }
+
+  @override
+  Future<String?> crateApiAccountGroupsGetDmGroupWithPeer({
+    required String accountPubkey,
+    required String peerPubkey,
+  }) async {
+    return null;
+  }
+
+  @override
   Stream<ChatListStreamItem> crateApiChatListSubscribeToChatList({
     required String accountPubkey,
   }) {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
- Added useStartDm hook that checks for existing DMs via getChatList before calling createGroup
- Replace duplicated DM creation logic in StartChatScreen and GroupMemberScreen with the shared hook
- Added missing frb wrapper get_dm_group_with_peer method

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [x] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)

Fixes #162 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevented creation of multiple direct-message chats with the same peer — initiating a DM will reuse an existing conversation when present.
* **Bug Fixes**
  * UI flows updated so DM creation/loading state is consistent and reflected during chat start.
* **Tests**
  * Added tests covering DM lookup, creation, error handling, and loading-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->