### PR TITLE
Add GitHub issue templates (bug, feature, other)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Report a reproducible bug or regression
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+---
+
+## Summary
+
+Describe the bug clearly and concisely.
+
+## Steps to reproduce
+
+1. Go to ...
+2. Click on ...
+3. Observe ...
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe what actually happened.
+
+## Environment
+
+- App version:
+- OS/device:
+- Additional context:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Problem
+
+Describe the problem or pain point this request addresses.
+
+## Proposed solution
+
+Describe the desired behavior or feature.
+
+## Alternatives considered
+
+Describe any alternative solutions or features you considered.
+
+## Additional context
+
+Add any extra context, mockups, or examples here.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,19 @@
+---
+name: Other
+about: Ask a question or open another type of issue
+title: "[Other]: "
+labels: ["question"]
+assignees: []
+---
+
+## Context
+
+Describe what this issue is about.
+
+## Details
+
+Share any relevant details, links, logs, or screenshots.
+
+## Outcome
+
+Describe what kind of answer, clarification, or next step you are looking for.


### PR DESCRIPTION
![marmot](https://blossom.primal.net/f59dfc88c48331253d9a1bfa112fc22b103aa231827e815b022d779f7bf92fc2.png)

The colony now has proper issue templates — every marmot reporting a bug, requesting a feature, or raising a question gets a structured form to fill out. Three templates cover Bug, Feature Request, and Other, with `blank_issues_enabled: false` to keep reports organized and actionable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced standardized GitHub issue templates for bug reports (with reproduction steps and environment details), feature requests (with problem statement and proposed solutions), and general inquiries.
  * Configured issue submissions to require template usage and prevent blank issue creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->