### PR TITLE
chore: bump version to 2026.3.17 and update Rust crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and this project adheres to Calendar Versioning (CalVer).
 
 ### Security
 
-## [2026.3.5] - 2026-03-05
+## [2026.3.17] - 2026-03-17
 
 ### Added
 - Show reply preview in message actions, add author color in reply preview in input, swipe to reply [PR #389](https://github.com/marmot-protocol/whitenoise/pull/389)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2026.3.5+17
+version: 2026.3.17+20
 
 environment:
   sdk: ^3.11.1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2618,7 +2618,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=ca0663ee332958aa92efadf916d19c6e1b1f99c7#ca0663ee332958aa92efadf916d19c6e1b1f99c7"
+source = "git+https://github.com/marmot-protocol/mdk?rev=b6f7dc64b82d10d0d0efad3a213b39816d79d9c6#b6f7dc64b82d10d0d0efad3a213b39816d79d9c6"
 dependencies = [
  "base64",
  "blurhash",
@@ -2643,7 +2643,7 @@ dependencies = [
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=ca0663ee332958aa92efadf916d19c6e1b1f99c7#ca0663ee332958aa92efadf916d19c6e1b1f99c7"
+source = "git+https://github.com/marmot-protocol/mdk?rev=b6f7dc64b82d10d0d0efad3a213b39816d79d9c6#b6f7dc64b82d10d0d0efad3a213b39816d79d9c6"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2664,7 +2664,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=ca0663ee332958aa92efadf916d19c6e1b1f99c7#ca0663ee332958aa92efadf916d19c6e1b1f99c7"
+source = "git+https://github.com/marmot-protocol/mdk?rev=b6f7dc64b82d10d0d0efad3a213b39816d79d9c6#b6f7dc64b82d10d0d0efad3a213b39816d79d9c6"
 dependencies = [
  "nostr",
  "openmls",
@@ -5367,7 +5367,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=809aa00424fc9fc05089c2f1610e3ceb87a66242#809aa00424fc9fc05089c2f1610e3ceb87a66242"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=73a4fd3d624448f2949a1f860940206db84f3e99#73a4fd3d624448f2949a1f860940206db84f3e99"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=809aa00424fc9fc05089c2f1610e3ceb87a66242#809aa00424fc9fc05089c2f1610e3ceb87a66242"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=73a4fd3d624448f2949a1f860940206db84f3e99#73a4fd3d624448f2949a1f860940206db84f3e99"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.99"
 chrono = { version = "0.4.40", features = ["serde"] }
 flutter_rust_bridge = { version = "=2.11.1", features = ["chrono"] }
 hex = "0.4"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "ca0663ee332958aa92efadf916d19c6e1b1f99c7", features = [
+mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "b6f7dc64b82d10d0d0efad3a213b39816d79d9c6", features = [
     "mip04",
 ] }
 nostr-sdk = { version = "0.44", features = [
@@ -25,7 +25,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "809aa00424fc9fc05089c2f1610e3ceb87a66242" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "73a4fd3d624448f2949a1f860940206db84f3e99" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -1487,7 +1487,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2026.3.5+17"
+    version: "2026.3.17+20"
   widgetbook:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Summary

- Bumps app version from `2026.3.5+17` to `2026.3.17+20` in `pubspec.yaml`
- Updates `CHANGELOG.md` release date from `2026-03-05` to `2026-03-17`
- Updates `mdk-core` git revision to `b6f7dc64b82d10d0d0efad3a213b39816d79d9c6`
- Updates `whitenoise` git revision to `73a4fd3d624448f2949a1f860940206db84f3e99`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 2026.3.17+20
  * Updated project dependencies to latest upstream revisions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->