### PR TITLE
feat: wire delivery status from Rust bridge to Flutter UI

### DIFF
--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -43,8 +43,7 @@ Future<void> initializeWhitenoise({required WhitenoiseConfig config}) =>
 
 Future<void> deleteAllData() => RustLib.instance.api.crateApiDeleteAllData();
 
-Future<AppSettings> getAppSettings() =>
-    RustLib.instance.api.crateApiGetAppSettings();
+Future<AppSettings> getAppSettings() => RustLib.instance.api.crateApiGetAppSettings();
 
 Future<void> updateThemeMode({required ThemeMode themeMode}) =>
     RustLib.instance.api.crateApiUpdateThemeMode(themeMode: themeMode);

--- a/lib/src/rust/api/accounts.dart
+++ b/lib/src/rust/api/accounts.dart
@@ -13,19 +13,15 @@ import 'users.dart';
 
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`
 
-Future<List<Account>> getAccounts() =>
-    RustLib.instance.api.crateApiAccountsGetAccounts();
+Future<List<Account>> getAccounts() => RustLib.instance.api.crateApiAccountsGetAccounts();
 
 Future<Account> getAccount({required String pubkey}) =>
     RustLib.instance.api.crateApiAccountsGetAccount(pubkey: pubkey);
 
-Future<Account> createIdentity() =>
-    RustLib.instance.api.crateApiAccountsCreateIdentity();
+Future<Account> createIdentity() => RustLib.instance.api.crateApiAccountsCreateIdentity();
 
-Future<LoginResult> loginStart({required String nsecOrHexPrivkey}) => RustLib
-    .instance
-    .api
-    .crateApiAccountsLoginStart(nsecOrHexPrivkey: nsecOrHexPrivkey);
+Future<LoginResult> loginStart({required String nsecOrHexPrivkey}) =>
+    RustLib.instance.api.crateApiAccountsLoginStart(nsecOrHexPrivkey: nsecOrHexPrivkey);
 
 Future<LoginResult> loginPublishDefaultRelays({required String pubkey}) =>
     RustLib.instance.api.crateApiAccountsLoginPublishDefaultRelays(

--- a/lib/src/rust/api/error.dart
+++ b/lib/src/rust/api/error.dart
@@ -41,13 +41,11 @@ sealed class ApiError with _$ApiError implements FrbException {
   const factory ApiError.loginInvalidKeyFormat({
     required String message,
   }) = ApiError_LoginInvalidKeyFormat;
-  const factory ApiError.loginNoRelayConnections() =
-      ApiError_LoginNoRelayConnections;
+  const factory ApiError.loginNoRelayConnections() = ApiError_LoginNoRelayConnections;
   const factory ApiError.loginTimeout({
     required String message,
   }) = ApiError_LoginTimeout;
-  const factory ApiError.loginNoLoginInProgress() =
-      ApiError_LoginNoLoginInProgress;
+  const factory ApiError.loginNoLoginInProgress() = ApiError_LoginNoLoginInProgress;
   const factory ApiError.loginInternal({
     required String message,
   }) = ApiError_LoginInternal;
@@ -56,14 +54,12 @@ sealed class ApiError with _$ApiError implements FrbException {
   }) = ApiError_Other;
 
   /// Get a user-friendly error type name
-  Future<String> errorType() =>
-      RustLib.instance.api.crateApiErrorApiErrorErrorType(
-        that: this,
-      );
+  Future<String> errorType() => RustLib.instance.api.crateApiErrorApiErrorErrorType(
+    that: this,
+  );
 
   /// Get the error message as a string
-  Future<String> messageText() =>
-      RustLib.instance.api.crateApiErrorApiErrorMessageText(
-        that: this,
-      );
+  Future<String> messageText() => RustLib.instance.api.crateApiErrorApiErrorMessageText(
+    that: this,
+  );
 }

--- a/lib/src/rust/api/groups.dart
+++ b/lib/src/rust/api/groups.dart
@@ -188,10 +188,8 @@ class Group {
     required this.state,
   });
 
-  Future<GroupType> groupType({required String accountPubkey}) => RustLib
-      .instance
-      .api
-      .crateApiGroupsGroupGroupType(that: this, accountPubkey: accountPubkey);
+  Future<GroupType> groupType({required String accountPubkey}) =>
+      RustLib.instance.api.crateApiGroupsGroupGroupType(that: this, accountPubkey: accountPubkey);
 
   Future<bool> isDirectMessageType({required String accountPubkey}) =>
       RustLib.instance.api.crateApiGroupsGroupIsDirectMessageType(
@@ -199,10 +197,8 @@ class Group {
         accountPubkey: accountPubkey,
       );
 
-  Future<bool> isGroupType({required String accountPubkey}) => RustLib
-      .instance
-      .api
-      .crateApiGroupsGroupIsGroupType(that: this, accountPubkey: accountPubkey);
+  Future<bool> isGroupType({required String accountPubkey}) =>
+      RustLib.instance.api.crateApiGroupsGroupIsGroupType(that: this, accountPubkey: accountPubkey);
 
   Future<void> updateGroupData({
     required String accountPubkey,
@@ -260,10 +256,7 @@ class GroupInformation {
 
   @override
   int get hashCode =>
-      mlsGroupId.hashCode ^
-      groupType.hashCode ^
-      createdAt.hashCode ^
-      updatedAt.hashCode;
+      mlsGroupId.hashCode ^ groupType.hashCode ^ createdAt.hashCode ^ updatedAt.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -310,10 +303,7 @@ class LeafNodeInfo {
 
   @override
   int get hashCode =>
-      index.hashCode ^
-      encryptionKey.hashCode ^
-      signatureKey.hashCode ^
-      credentialIdentity.hashCode;
+      index.hashCode ^ encryptionKey.hashCode ^ signatureKey.hashCode ^ credentialIdentity.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -344,8 +334,7 @@ class RatchetTreeInfo {
   });
 
   @override
-  int get hashCode =>
-      treeHash.hashCode ^ serializedTree.hashCode ^ leafNodes.hashCode;
+  int get hashCode => treeHash.hashCode ^ serializedTree.hashCode ^ leafNodes.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -369,8 +358,7 @@ class UploadGroupImageResult {
   });
 
   @override
-  int get hashCode =>
-      encryptedHash.hashCode ^ imageKey.hashCode ^ imageNonce.hashCode;
+  int get hashCode => encryptedHash.hashCode ^ imageKey.hashCode ^ imageNonce.hashCode;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/rust/api/logs.dart
+++ b/lib/src/rust/api/logs.dart
@@ -12,7 +12,5 @@ import 'error.dart';
 
 /// Stream new lines from the Rust log file to Flutter.
 /// Tails the whitenoise log file and emits each new line via the sink.
-Stream<String> subscribeToRustLogs({required String logsBaseDir}) => RustLib
-    .instance
-    .api
-    .crateApiLogsSubscribeToRustLogs(logsBaseDir: logsBaseDir);
+Stream<String> subscribeToRustLogs({required String logsBaseDir}) =>
+    RustLib.instance.api.crateApiLogsSubscribeToRustLogs(logsBaseDir: logsBaseDir);

--- a/lib/src/rust/api/media_files.dart
+++ b/lib/src/rust/api/media_files.dart
@@ -42,8 +42,7 @@ class FileMetadata {
   });
 
   @override
-  int get hashCode =>
-      originalFilename.hashCode ^ dimensions.hashCode ^ blurhash.hashCode;
+  int get hashCode => originalFilename.hashCode ^ dimensions.hashCode ^ blurhash.hashCode;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/rust/api/notifications.dart
+++ b/lib/src/rust/api/notifications.dart
@@ -77,8 +77,7 @@ class NotificationUser {
   });
 
   @override
-  int get hashCode =>
-      pubkey.hashCode ^ displayName.hashCode ^ pictureUrl.hashCode;
+  int get hashCode => pubkey.hashCode ^ displayName.hashCode ^ pictureUrl.hashCode;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/rust/api/relays.dart
+++ b/lib/src/rust/api/relays.dart
@@ -11,19 +11,15 @@ import 'error.dart';
 
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`, `from`
 
-Future<RelayType> relayTypeNip65() =>
-    RustLib.instance.api.crateApiRelaysRelayTypeNip65();
+Future<RelayType> relayTypeNip65() => RustLib.instance.api.crateApiRelaysRelayTypeNip65();
 
-Future<RelayType> relayTypeInbox() =>
-    RustLib.instance.api.crateApiRelaysRelayTypeInbox();
+Future<RelayType> relayTypeInbox() => RustLib.instance.api.crateApiRelaysRelayTypeInbox();
 
-Future<RelayType> relayTypeKeyPackage() =>
-    RustLib.instance.api.crateApiRelaysRelayTypeKeyPackage();
+Future<RelayType> relayTypeKeyPackage() => RustLib.instance.api.crateApiRelaysRelayTypeKeyPackage();
 
 Future<List<(String, String)>> getAccountRelayStatuses({
   required String pubkey,
-}) =>
-    RustLib.instance.api.crateApiRelaysGetAccountRelayStatuses(pubkey: pubkey);
+}) => RustLib.instance.api.crateApiRelaysGetAccountRelayStatuses(pubkey: pubkey);
 
 /// Ensures all subscriptions (global and all accounts) are operational.
 ///

--- a/lib/src/rust/api/signer.dart
+++ b/lib/src/rust/api/signer.dart
@@ -64,8 +64,7 @@ Future<LoginResult> loginExternalSignerStart({
 /// Called after `login_external_signer_start` returned `NeedsRelayLists`.
 Future<LoginResult> loginExternalSignerPublishDefaultRelays({
   required String pubkey,
-}) => RustLib.instance.api
-    .crateApiSignerLoginExternalSignerPublishDefaultRelays(pubkey: pubkey);
+}) => RustLib.instance.api.crateApiSignerLoginExternalSignerPublishDefaultRelays(pubkey: pubkey);
 
 /// Step 2b for external signer: search a user-provided relay for existing lists.
 ///

--- a/lib/src/rust/api/user_search.dart
+++ b/lib/src/rust/api/user_search.dart
@@ -46,8 +46,7 @@ sealed class SearchUpdateTrigger with _$SearchUpdateTrigger {
   const factory SearchUpdateTrigger.radiusStarted({
     required int radius,
   }) = SearchUpdateTrigger_RadiusStarted;
-  const factory SearchUpdateTrigger.resultsFound() =
-      SearchUpdateTrigger_ResultsFound;
+  const factory SearchUpdateTrigger.resultsFound() = SearchUpdateTrigger_ResultsFound;
   const factory SearchUpdateTrigger.radiusCompleted({
     required int radius,
     required BigInt totalPubkeysSearched,
@@ -115,8 +114,7 @@ class UserSearchUpdate {
   });
 
   @override
-  int get hashCode =>
-      trigger.hashCode ^ newResults.hashCode ^ totalResultCount.hashCode;
+  int get hashCode => trigger.hashCode ^ newResults.hashCode ^ totalResultCount.hashCode;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/rust/api/users.dart
+++ b/lib/src/rust/api/users.dart
@@ -67,11 +67,7 @@ class User {
   });
 
   @override
-  int get hashCode =>
-      pubkey.hashCode ^
-      metadata.hashCode ^
-      createdAt.hashCode ^
-      updatedAt.hashCode;
+  int get hashCode => pubkey.hashCode ^ metadata.hashCode ^ createdAt.hashCode ^ updatedAt.hashCode;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/rust/api/utils.dart
+++ b/lib/src/rust/api/utils.dart
@@ -37,38 +37,30 @@ Future<String> groupIdToString({required GroupId groupId}) =>
 Future<GroupId> groupIdFromString({required String groupId}) =>
     RustLib.instance.api.crateApiUtilsGroupIdFromString(groupId: groupId);
 
-ThemeMode themeModeLight() =>
-    RustLib.instance.api.crateApiUtilsThemeModeLight();
+ThemeMode themeModeLight() => RustLib.instance.api.crateApiUtilsThemeModeLight();
 
 ThemeMode themeModeDark() => RustLib.instance.api.crateApiUtilsThemeModeDark();
 
-ThemeMode themeModeSystem() =>
-    RustLib.instance.api.crateApiUtilsThemeModeSystem();
+ThemeMode themeModeSystem() => RustLib.instance.api.crateApiUtilsThemeModeSystem();
 
 String themeModeToString({required ThemeMode themeMode}) =>
     RustLib.instance.api.crateApiUtilsThemeModeToString(themeMode: themeMode);
 
-Language languageEnglish() =>
-    RustLib.instance.api.crateApiUtilsLanguageEnglish();
+Language languageEnglish() => RustLib.instance.api.crateApiUtilsLanguageEnglish();
 
-Language languageSpanish() =>
-    RustLib.instance.api.crateApiUtilsLanguageSpanish();
+Language languageSpanish() => RustLib.instance.api.crateApiUtilsLanguageSpanish();
 
 Language languageFrench() => RustLib.instance.api.crateApiUtilsLanguageFrench();
 
 Language languageGerman() => RustLib.instance.api.crateApiUtilsLanguageGerman();
 
-Language languageItalian() =>
-    RustLib.instance.api.crateApiUtilsLanguageItalian();
+Language languageItalian() => RustLib.instance.api.crateApiUtilsLanguageItalian();
 
-Language languagePortuguese() =>
-    RustLib.instance.api.crateApiUtilsLanguagePortuguese();
+Language languagePortuguese() => RustLib.instance.api.crateApiUtilsLanguagePortuguese();
 
-Language languageRussian() =>
-    RustLib.instance.api.crateApiUtilsLanguageRussian();
+Language languageRussian() => RustLib.instance.api.crateApiUtilsLanguageRussian();
 
-Language languageTurkish() =>
-    RustLib.instance.api.crateApiUtilsLanguageTurkish();
+Language languageTurkish() => RustLib.instance.api.crateApiUtilsLanguageTurkish();
 
 Language languageSystem() => RustLib.instance.api.crateApiUtilsLanguageSystem();
 

--- a/lib/src/rust/frb_generated.io.dart
+++ b/lib/src/rust/frb_generated.io.dart
@@ -37,39 +37,31 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
     required super.portManager,
   });
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_AppSettingsPtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_AppSettingsPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettingsPtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_DartSignerPtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_DartSignerPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSignerPtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_GroupIdPtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_GroupIdPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupIdPtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_LanguagePtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_LanguagePtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguagePtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_PublicKeyPtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_PublicKeyPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKeyPtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_RelayTypePtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_RelayTypePtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayTypePtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_RelayUrlPtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_RelayUrlPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrlPtr;
 
   CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_TagPtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTagPtr;
 
-  CrossPlatformFinalizerArg
-  get rust_arc_decrement_strong_count_ThemeModePtr => wire
+  CrossPlatformFinalizerArg get rust_arc_decrement_strong_count_ThemeModePtr => wire
       ._rust_arc_decrement_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeModePtr;
 
   @protected
@@ -118,8 +110,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  Tag
-  dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  Tag dco_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     dynamic raw,
   );
 
@@ -136,8 +127,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  GroupId
-  dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  GroupId dco_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     dynamic raw,
   );
 
@@ -163,8 +153,9 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   DateTime dco_decode_Chrono_Utc(dynamic raw);
 
   @protected
-  FutureOr<String> Function(String)
-  dco_decode_DartFn_Inputs_String_Output_String_AnyhowException(dynamic raw);
+  FutureOr<String> Function(String) dco_decode_DartFn_Inputs_String_Output_String_AnyhowException(
+    dynamic raw,
+  );
 
   @protected
   FutureOr<String> Function(String, String)
@@ -179,56 +170,47 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   Map<String, String> dco_decode_Map_String_String_None(dynamic raw);
 
   @protected
-  AppSettings
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
+  AppSettings dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
     dynamic raw,
   );
 
   @protected
-  DartSigner
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
+  DartSigner dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
     dynamic raw,
   );
 
   @protected
-  GroupId
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  GroupId dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     dynamic raw,
   );
 
   @protected
-  Language
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
+  Language dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
     dynamic raw,
   );
 
   @protected
-  PublicKey
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
+  PublicKey dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
     dynamic raw,
   );
 
   @protected
-  RelayType
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
+  RelayType dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
     dynamic raw,
   );
 
   @protected
-  RelayUrl
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
+  RelayUrl dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
     dynamic raw,
   );
 
   @protected
-  Tag
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  Tag dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     dynamic raw,
   );
 
   @protected
-  ThemeMode
-  dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
+  ThemeMode dco_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
     dynamic raw,
   );
 
@@ -236,16 +218,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   RustStreamSink<String> dco_decode_StreamSink_String_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<ChatListStreamItem>
-  dco_decode_StreamSink_chat_list_stream_item_Sse(dynamic raw);
+  RustStreamSink<ChatListStreamItem> dco_decode_StreamSink_chat_list_stream_item_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<MessageStreamItem>
-  dco_decode_StreamSink_message_stream_item_Sse(dynamic raw);
+  RustStreamSink<MessageStreamItem> dco_decode_StreamSink_message_stream_item_Sse(dynamic raw);
 
   @protected
-  RustStreamSink<NotificationUpdate>
-  dco_decode_StreamSink_notification_update_Sse(dynamic raw);
+  RustStreamSink<NotificationUpdate> dco_decode_StreamSink_notification_update_Sse(dynamic raw);
 
   @protected
   RustStreamSink<UserSearchUpdate> dco_decode_StreamSink_user_search_update_Sse(
@@ -632,8 +611,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  Tag
-  sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  Tag sse_decode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     SseDeserializer deserializer,
   );
 
@@ -650,8 +628,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  GroupId
-  sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  GroupId sse_decode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     SseDeserializer deserializer,
   );
 
@@ -685,56 +662,47 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  AppSettings
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
+  AppSettings sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
     SseDeserializer deserializer,
   );
 
   @protected
-  DartSigner
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
+  DartSigner sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
     SseDeserializer deserializer,
   );
 
   @protected
-  GroupId
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  GroupId sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     SseDeserializer deserializer,
   );
 
   @protected
-  Language
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
+  Language sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
     SseDeserializer deserializer,
   );
 
   @protected
-  PublicKey
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
+  PublicKey sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
     SseDeserializer deserializer,
   );
 
   @protected
-  RelayType
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
+  RelayType sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
     SseDeserializer deserializer,
   );
 
   @protected
-  RelayUrl
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
+  RelayUrl sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
     SseDeserializer deserializer,
   );
 
   @protected
-  Tag
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  Tag sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     SseDeserializer deserializer,
   );
 
   @protected
-  ThemeMode
-  sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
+  ThemeMode sse_decode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
     SseDeserializer deserializer,
   );
 
@@ -744,16 +712,19 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  RustStreamSink<ChatListStreamItem>
-  sse_decode_StreamSink_chat_list_stream_item_Sse(SseDeserializer deserializer);
+  RustStreamSink<ChatListStreamItem> sse_decode_StreamSink_chat_list_stream_item_Sse(
+    SseDeserializer deserializer,
+  );
 
   @protected
-  RustStreamSink<MessageStreamItem>
-  sse_decode_StreamSink_message_stream_item_Sse(SseDeserializer deserializer);
+  RustStreamSink<MessageStreamItem> sse_decode_StreamSink_message_stream_item_Sse(
+    SseDeserializer deserializer,
+  );
 
   @protected
-  RustStreamSink<NotificationUpdate>
-  sse_decode_StreamSink_notification_update_Sse(SseDeserializer deserializer);
+  RustStreamSink<NotificationUpdate> sse_decode_StreamSink_notification_update_Sse(
+    SseDeserializer deserializer,
+  );
 
   @protected
   RustStreamSink<UserSearchUpdate> sse_decode_StreamSink_user_search_update_Sse(
@@ -1177,15 +1148,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  void sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     GroupId self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
+  void sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
     Language self,
     SseSerializer serializer,
   );
@@ -1205,15 +1174,13 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
+  void sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
     RelayUrl self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  void sse_encode_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     Tag self,
     SseSerializer serializer,
   );
@@ -1233,29 +1200,25 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  void sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     GroupId self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
+  void sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
     Language self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
+  void sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
     RelayUrl self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
+  void sse_encode_Auto_Ref_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
     ThemeMode self,
     SseSerializer serializer,
   );
@@ -1285,64 +1248,55 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(
     AppSettings self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerDartSigner(
     DartSigner self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerGroupId(
     GroupId self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerLanguage(
     Language self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerPublicKey(
     PublicKey self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayType(
     RelayType self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerRelayUrl(
     RelayUrl self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     Tag self,
     SseSerializer serializer,
   );
 
   @protected
-  void
-  sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
+  void sse_encode_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerThemeMode(
     ThemeMode self,
     SseSerializer serializer,
   );
@@ -1570,8 +1524,7 @@ abstract class RustLibApiImplPlatform extends BaseApiImpl<RustLibWire> {
   void sse_encode_leaf_node_info(LeafNodeInfo self, SseSerializer serializer);
 
   @protected
-  void
-  sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
+  void sse_encode_list_Auto_Owned_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerTag(
     List<Tag> self,
     SseSerializer serializer,
   );
@@ -1882,12 +1835,10 @@ class RustLibWire implements BaseWire {
       RustLibWire(lib.ffiDynamicLibrary);
 
   /// Holds the symbol lookup function.
-  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName)
-  _lookup;
+  final ffi.Pointer<T> Function<T extends ffi.NativeType>(String symbolName) _lookup;
 
   /// The symbols are looked up in [dynamicLibrary].
-  RustLibWire(ffi.DynamicLibrary dynamicLibrary)
-    : _lookup = dynamicLibrary.lookup;
+  RustLibWire(ffi.DynamicLibrary dynamicLibrary) : _lookup = dynamicLibrary.lookup;
 
   void
   rust_arc_increment_strong_count_RustOpaque_flutter_rust_bridgefor_generatedRustAutoOpaqueInnerAppSettings(


### PR DESCRIPTION
## Summary
- Wires `DeliveryStatus` enum from whitenoise-rs (PR #519) through flutter_rust_bridge to the Flutter UI
- Messages now show real-time delivery indicators: sending (clock), delivered (checkmark), or failed (red error icon)
- Adds `MessageRetried` handler to reposition retried messages to end of chat list
- Updates whitenoise-rs dependency to rev `328977a` (delivery status backend)

## Changes
- **`rust/src/api/messages.rs`** — Bridge `DeliveryStatus` enum, `retry_message_publish` function, `DeliveryStatusChanged`/`MessageRetried` update triggers, conversion impls, and 5 tests
- **`rust/Cargo.toml`** — Bump whitenoise rev to `328977a`
- **`lib/widgets/chat_message_bubble.dart`** — Map `DeliveryStatus` variants to `ChatStatusType` and pass to bubble widget
- **`lib/widgets/wn_message_bubble.dart`** — Accept optional `deliveryStatus` parameter, use it instead of hardcoded `sent`
- **`lib/hooks/use_chat_messages.dart`** — Handle `MessageRetried` trigger to reposition retried messages
- Regenerated `flutter_rust_bridge` and `freezed` output files

## Test plan
- [ ] Verify sent messages show sending → delivered status transition
- [ ] Verify failed messages show red error icon
- [ ] Verify retry repositions message to end of chat
- [ ] Incoming messages from others show no delivery status indicator

Closes #511 (Phase 2 — Flutter UI)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retry failed messages directly from chat.
  * Real-time delivery status indicators on outgoing messages: sending, sent (with relay count), or failed (with reason).
  * Outgoing message bubbles update to reflect delivery state.

* **Bug Fixes**
  * Retried messages are moved to the latest position so their status and ordering refresh correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->