### PR TITLE
Set app flavor variable as default to staging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
         cd widgetbook && flutter pub get
 
     - name: Run Flutter tests with coverage
-      run: flutter test --coverage --dart-define=APP_FLAVOR=staging
+      run: flutter test --coverage
 
     - name: Extract coverage percentage
       id: coverage

--- a/justfile
+++ b/justfile
@@ -156,7 +156,7 @@ check-dart-format:
 test-flutter:
     @echo "🧪 Testing Flutter code..."
     @if [ -d "test" ]; then \
-        flutter test --reporter=compact --dart-define=APP_FLAVOR=staging && echo "✅ Flutter tests passed!" || (echo "❌ Flutter tests failed!" && exit 1); \
+        flutter test --reporter=compact && echo "✅ Flutter tests passed!" || (echo "❌ Flutter tests failed!" && exit 1); \
     else \
         echo "No test directory found. Create tests in test/ directory."; \
     fi
@@ -164,7 +164,7 @@ test-flutter:
 # Test Flutter code with minimal output (for agents/CI)
 test-flutter-quiet:
     @if [ -d "test" ]; then \
-        flutter test --no-pub --reporter=failures-only --dart-define=APP_FLAVOR=staging; \
+        flutter test --no-pub --reporter=failures-only; \
     else \
         echo "No test directory found."; \
     fi
@@ -172,12 +172,12 @@ test-flutter-quiet:
 
 coverage min="99":
     @echo "🧪 Running Flutter tests with coverage..."
-    flutter test --coverage --dart-define=APP_FLAVOR=staging && \
+    flutter test --coverage && \
         ./scripts/check-coverage.sh --min {{min}}
 
 coverage-report:
   @echo "🧪 Generating coverage report..."
-  flutter test --coverage --dart-define=APP_FLAVOR=staging && \
+  flutter test --coverage && \
   ./scripts/check-coverage.sh && \
   genhtml coverage/lcov.info -o coverage/html
   @echo "📊 Coverage report generated at coverage/html/index.html"

--- a/lib/utils/app_flavor.dart
+++ b/lib/utils/app_flavor.dart
@@ -1,1 +1,1 @@
-const bool isStaging = String.fromEnvironment('APP_FLAVOR') == 'staging';
+const bool isStaging = String.fromEnvironment('APP_FLAVOR', defaultValue: 'staging') == 'staging';

--- a/test/utils/app_flavor_test.dart
+++ b/test/utils/app_flavor_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/utils/app_flavor.dart';
 
 void main() {
-  const appFlavor = String.fromEnvironment('APP_FLAVOR');
+  const appFlavor = String.fromEnvironment('APP_FLAVOR', defaultValue: 'staging');
 
   group('isStaging', () {
     test('matches APP_FLAVOR', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Adding` --dart-define=APP_FLAVOR=staging` to every test or run command we run lcoally is messing up with my muscle memory. It woudl be easier for development if APP_FLAVOR defaults to staging, so this PR adds that.

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [X] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified test execution and app flavor handling to use a default staging configuration instead of explicit flavor definitions. Updated related test assertions to reflect the new default behavior while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->