### PR TITLE
Remove agents.md instructions that mess up with plan and review…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,20 +32,6 @@ This is a secure messaging app that uses the [whitenoise Rust crate](https://git
 - **flutter_hooks** - Ephemeral widget state
 - **go_router** - Navigation/routing
 
-## Git Worktrees
-
-**IMPORTANT:** When starting work on a new feature, bug fix, or issue, use the `/create-git-worktree` command to create an isolated development environment.
-
-```bash
-/create-git-worktree <branch-name>
-```
-
-This creates a worktree in the `trees/` directory at the repository root. Worktrees allow parallel development without affecting the main working directory.
-
-Example: `/create-git-worktree issue-42-fix-login`
-
-After running, you'll be working in `trees/issue-42-fix-login/` on that branch.
-
 ## Directory Structure
 
 ```text
@@ -256,17 +242,6 @@ Screen (watches providers)
 - Structs use `#[frb(non_opaque)]` for Flutter compatibility
 - Errors wrapped in `ApiError` enum using `thiserror`
 - Files in `lib/src/rust/` are auto-generated - DO NOT EDIT manually
-
-## Commit Checklist
-
-**CRITICAL: You MUST run `just precommit` before EVERY commit. No exceptions.**
-
-1. Run `just precommit` and ensure it passes completely
-2. Coverage meets 95% minimum
-3. Update `CHANGELOG.md` for any user-facing changes
-4. Follow existing code patterns and naming conventions
-
-The precommit command runs all checks: formatting, linting, and tests. If it passes, you're good to commit. If it fails, fix the issues before committing.
 
 ## Fixing Bugs
 


### PR DESCRIPTION
… commands

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I'm removing some instructions in AGENTS.md that are very related to coding chores but that are annoying for other kind of tasks like planning and code review. I think that this instructions  should be loaded in personal agents or commands instead of being general instructions

- Worktrees: I use them a lot, but not for every task and not with that command name. This instructions make my agents to always fail when runnning that command and then following my agents worktree instructions. Also, I find i tannoying cause I have some commands for planning and review that don't need to create a worktree but this makes my agent to create a worktree anyways

- Precommits: This instruction is annoying for planning and review chores, where I don't need to run precommit commands

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [X] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
