### PR TITLE
chore: prepare 2026.3.23+22 release

### DIFF
--- a/lib/src/rust/api/users.dart
+++ b/lib/src/rust/api/users.dart
@@ -14,6 +14,7 @@ import 'relays.dart';
 
 part 'users.freezed.dart';
 
+// These functions are ignored because they are not marked as `pub`: `resolve_whitenoise_user`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`
 
 Stream<UserStreamItem> subscribeToUser({required String pubkey}) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2026.3.17+21
+version: 2026.3.23+22
 
 environment:
   sdk: ^3.11.1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5367,7 +5367,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=6aff825ef8570b31ab01fe9ab738a73f83f2c897#6aff825ef8570b31ab01fe9ab738a73f83f2c897"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=60770fdb15b2fb86327a926918d02a64612fa1cb#60770fdb15b2fb86327a926918d02a64612fa1cb"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=6aff825ef8570b31ab01fe9ab738a73f83f2c897#6aff825ef8570b31ab01fe9ab738a73f83f2c897"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=60770fdb15b2fb86327a926918d02a64612fa1cb#60770fdb15b2fb86327a926918d02a64612fa1cb"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "6aff825ef8570b31ab01fe9ab738a73f83f2c897" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "60770fdb15b2fb86327a926918d02a64612fa1cb" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/users.rs
+++ b/rust/src/api/users.rs
@@ -6,8 +6,8 @@ use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
 use whitenoise::{
     KeyPackageStatus as WhitenoiseKeyPackageStatus, RelayType, User as WhitenoiseUser,
-    UserSyncMode, UserUpdate as WhitenoiseUserUpdate,
-    UserUpdateTrigger as WhitenoiseUserUpdateTrigger, Whitenoise,
+    UserUpdate as WhitenoiseUserUpdate, UserUpdateTrigger as WhitenoiseUserUpdateTrigger,
+    Whitenoise,
 };
 
 #[frb]
@@ -79,6 +79,18 @@ pub enum UserStreamItem {
     Update { update: UserUpdate },
 }
 
+async fn resolve_whitenoise_user(
+    whitenoise: &Whitenoise,
+    pubkey: &PublicKey,
+    blocking_data_sync: bool,
+) -> Result<WhitenoiseUser, ApiError> {
+    if blocking_data_sync {
+        Ok(whitenoise.resolve_user_blocking(pubkey).await?)
+    } else {
+        Ok(whitenoise.resolve_user(pubkey).await?)
+    }
+}
+
 #[frb]
 pub async fn subscribe_to_user(
     pubkey: String,
@@ -126,15 +138,7 @@ pub async fn subscribe_to_user(
 pub async fn get_user(pubkey: String, blocking_data_sync: bool) -> Result<User, ApiError> {
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let sync_mode = if blocking_data_sync {
-        UserSyncMode::Blocking
-    } else {
-        UserSyncMode::Background
-    };
-    let user = whitenoise
-        .find_or_create_user_by_pubkey(&pubkey, sync_mode)
-        .await
-        .map_err(ApiError::from)?;
+    let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     Ok(user.into())
 }
 
@@ -145,14 +149,7 @@ pub async fn user_metadata(
 ) -> Result<FlutterMetadata, ApiError> {
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let sync_mode = if blocking_data_sync {
-        UserSyncMode::Blocking
-    } else {
-        UserSyncMode::Background
-    };
-    let user = whitenoise
-        .find_or_create_user_by_pubkey(&pubkey, sync_mode)
-        .await?;
+    let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     Ok(user.metadata.into())
 }
 
@@ -164,14 +161,7 @@ pub async fn user_relays(
 ) -> Result<Vec<Relay>, ApiError> {
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let sync_mode = if blocking_data_sync {
-        UserSyncMode::Blocking
-    } else {
-        UserSyncMode::Background
-    };
-    let user = whitenoise
-        .find_or_create_user_by_pubkey(&pubkey, sync_mode)
-        .await?;
+    let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     let relays = user.relays_by_type(relay_type, &whitenoise).await?;
     Ok(relays.into_iter().map(|r| r.into()).collect())
 }
@@ -183,14 +173,7 @@ pub async fn user_has_key_package(
 ) -> Result<KeyPackageStatus, ApiError> {
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let sync_mode = if blocking_data_sync {
-        UserSyncMode::Blocking
-    } else {
-        UserSyncMode::Background
-    };
-    let user = whitenoise
-        .find_or_create_user_by_pubkey(&pubkey, sync_mode)
-        .await?;
+    let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     match user.key_package_status(whitenoise).await? {
         WhitenoiseKeyPackageStatus::Valid(_) => Ok(KeyPackageStatus::Valid),
         WhitenoiseKeyPackageStatus::NotFound => Ok(KeyPackageStatus::NotFound),

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -1487,7 +1487,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2026.3.17+21"
+    version: "2026.3.23+22"
   widgetbook:
     dependency: "direct main"
     description:


### PR DESCRIPTION
## Summary
- bump app version to 2026.3.23+22
- update whitenoise-rs to rev 60770fdb15b2fb86327a926918d02a64612fa1cb
- adapt rust user APIs to the new resolve_user/resolve_user_blocking flow after removal of the old blocking sync API

## Testing
- just precommit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2026.3.23+22
  * Internal dependency and code improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->