### PR TITLE
Enforce 10-min CI timeout, optimize pipeline speed

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -15,6 +15,7 @@ jobs:
       github.event_name == 'pull_request'
       && contains(github.event.pull_request.labels.*.name, 'apk')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       is-member: ${{ steps.check.outputs.is-member }}
 
@@ -42,6 +43,7 @@ jobs:
   build-apk:
     name: Build Staging APK
     runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
     needs: [check-team]
     # Run when: push/dispatch (not a PR, check-team was skipped), or PR where
     # the "apk" label is present and actor is a contributor.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,13 @@ jobs:
   check:
     name: Check
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -21,6 +24,16 @@ jobs:
         flutter-version: '3.38.4'
         channel: 'stable'
         cache: true
+
+    - name: Cache Flutter dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.pub-cache
+          ${{ github.workspace }}/.pub-cache
+        key: ${{ runner.os }}-pub-cache-${{ hashFiles('**/pubspec.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-pub-cache-
 
     - name: Setup Rust
       uses: dtolnay/rust-toolchain@stable
@@ -73,6 +86,7 @@ jobs:
   test:
     name: Test (${{ matrix.shard }}/4)
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -81,6 +95,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -100,9 +116,7 @@ jobs:
           ${{ runner.os }}-pub-cache-
 
     - name: Install Flutter dependencies
-      run: |
-        flutter pub get
-        cd widgetbook && flutter pub get
+      run: flutter pub get
 
     - name: Install lcov (cached)
       uses: awalsh128/cache-apt-pkgs-action@v1
@@ -142,6 +156,7 @@ jobs:
     if: always()
     needs: test
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -150,7 +165,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-
+      with:
+        fetch-depth: 1
 
     - name: Download test failure artifacts
       id: download_failures

--- a/.github/workflows/deploy-when-apk.yml
+++ b/.github/workflows/deploy-when-apk.yml
@@ -13,6 +13,7 @@ jobs:
   deploy:
     name: Generate & Deploy to Cloudflare Pages
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only deploy if the APK build succeeded (or manual trigger)
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
@@ -23,8 +24,11 @@ jobs:
       - name: Checkout helpers
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: sudo apt-get install -y jq
+      - name: Install jq (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: jq
+          version: 1.0
 
       - name: Generate static site
         env:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,6 +12,7 @@ jobs:
   label:
     name: Apply PR labels
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Apply labels from changed files
         uses: actions/labeler@v6


### PR DESCRIPTION
![marmot](https://blossom.primal.net/bed0a168fa9200d7be5abbb9d3d198390ddb74253d3fee6f43d61fcf44eb63f4.png)

The colony's pipelines were running without a leash — defaulting to GitHub's 360-minute timeout, meaning a hung build could burn runner minutes for 6 hours. This PR enforces a hard 10-minute timeout on all 7 jobs across all 4 workflows, and shaves time off the pipeline with shallow clones, pub-cache on the check job, removal of dead widgetbook installs from test shards, and cached jq in the deploy workflow.

## Changes

### Hard timeout (all workflows)
- `timeout-minutes: 10` added to every job: `check`, `test` (x4 shards), `coverage`, `check-team`, `build-apk`, `deploy`, `label`

### Speed optimizations
| Change | Where | Savings |
|--------|-------|---------|
| Remove widgetbook pub get from test shards | `ci.yml` test job | ~10s × 4 shards (tests never import widgetbook) |
| Add pub-cache to check job | `ci.yml` check job | ~5-15s on warm cache (was missing) |
| Shallow clone (`fetch-depth: 1`) | All 3 `ci.yml` jobs | ~2-5s per job |
| Cache jq install | `deploy-when-apk.yml` | ~3-5s (no more raw `apt-get install`) |

### Note
The `build-apk` job does Rust cross-compilation for 3 Android architectures — on cold cache this can take 10-15 minutes. On warm cache (jniLibs hit) it should be well under 10. Monitor first few runs; if cold builds timeout, that job may need a bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added execution timeouts to all CI/CD pipeline jobs to prevent hanging builds and improve reliability
* Implemented dependency caching for Flutter and Rust to accelerate build processes
* Optimized continuous integration workflow steps for more efficient and deterministic builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->