### PR TITLE
fix: remove duplicate tracing init that panics on iOS

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4010,8 +4010,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-appender",
- "tracing-subscriber",
  "url",
  "whitenoise",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -24,8 +24,6 @@ serde_json = "1.0.140"
 thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
-tracing-appender = "0.2"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5.1"
 whitenoise = { version = "0.1.0", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "23f1a03" }
 

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,9 +1,6 @@
 // Re-export everything from the whitenoise crate
 use flutter_rust_bridge::frb;
 use std::path::Path;
-use std::sync::OnceLock;
-use tracing_appender::{non_blocking::WorkerGuard, rolling::Rotation};
-use tracing_subscriber::{EnvFilter, layer::SubscriberExt};
 pub use whitenoise::{AppSettings, Language, RelayType, ThemeMode, Whitenoise};
 
 // Re-export types that flutter_rust_bridge needs
@@ -93,64 +90,8 @@ pub use user_search::*;
 pub use users::*;
 pub use utils::*;
 
-static TRACING_GUARD: OnceLock<WorkerGuard> = OnceLock::new();
-
-fn initialize_tracing(logs_dir: &str) -> Result<(), ApiError> {
-    if TRACING_GUARD.get().is_some() {
-        return Ok(());
-    }
-
-    let subdir = if cfg!(debug_assertions) {
-        "dev"
-    } else {
-        "release"
-    };
-    let log_dir = Path::new(logs_dir).join(subdir);
-    std::fs::create_dir_all(&log_dir)?;
-
-    let appender = tracing_appender::rolling::RollingFileAppender::builder()
-        .rotation(Rotation::DAILY)
-        .filename_prefix("whitenoise")
-        .filename_suffix("log")
-        .build(log_dir)
-        .map_err(|e| ApiError::Other {
-            message: format!("Failed to initialize tracing appender: {e}"),
-        })?;
-    let (non_blocking, guard) = tracing_appender::non_blocking(appender);
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let fmt_layer = tracing_subscriber::fmt::layer()
-        .with_ansi(false)
-        .with_target(true)
-        .with_writer(non_blocking);
-
-    let subscriber = tracing_subscriber::registry()
-        .with(env_filter)
-        .with(fmt_layer);
-
-    // Try setting as global default. If that fails (because flutter_rust_bridge
-    // already set one), fall back to setting it as the *default for this thread*
-    // — but more importantly, we keep the guard alive either way.
-    match tracing::subscriber::set_global_default(subscriber) {
-        Ok(()) => {}
-        Err(_) => {
-            // FRB (or something else) already owns the global subscriber.
-            // We can't add layers to it after the fact.
-            // Log a warning and move on — the guard will still be stored
-            // so the appender stays alive, but logs will go to FRB's subscriber.
-            eprintln!(
-                "Warning: global tracing subscriber already set (likely by flutter_rust_bridge). \
-                 File logging layer could not be installed."
-            );
-        }
-    }
-
-    let _ = TRACING_GUARD.set(guard);
-    Ok(())
-}
-
 #[frb]
 pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<(), ApiError> {
-    initialize_tracing(&config.logs_dir)?;
     let core_config = whitenoise::WhitenoiseConfig::new(
         Path::new(&config.data_dir),
         Path::new(&config.logs_dir),


### PR DESCRIPTION
![marmot](https://blossom.primal.net/5a71106d8f186a4630c643d3f4728cdde08b14da28097e695f18921915841973.png)

The app wrapper had its own `initialize_tracing()` that called `set_global_default()` before whitenoise-rs's `init_tracing()` ran inside `initialize_whitenoise()` — which then panicked via `.init()` → `.expect()` because the global subscriber slot was already taken. Removed the wrapper's redundant subscriber setup entirely since whitenoise-rs already handles file + stdout tracing with daily rotation and `OnceLock`-based idempotency.

Closes #426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed tracing infrastructure components and initialization code to reduce dependencies and simplify the startup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->