### PR TITLE
Remove unnecessary sort of reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Changed reaction emoji sorting [PR #391](https://github.com/marmot-protocol/whitenoise/pull/391)
 
 ### Deprecated
 
 ### Removed
+
 
 ### Fixed
 

--- a/lib/widgets/wn_message_bubble.dart
+++ b/lib/widgets/wn_message_bubble.dart
@@ -279,9 +279,7 @@ class WnMessageBubble extends StatelessWidget {
                             spacing: 4.w,
                             runSpacing: 4.h,
                             children: [
-                              for (final reaction
-                                  in (reactions.toList()
-                                    ..sort((a, b) => a.emoji.compareTo(b.emoji))))
+                              for (final reaction in reactions)
                                 WnReaction(
                                   key: ValueKey(reaction.emoji),
                                   emoji: reaction.emoji,

--- a/test/widgets/wn_message_bubble_test.dart
+++ b/test/widgets/wn_message_bubble_test.dart
@@ -227,7 +227,7 @@ void main() {
         expect(widget.type, WnReactionType.incoming);
       });
 
-      testWidgets('renders reactions in stable alphabetical order regardless of input order', (
+      testWidgets('renders reactions in order sent by rust crate', (
         tester,
       ) async {
         final reactions = [
@@ -246,7 +246,7 @@ void main() {
 
         final widgets = tester.widgetList<WnReaction>(find.byType(WnReaction)).toList();
         final emojis = widgets.map((w) => w.emoji).toList();
-        final expectedEmojis = ['❤️', '👍', '🔥'];
+        final expectedEmojis = ['🔥', '❤️', '👍'];
         expect(emojis, equals(expectedEmojis));
       });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Now that rust crate handles reaction sorting (before the order changed every time) there is no need to sort reactions alphabetically in wn message bubble, so that line is removed

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reactions now display in the original order they were sent, matching the backend instead of being alphabetically sorted.

* **Tests**
  * Updated tests to expect reaction order provided by the backend.

* **Changelog**
  * Noted the change to reaction ordering in the Unreleased changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->