### PR TITLE
Revert APK build runner to ubuntu-latest

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -42,8 +42,8 @@ jobs:
 
   build-apk:
     name: Build Staging APK
-    runs-on: blacksmith-8vcpu-ubuntu-2404
-    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [check-team]
     # Run when: push/dispatch (not a PR, check-team was skipped), or PR where
     # the "apk" label is present and actor is a contributor.


### PR DESCRIPTION
![Construction Marmot - Cost Efficiency](https://blossom.primal.net/6e241fdd544beb88ae8137e31404ab7068e6731efc3812b34e119b5126c42741.png)

The blacksmith-8vcpu-ubuntu-2404 runner was intended for performance validation but adds significant cost per build. This change reverts to standard ubuntu-latest and adjusts the timeout from 10 to 30 minutes to accommodate the longer build time on standard runners, maintaining a balance between cost efficiency and build reliability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure configuration for improved reliability and extended build time allowance.

---

**Note:** This release contains internal infrastructure updates with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->