### PR TITLE
fix: stabilize message actions modal layout for long messages(#485)

### DIFF
--- a/lib/screens/message_actions_screen.dart
+++ b/lib/screens/message_actions_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -14,6 +16,72 @@ import 'package:whitenoise/widgets/wn_emoji_picker.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 import 'package:whitenoise/widgets/wn_slate.dart';
 import 'package:whitenoise/widgets/wn_system_notice.dart';
+
+const _modalViewportVerticalInset = 96.0;
+const _modalPreviewTopPadding = 10.0;
+const _modalPreviewBottomPadding = 12.0;
+const _modalSenderRowHeight = 20.0;
+const _modalSenderGap = 8.0;
+const _modalReplyRowHeight = 56.0;
+const _modalMediaHeight = 96.0;
+const _modalReactionsHeight = 36.0;
+const _modalSectionSpacing = 16.0;
+const _modalButtonSpacing = 8.0;
+const _modalContentHorizontalPadding = 14.0;
+const _modalContentVerticalPadding = 14.0;
+const _modalPreviewSafetyReserve = 12.0;
+const _modalMinPreviewHeight = 1.0;
+const _emojiPickerReservedHeight = 320.0;
+const _modalToPickerGap = 8.0;
+
+double _modalMessageLineHeight(BuildContext context, Color textColor) {
+  final style = context.typographyScaled.medium16Compact.copyWith(color: textColor);
+  final tp = TextPainter(
+    text: TextSpan(text: ' ', style: style),
+    textDirection: TextDirection.ltr,
+    textScaler: MediaQuery.textScalerOf(context),
+  );
+  try {
+    tp.layout();
+    return tp.preferredLineHeight;
+  } finally {
+    tp.dispose();
+  }
+}
+
+int _modalPreviewContentMaxLines(
+  BuildContext context, {
+  required double slotHeight,
+  required bool isOwnMessage,
+  required bool showAvatar,
+  required String? senderName,
+  required bool hasReplyPreview,
+  required bool hasBubbleMedia,
+  required bool hasBubbleReactions,
+}) {
+  var textBudget =
+      slotHeight -
+      _modalPreviewTopPadding.h -
+      _modalPreviewBottomPadding.h -
+      _modalPreviewSafetyReserve.h;
+  final hasSender = !isOwnMessage && showAvatar && senderName != null && senderName.isNotEmpty;
+  if (hasSender) {
+    textBudget -= _modalSenderRowHeight.h + _modalSenderGap.h;
+  }
+  if (hasReplyPreview) {
+    textBudget -= _modalSenderGap.h + _modalReplyRowHeight.h;
+  }
+  if (hasBubbleMedia) {
+    textBudget -= _modalSenderGap.h + _modalMediaHeight.h;
+  }
+  if (hasBubbleReactions) {
+    textBudget -= _modalSenderGap.h + _modalReactionsHeight.h;
+  }
+  final colors = context.colors;
+  final textColor = isOwnMessage ? colors.fillContentPrimary : colors.backgroundContentPrimary;
+  final lh = math.max(_modalMessageLineHeight(context, textColor), 1.0);
+  return math.max(1, (textBudget / lh).floor());
+}
 
 class MessageActionsScreen extends HookWidget {
   const MessageActionsScreen({
@@ -175,6 +243,9 @@ class MessageActionsScreen extends HookWidget {
                     senderPictureUrl: senderPictureUrl,
                     isGroupChat: isGroupChat,
                     getChatMessageQuote: getChatMessageQuote,
+                    bottomInset: showEmojiPicker.value
+                        ? _emojiPickerReservedHeight.h + _modalToPickerGap.h
+                        : 0,
                   ),
                 ],
               ),
@@ -206,6 +277,7 @@ class MessageActionsModal extends StatelessWidget {
     this.senderPictureUrl,
     this.isGroupChat = false,
     this.getChatMessageQuote,
+    this.bottomInset = 0,
   });
 
   final ChatMessage message;
@@ -220,6 +292,7 @@ class MessageActionsModal extends StatelessWidget {
   final String? senderPictureUrl;
   final bool isGroupChat;
   final ChatMessageQuoteData? Function(String? replyId)? getChatMessageQuote;
+  final double bottomInset;
 
   static const List<String> reactions = [
     '❤',
@@ -231,97 +304,172 @@ class MessageActionsModal extends StatelessWidget {
     '🦥',
   ];
 
+  double _controlsEstimatedHeight() {
+    var height = _modalSectionSpacing.h + 40.h + _modalSectionSpacing.h + 52.h;
+    if (onReply != null) {
+      height += _modalButtonSpacing.h + 52.h;
+    }
+    if (onDelete != null) {
+      height += _modalButtonSpacing.h + 52.h;
+    }
+    return height;
+  }
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
     final replyPreview = message.isReply ? getChatMessageQuote?.call(message.replyToId) : null;
+    final maxSlateHeight = math.max(
+      0.0,
+      MediaQuery.sizeOf(context).height - (2 * _modalViewportVerticalInset.h) - bottomInset,
+    );
 
-    return WnSlate(
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(14.w, 14.h, 14.w, 14.h),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            ChatMessageBubble(
-              message: message,
-              isOwnMessage: isOwnMessage,
-              currentUserPubkey: currentUserPubkey,
-              showAvatar: shouldShowAvatar(
-                current: message,
-                next: null,
-                isOwnMessage: isOwnMessage,
-                isGroupChat: isGroupChat,
+    return ConstrainedBox(
+      constraints: BoxConstraints(maxHeight: maxSlateHeight),
+      child: LayoutBuilder(
+        builder: (context, slateConstraints) {
+          return WnSlate(
+            shrinkWrapContent: true,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxWidth: slateConstraints.maxWidth,
+                maxHeight: math.max(0.0, slateConstraints.maxHeight - 2),
               ),
-              senderName: senderName,
-              senderPictureUrl: senderPictureUrl,
-              isGroupChat: isGroupChat,
-              replyPreview: replyPreview,
-            ),
-            SizedBox(height: 16.h),
-            Row(
-              children: [
-                ...reactions.map(
-                  (emoji) => Expanded(
-                    child: _ReactionButton(
-                      key: Key('reaction_$emoji'),
-                      colors: colors,
-                      emoji: emoji,
-                      isSelected: selectedEmojis.contains(emoji),
-                      onTap: () => onReaction(emoji),
-                    ),
-                  ),
+              child: Padding(
+                padding: EdgeInsets.fromLTRB(
+                  _modalContentHorizontalPadding.w,
+                  _modalContentVerticalPadding.h,
+                  _modalContentHorizontalPadding.w,
+                  _modalContentVerticalPadding.h,
                 ),
-                Expanded(
-                  child: GestureDetector(
-                    key: const Key('emoji_picker_button'),
-                    onTap: onEmojiPicker,
-                    child: Center(
-                      child: WnIcon(
-                        WnIcons.addEmoji,
-                        color: colors.backgroundContentPrimary,
-                        size: 20.sp,
-                      ),
-                    ),
-                  ),
+                child: LayoutBuilder(
+                  builder: (context, innerConstraints) {
+                    final showAvatar = shouldShowAvatar(
+                      current: message,
+                      next: null,
+                      isOwnMessage: isOwnMessage,
+                      isGroupChat: isGroupChat,
+                    );
+                    final previewMaxHeight = math.max(
+                      0.0,
+                      innerConstraints.maxHeight - _controlsEstimatedHeight(),
+                    );
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        if (previewMaxHeight >= _modalMinPreviewHeight.h)
+                          ConstrainedBox(
+                            constraints: BoxConstraints(maxHeight: previewMaxHeight),
+                            child: LayoutBuilder(
+                              builder: (context, slotConstraints) {
+                                final maxLines = _modalPreviewContentMaxLines(
+                                  context,
+                                  slotHeight: slotConstraints.maxHeight,
+                                  isOwnMessage: isOwnMessage,
+                                  showAvatar: showAvatar,
+                                  senderName: senderName,
+                                  hasReplyPreview: replyPreview != null,
+                                  hasBubbleMedia: message.mediaAttachments.isNotEmpty,
+                                  hasBubbleReactions: message.reactions.byEmoji.isNotEmpty,
+                                );
+                                final shouldConstrainPreviewLines =
+                                    message.content.runes.length > 32 ||
+                                    message.content.contains('\n') ||
+                                    replyPreview != null ||
+                                    message.mediaAttachments.isNotEmpty ||
+                                    message.reactions.byEmoji.isNotEmpty;
+                                return Align(
+                                  alignment: isOwnMessage ? Alignment.topRight : Alignment.topLeft,
+                                  heightFactor: 1,
+                                  child: ChatMessageBubble(
+                                    message: message,
+                                    isOwnMessage: isOwnMessage,
+                                    currentUserPubkey: currentUserPubkey,
+                                    showAvatar: showAvatar,
+                                    senderName: senderName,
+                                    senderPictureUrl: senderPictureUrl,
+                                    isGroupChat: isGroupChat,
+                                    replyPreview: replyPreview,
+                                    contentMaxLines: shouldConstrainPreviewLines ? maxLines : null,
+                                    bubbleWidthFactor: 0.865,
+                                    forceTightHeight: true,
+                                  ),
+                                );
+                              },
+                            ),
+                          ),
+                        SizedBox(height: _modalSectionSpacing.h),
+                        Row(
+                          children: [
+                            ...reactions.map(
+                              (emoji) => Expanded(
+                                child: _ReactionButton(
+                                  key: Key('reaction_$emoji'),
+                                  colors: colors,
+                                  emoji: emoji,
+                                  isSelected: selectedEmojis.contains(emoji),
+                                  onTap: () => onReaction(emoji),
+                                ),
+                              ),
+                            ),
+                            Expanded(
+                              child: GestureDetector(
+                                key: const Key('emoji_picker_button'),
+                                onTap: onEmojiPicker,
+                                child: Center(
+                                  child: WnIcon(
+                                    WnIcons.addEmoji,
+                                    color: colors.backgroundContentPrimary,
+                                    size: 20.sp,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        SizedBox(height: _modalSectionSpacing.h),
+                        if (onReply != null) ...[
+                          WnButton(
+                            key: const Key('reply_button'),
+                            text: context.l10n.reply,
+                            type: WnButtonType.outline,
+                            size: WnButtonSize.medium,
+                            trailingIcon: WnIcons.reply,
+                            onPressed: onReply,
+                          ),
+                          Gap(_modalButtonSpacing.h),
+                        ],
+                        WnButton(
+                          key: const Key('copy_button'),
+                          text: context.l10n.copyMessage,
+                          type: WnButtonType.outline,
+                          size: WnButtonSize.medium,
+                          trailingIcon: WnIcons.copy,
+                          onPressed: () {
+                            Clipboard.setData(ClipboardData(text: message.content));
+                            Navigator.of(context).pop();
+                          },
+                        ),
+                        if (onDelete != null) ...[
+                          Gap(_modalButtonSpacing.h),
+                          WnButton(
+                            key: const Key('delete_button'),
+                            text: context.l10n.delete,
+                            type: WnButtonType.destructive,
+                            size: WnButtonSize.medium,
+                            trailingIcon: WnIcons.trashCan,
+                            onPressed: onDelete,
+                          ),
+                        ],
+                      ],
+                    );
+                  },
                 ),
-              ],
-            ),
-            SizedBox(height: 16.h),
-            if (onReply != null)
-              WnButton(
-                key: const Key('reply_button'),
-                text: context.l10n.reply,
-                type: WnButtonType.outline,
-                size: WnButtonSize.medium,
-                trailingIcon: WnIcons.reply,
-                onPressed: onReply,
               ),
-            Gap(8.h),
-            WnButton(
-              key: const Key('copy_button'),
-              text: context.l10n.copyMessage,
-              type: WnButtonType.outline,
-              size: WnButtonSize.medium,
-              trailingIcon: WnIcons.copy,
-              onPressed: () {
-                Clipboard.setData(ClipboardData(text: message.content));
-                Navigator.of(context).pop();
-              },
             ),
-            if (onDelete != null) ...[
-              Gap(8.h),
-              WnButton(
-                key: const Key('delete_button'),
-                text: context.l10n.delete,
-                type: WnButtonType.destructive,
-                size: WnButtonSize.medium,
-                trailingIcon: WnIcons.trashCan,
-                onPressed: onDelete,
-              ),
-            ],
-          ],
-        ),
+          );
+        },
       ),
     );
   }

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -26,6 +26,9 @@ class ChatMessageBubble extends StatelessWidget {
   final bool showAvatar;
   final bool showTail;
   final bool isGroupChat;
+  final int? contentMaxLines;
+  final double bubbleWidthFactor;
+  final bool forceTightHeight;
 
   const ChatMessageBubble({
     super.key,
@@ -43,6 +46,9 @@ class ChatMessageBubble extends StatelessWidget {
     this.showAvatar = false,
     this.showTail = true,
     this.isGroupChat = false,
+    this.contentMaxLines,
+    this.bubbleWidthFactor = 0.8,
+    this.forceTightHeight = false,
   });
 
   ChatStatusType? get _deliveryStatusType {
@@ -135,6 +141,9 @@ class ChatMessageBubble extends StatelessWidget {
       ),
       deliveryStatus: isOwnMessage ? _deliveryStatusType : null,
       onStatusTap: _deliveryStatusType == ChatStatusType.failed ? onRetry : null,
+      contentMaxLines: contentMaxLines,
+      bubbleWidthFactor: bubbleWidthFactor,
+      forceTightHeight: forceTightHeight,
     );
   }
 }

--- a/lib/widgets/wn_message_bubble.dart
+++ b/lib/widgets/wn_message_bubble.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -11,6 +13,8 @@ export 'package:whitenoise/src/rust/api/messages.dart' show EmojiReaction;
 const _timestampMinPadding = 16.0;
 const _chatStatusW = 18.0;
 const _chatStatusGap = 4.0;
+const _truncatedStatusTopGap = 2.0;
+const _truncatedStatusBottomReserve = 6.0;
 
 enum MessageDirection { incoming, outgoing }
 
@@ -30,6 +34,7 @@ class _TextWithTimestamp extends StatelessWidget {
     required this.showDeliveryStatus,
     this.deliveryStatus,
     this.onStatusTap,
+    this.maxLines,
   });
 
   final String content;
@@ -40,6 +45,7 @@ class _TextWithTimestamp extends StatelessWidget {
   final bool showDeliveryStatus;
   final ChatStatusType? deliveryStatus;
   final VoidCallback? onStatusTap;
+  final int? maxLines;
 
   @override
   Widget build(BuildContext context) {
@@ -51,6 +57,7 @@ class _TextWithTimestamp extends StatelessWidget {
     );
 
     Widget statusRow = Row(
+      key: const Key('message_status_row'),
       mainAxisSize: MainAxisSize.min,
       children: [
         Text(timestamp, style: tsStyle),
@@ -67,6 +74,122 @@ class _TextWithTimestamp extends StatelessWidget {
         behavior: HitTestBehavior.opaque,
         onTap: onStatusTap,
         child: statusRow,
+      );
+    }
+
+    if (maxLines != null) {
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          final textMaxWidth = (constraints.maxWidth - reservedWidth).clamp(0.0, double.infinity);
+          final painter = TextPainter(
+            text: TextSpan(text: content, style: textStyle),
+            textDirection: Directionality.of(context),
+            maxLines: maxLines,
+            ellipsis: '\u2026',
+            textScaler: MediaQuery.textScalerOf(context),
+          );
+          try {
+            painter.layout(maxWidth: textMaxWidth);
+            final isTruncated = painter.didExceedMaxLines;
+            if (isTruncated) {
+              final textLinePainter = TextPainter(
+                text: TextSpan(text: ' ', style: textStyle),
+                textDirection: Directionality.of(context),
+                textScaler: MediaQuery.textScalerOf(context),
+              );
+              final statusLinePainter = TextPainter(
+                text: TextSpan(text: timestamp, style: tsStyle),
+                textDirection: Directionality.of(context),
+                textScaler: MediaQuery.textScalerOf(context),
+              );
+              final (:lineHeight, :statusHeight, :effectiveMaxLines) = (() {
+                try {
+                  textLinePainter.layout();
+                  statusLinePainter.layout();
+                  final lineHeight = math.max(textLinePainter.preferredLineHeight, 1.0);
+                  final statusHeight = math.max(
+                    statusLinePainter.preferredLineHeight,
+                    (showDeliveryStatus && isOutgoing) ? _chatStatusW.h : 0.0,
+                  );
+                  final availableTextHeight = constraints.maxHeight.isFinite
+                      ? math.max(
+                          0.0,
+                          constraints.maxHeight -
+                              statusHeight -
+                              _truncatedStatusTopGap.h -
+                              _truncatedStatusBottomReserve.h,
+                        )
+                      : double.infinity;
+                  final linesByHeight = availableTextHeight.isFinite
+                      ? (availableTextHeight / lineHeight).floor()
+                      : maxLines!;
+                  final effectiveMaxLines = math.max(1, math.min(maxLines!, linesByHeight) - 1);
+                  return (
+                    lineHeight: lineHeight,
+                    statusHeight: statusHeight,
+                    effectiveMaxLines: effectiveMaxLines,
+                  );
+                } finally {
+                  textLinePainter.dispose();
+                  statusLinePainter.dispose();
+                }
+              })();
+              if (constraints.maxHeight.isFinite) {
+                return SizedBox(
+                  height: constraints.maxHeight,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          content,
+                          style: textStyle,
+                          maxLines: effectiveMaxLines,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      SizedBox(height: _truncatedStatusTopGap.h),
+                      Align(alignment: Alignment.centerRight, child: statusRow),
+                    ],
+                  ),
+                );
+              }
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    content,
+                    style: textStyle,
+                    maxLines: effectiveMaxLines,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  SizedBox(height: _truncatedStatusTopGap.h),
+                  Align(alignment: Alignment.centerRight, child: statusRow),
+                ],
+              );
+            }
+            final isSingleLine = painter.computeLineMetrics().length <= 1;
+            return Stack(
+              alignment: isOutgoing && isSingleLine ? Alignment.topRight : Alignment.topLeft,
+              children: [
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(text: content, style: textStyle),
+                      WidgetSpan(child: SizedBox(width: reservedWidth)),
+                    ],
+                  ),
+                  maxLines: maxLines,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Positioned(bottom: 0, right: 0, child: statusRow),
+              ],
+            );
+          } finally {
+            painter.dispose();
+          }
+        },
       );
     }
 
@@ -215,6 +338,7 @@ class _BubbleContent extends StatelessWidget {
     required this.showDeliveryStatus,
     this.deliveryStatus,
     this.onStatusTap,
+    this.contentMaxLines,
   });
 
   final Color bubbleColor;
@@ -239,9 +363,11 @@ class _BubbleContent extends StatelessWidget {
   final bool showDeliveryStatus;
   final ChatStatusType? deliveryStatus;
   final VoidCallback? onStatusTap;
+  final int? contentMaxLines;
 
   Widget _buildTimestampRow() {
     Widget row = Row(
+      key: const Key('message_status_row'),
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         Text(timestamp!, style: tsStyle),
@@ -266,13 +392,15 @@ class _BubbleContent extends StatelessWidget {
   Widget build(BuildContext context) {
     final colors = context.colors;
 
+    final padding = EdgeInsets.only(
+      left: 10.w,
+      right: 10.w,
+      top: 10.h,
+      bottom: 12.h,
+    );
+
     return Container(
-      padding: EdgeInsets.only(
-        left: 10.w,
-        right: 10.w,
-        top: 10.h,
-        bottom: 12.h,
-      ),
+      padding: padding,
       decoration: BoxDecoration(color: bubbleColor, borderRadius: borderRadius),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -304,9 +432,15 @@ class _BubbleContent extends StatelessWidget {
               showDeliveryStatus: showDeliveryStatus,
               deliveryStatus: deliveryStatus,
               onStatusTap: onStatusTap,
+              maxLines: contentMaxLines,
             )
           else if (hasText)
-            Text(content!, style: textStyle)
+            Text(
+              content!,
+              style: textStyle,
+              maxLines: contentMaxLines,
+              overflow: contentMaxLines != null ? TextOverflow.ellipsis : TextOverflow.clip,
+            )
           else if (hasTimestamp) ...[
             SizedBox(height: 2.h),
             _buildTimestampRow(),
@@ -514,6 +648,9 @@ class WnMessageBubble extends StatelessWidget {
   final BubbleLeadingVariant leadingVariant;
   final ChatStatusType? deliveryStatus;
   final VoidCallback? onStatusTap;
+  final int? contentMaxLines;
+  final double bubbleWidthFactor;
+  final bool forceTightHeight;
 
   const WnMessageBubble({
     super.key,
@@ -536,12 +673,15 @@ class WnMessageBubble extends StatelessWidget {
     this.leadingVariant = BubbleLeadingVariant.none,
     this.deliveryStatus,
     this.onStatusTap,
+    this.contentMaxLines,
+    this.bubbleWidthFactor = 0.8,
+    this.forceTightHeight = false,
   });
 
   bool get _isOutgoing => direction == MessageDirection.outgoing;
 
-  static Widget _wrapBubbleInner({required bool hasMedia, required Widget child}) {
-    if (hasMedia) return child;
+  static Widget _wrapBubbleInner({required bool useIntrinsicWidth, required Widget child}) {
+    if (!useIntrinsicWidth) return child;
     return IntrinsicWidth(child: child);
   }
 
@@ -614,17 +754,21 @@ class WnMessageBubble extends StatelessWidget {
       showDeliveryStatus: !isDeleted,
       deliveryStatus: actualDeliveryStatus,
       onStatusTap: isDeleted ? null : onStatusTap,
+      contentMaxLines: contentMaxLines,
     );
 
     return LayoutBuilder(
       builder: (context, constraints) {
-        final baseMaxBubbleWidth = (constraints.maxWidth - avatarColW - leadingIndent) * 0.8;
+        final bottomMargin = showTail ? 12.h : 4.h;
+
+        final baseMaxBubbleWidth =
+            (constraints.maxWidth - avatarColW - leadingIndent) * bubbleWidthFactor;
         final maxBubbleWidth = _isOutgoing && !showTail
             ? baseMaxBubbleWidth - tailOverhang
             : baseMaxBubbleWidth;
-
         final bubble = Align(
           alignment: _isOutgoing ? Alignment.centerRight : Alignment.centerLeft,
+          heightFactor: (forceTightHeight || contentMaxLines != null) ? 1 : null,
           child: ConstrainedBox(
             constraints: BoxConstraints(maxWidth: maxBubbleWidth),
             child: isDeleted
@@ -645,7 +789,7 @@ class WnMessageBubble extends StatelessWidget {
                       ),
                     ),
                     child: _wrapBubbleInner(
-                      hasMedia: actualMediaContent != null,
+                      useIntrinsicWidth: actualMediaContent == null && contentMaxLines == null,
                       child: bubbleContent,
                     ),
                   )
@@ -656,7 +800,7 @@ class WnMessageBubble extends StatelessWidget {
                       right: _isOutgoing && showTail ? tailOverhang : 0,
                     ),
                     child: _wrapBubbleInner(
-                      hasMedia: mediaContent != null,
+                      useIntrinsicWidth: mediaContent == null && contentMaxLines == null,
                       child: _BubbleInner(
                         onHorizontalDragEnd: onHorizontalDragEnd,
                         onLongPress: onLongPress,
@@ -672,8 +816,6 @@ class WnMessageBubble extends StatelessWidget {
                   ),
           ),
         );
-
-        final bottomMargin = showTail ? 12.h : 4.h;
 
         if (!hasAvatar) {
           final trailingIndent = _isOutgoing && !showTail ? tailOverhang : 0.0;

--- a/test/screens/key_package_management_screen_test.dart
+++ b/test/screens/key_package_management_screen_test.dart
@@ -356,6 +356,18 @@ void main() {
       expect(effect.type, ScrollEdgeEffectType.slate);
     });
 
+    testWidgets('handles scroll notifications while list is scrolled', (tester) async {
+      mockApi.keyPackages = _manyKeyPackages(20);
+
+      await pumpScreen(tester);
+      await tester.pumpAndSettle();
+
+      await tester.drag(find.byType(ListView).first, const Offset(0, -300));
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+    });
+
     testWidgets('no error notice during initial loading', (tester) async {
       mockApi.fetchCompleter = Completer<List<FlutterEvent>>();
 

--- a/test/screens/message_actions_screen_test.dart
+++ b/test/screens/message_actions_screen_test.dart
@@ -4,12 +4,16 @@ import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:gap/gap.dart';
 import 'package:whitenoise/hooks/use_chat_messages.dart' show ChatMessageQuoteData;
 import 'package:whitenoise/l10n/generated/app_localizations.dart';
 import 'package:whitenoise/screens/message_actions_screen.dart';
+import 'package:whitenoise/src/rust/api/media_files.dart';
 import 'package:whitenoise/src/rust/api/messages.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart';
+import 'package:whitenoise/widgets/chat_message_bubble.dart';
 import 'package:whitenoise/widgets/wn_message_bubble.dart';
+import 'package:whitenoise/widgets/wn_slate.dart';
 import 'package:whitenoise/widgets/wn_system_notice.dart';
 
 import '../test_helpers.dart';
@@ -34,6 +38,8 @@ ChatMessage _createTestMessage({
   ReactionSummary? reactions,
   bool isReply = false,
   String? replyToId,
+  DeliveryStatus? deliveryStatus,
+  List<MediaFile> mediaAttachments = const [],
 }) {
   return ChatMessage(
     id: id,
@@ -46,13 +52,134 @@ ChatMessage _createTestMessage({
     isDeleted: false,
     contentTokens: const [],
     reactions: reactions ?? const ReactionSummary(byEmoji: [], userReactions: []),
-    mediaAttachments: const [],
+    mediaAttachments: mediaAttachments,
     kind: 9,
+    deliveryStatus: deliveryStatus,
   );
 }
 
+MediaFile _mediaFile(String id) => MediaFile(
+  id: id,
+  mlsGroupId: testGroupId,
+  accountPubkey: testPubkeyA,
+  filePath: '/test/path/$id.jpg',
+  originalFileHash: 'hash$id',
+  encryptedFileHash: 'encrypted$id',
+  mimeType: 'image/jpeg',
+  mediaType: 'image',
+  blossomUrl: 'https://example.com/$id',
+  nostrKey: 'nostr$id',
+  createdAt: DateTime(2024),
+);
+
 void main() {
   group('MessageActionsModal', () {
+    testWidgets('does not stretch to max height for short messages', (tester) async {
+      await mountWidget(
+        MessageActionsModal(
+          message: _createTestMessage(content: 'short'),
+          isOwnMessage: true,
+          onReaction: (_) {},
+          onEmojiPicker: () {},
+          currentUserPubkey: testPubkeyA,
+        ),
+        tester,
+      );
+
+      final viewportHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+      // Intentionally mirrors MessageActionsModal viewport inset (96.h top + 96.h bottom).
+      final expectedMaxHeight = viewportHeight - (2 * 96.h);
+      final slateHeight = tester.getSize(find.byType(WnSlate)).height;
+
+      expect(slateHeight, lessThan(expectedMaxHeight - 1));
+    });
+
+    testWidgets('limits preview by modal max height and truncates long text', (tester) async {
+      final veryLongContent = List.filled(500, 'very-long-message-token').join(' ');
+
+      await mountWidget(
+        MessageActionsModal(
+          message: _createTestMessage(
+            content: veryLongContent,
+            deliveryStatus: const DeliveryStatus.failed(reason: 'timeout'),
+          ),
+          isOwnMessage: true,
+          onReaction: (_) {},
+          onEmojiPicker: () {},
+          currentUserPubkey: testPubkeyA,
+        ),
+        tester,
+      );
+
+      final viewportHeight = tester.view.physicalSize.height / tester.view.devicePixelRatio;
+      // Intentionally mirrors MessageActionsModal viewport inset (96.h top + 96.h bottom).
+      final expectedMaxHeight = viewportHeight - (2 * 96.h);
+
+      final constrainedBoxes = tester.widgetList<ConstrainedBox>(
+        find.descendant(
+          of: find.byType(MessageActionsModal),
+          matching: find.byType(ConstrainedBox),
+        ),
+      );
+      final hasExpectedMaxHeight = constrainedBoxes.any(
+        (box) =>
+            box.constraints.maxHeight.isFinite &&
+            (box.constraints.maxHeight - expectedMaxHeight).abs() < 0.01,
+      );
+      expect(hasExpectedMaxHeight, isTrue);
+
+      final longMessageFinder = find.descendant(
+        of: find.byType(MessageActionsModal),
+        matching: find.textContaining('very-long-message-token', findRichText: true),
+      );
+      expect(longMessageFinder, findsAtLeastNWidgets(1));
+
+      final longMessageWidgets = longMessageFinder
+          .evaluate()
+          .map((element) => element.widget)
+          .toList();
+      final hasEllipsizedText =
+          longMessageWidgets.whereType<Text>().any(
+            (text) => text.maxLines != null && text.overflow == TextOverflow.ellipsis,
+          ) ||
+          longMessageWidgets.whereType<RichText>().any(
+            (text) => text.maxLines != null && text.overflow == TextOverflow.ellipsis,
+          );
+      expect(hasEllipsizedText, isTrue);
+      expect(find.byKey(const Key('message_status_row')), findsOneWidget);
+    });
+
+    testWidgets('reduces modal max height when bottom inset is provided', (tester) async {
+      final longContent = List.filled(500, 'very-long-message-token').join(' ');
+
+      await mountWidget(
+        MessageActionsModal(
+          message: _createTestMessage(content: longContent),
+          isOwnMessage: true,
+          onReaction: (_) {},
+          onEmojiPicker: () {},
+          currentUserPubkey: testPubkeyA,
+        ),
+        tester,
+      );
+      final fullHeight = tester.getSize(find.byType(WnSlate)).height;
+
+      await mountWidget(
+        MessageActionsModal(
+          message: _createTestMessage(content: longContent),
+          isOwnMessage: true,
+          onReaction: (_) {},
+          onEmojiPicker: () {},
+          currentUserPubkey: testPubkeyA,
+          bottomInset: 200.h,
+        ),
+        tester,
+      );
+      final insetHeight = tester.getSize(find.byType(WnSlate)).height;
+
+      expect(insetHeight, lessThan(fullHeight));
+    });
+
     testWidgets('displays message content', (tester) async {
       await mountWidget(
         MessageActionsModal(
@@ -204,6 +331,147 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(replyCalled, isTrue);
+      });
+    });
+
+    group('modal spacing and preview constraints', () {
+      testWidgets('does not add button gap before copy when reply is absent', (tester) async {
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(),
+            isOwnMessage: false,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+          ),
+          tester,
+        );
+
+        final modalSubtree = find.descendant(
+          of: find.byType(MessageActionsModal),
+          matching: find.byType(Gap),
+        );
+        expect(modalSubtree, findsNothing);
+      });
+
+      testWidgets('adds exactly one button gap between reply and copy when reply is present', (
+        tester,
+      ) async {
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(),
+            isOwnMessage: false,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+            onReply: () {},
+          ),
+          tester,
+        );
+
+        final gaps = tester
+            .widgetList<Gap>(
+              find.descendant(
+                of: find.byType(MessageActionsModal),
+                matching: find.byType(Gap),
+              ),
+            )
+            .toList();
+        expect(gaps, hasLength(1));
+      });
+
+      testWidgets('does not constrain preview lines for short plain text message', (tester) async {
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(content: 'short plain text'),
+            isOwnMessage: true,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+          ),
+          tester,
+        );
+
+        final bubble = tester.widget<ChatMessageBubble>(find.byType(ChatMessageBubble));
+        expect(bubble.contentMaxLines, isNull);
+      });
+
+      testWidgets('constrains preview lines for long message', (tester) async {
+        final longContent = List.filled(120, 'token').join(' ');
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(content: longContent),
+            isOwnMessage: true,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+          ),
+          tester,
+        );
+
+        final bubble = tester.widget<ChatMessageBubble>(find.byType(ChatMessageBubble));
+        expect(bubble.contentMaxLines, isNotNull);
+        expect(bubble.contentMaxLines!, greaterThan(0));
+      });
+
+      testWidgets('constrains preview lines when message contains media', (tester) async {
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(
+              content: 'caption',
+              mediaAttachments: [_mediaFile('1')],
+            ),
+            isOwnMessage: true,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+          ),
+          tester,
+        );
+
+        final bubble = tester.widget<ChatMessageBubble>(find.byType(ChatMessageBubble));
+        expect(bubble.contentMaxLines, isNotNull);
+        expect(bubble.contentMaxLines!, greaterThan(0));
+      });
+
+      testWidgets('constrains preview lines for short multiline message', (tester) async {
+        final multilineContent = List.filled(16, 'a').join('\n');
+        await mountWidget(
+          MessageActionsModal(
+            message: _createTestMessage(content: multilineContent),
+            isOwnMessage: true,
+            onReaction: (_) {},
+            onEmojiPicker: () {},
+            currentUserPubkey: testPubkeyA,
+          ),
+          tester,
+        );
+
+        final bubble = tester.widget<ChatMessageBubble>(find.byType(ChatMessageBubble));
+        expect(bubble.contentMaxLines, isNotNull);
+        expect(bubble.contentMaxLines!, greaterThan(0));
+      });
+
+      testWidgets('skips preview bubble when no vertical space remains', (tester) async {
+        await mountWidget(
+          SizedBox(
+            height: 120,
+            child: MessageActionsModal(
+              message: _createTestMessage(
+                id: 'tight-space-msg',
+                content: 'preview',
+              ),
+              isOwnMessage: true,
+              onReaction: (_) {},
+              onEmojiPicker: () {},
+              currentUserPubkey: testPubkeyA,
+            ),
+          ),
+          tester,
+        );
+
+        expect(find.byType(ChatMessageBubble), findsNothing);
+        expect(tester.takeException(), isNull);
       });
     });
 
@@ -987,13 +1255,14 @@ void main() {
       Future<void> openEmojiPicker(
         WidgetTester tester, {
         Future<void> Function(String)? onAddReaction,
+        ChatMessage? message,
       }) async {
         await mountShowTest(
           tester,
           builder: (context) => ElevatedButton(
             onPressed: () => MessageActionsScreen.show(
               context,
-              message: _createTestMessage(),
+              message: message ?? _createTestMessage(),
               pubkey: testPubkeyA,
               onAddReaction: onAddReaction ?? (_) async {},
               onRemoveReaction: (_) async {},
@@ -1048,6 +1317,19 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.textContaining('Test message content'), findsOneWidget);
+      });
+
+      testWidgets('long message does not overflow when emoji picker is open', (tester) async {
+        final longMessage = _createTestMessage(
+          content: List.filled(800, 'very-long-message-token').join(' '),
+          deliveryStatus: const DeliveryStatus.failed(reason: 'timeout'),
+        );
+
+        await openEmojiPicker(tester, message: longMessage);
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('very-long-message-token', findRichText: true), findsWidgets);
+        expect(tester.takeException(), isNull);
       });
 
       testWidgets('selecting emoji invokes onAddReaction and closes screen', (tester) async {

--- a/test/screens/start_chat_screen_test.dart
+++ b/test/screens/start_chat_screen_test.dart
@@ -410,6 +410,36 @@ void main() {
         expect(find.byType(WnSystemNotice), findsOneWidget);
         expect(find.text('Failed to start chat. Please try again.'), findsOneWidget);
       });
+
+      testWidgets('does not navigate when widget unmounted before DM creation completes', (
+        tester,
+      ) async {
+        _api.createGroupCompleter = Completer<Group>();
+        await pumpStartChatScreen(tester, userPubkey: _otherPubkey);
+
+        await tester.tap(find.byKey(const Key('start_chat_button')));
+        await tester.pump();
+
+        await tester.tap(find.byKey(const Key('slate_back_button')));
+        await tester.pumpAndSettle();
+        expect(find.text('Start new chat'), findsNothing);
+
+        _api.createGroupCompleter!.complete(
+          Group(
+            mlsGroupId: testGroupId,
+            nostrGroupId: testNostrGroupId,
+            name: '',
+            description: '',
+            adminPubkeys: const [],
+            epoch: BigInt.zero,
+            state: GroupState.active,
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(tester.takeException(), isNull);
+      });
     });
 
     group('back button', () {

--- a/test/widgets/wn_message_bubble_test.dart
+++ b/test/widgets/wn_message_bubble_test.dart
@@ -566,6 +566,73 @@ void main() {
 
         expect(find.textContaining('12:29', findRichText: true), findsNothing);
       });
+
+      testWidgets('renders non-truncated maxLines path without overflow', (tester) async {
+        await mountWidget(
+          const SizedBox(
+            width: 260,
+            child: WnMessageBubble(
+              direction: MessageDirection.outgoing,
+              isDeleted: false,
+              content: 'Short content',
+              timestamp: '12:00',
+              contentMaxLines: 3,
+            ),
+          ),
+          tester,
+        );
+
+        expect(find.text('Short content'), findsOneWidget);
+        expect(find.byKey(const Key('message_status_row')), findsOneWidget);
+      });
+
+      testWidgets('renders truncated maxLines path with finite height constraints', (tester) async {
+        final veryLongText = List.filled(300, 'long-token').join(' ');
+        await mountWidget(
+          SizedBox(
+            width: 280,
+            height: 220,
+            child: WnMessageBubble(
+              direction: MessageDirection.outgoing,
+              isDeleted: false,
+              content: veryLongText,
+              timestamp: '12:00',
+              contentMaxLines: 6,
+              forceTightHeight: true,
+            ),
+          ),
+          tester,
+        );
+
+        final textWidgets = tester.widgetList<Text>(find.byType(Text));
+        final hasEllipsisText = textWidgets.any(
+          (t) => t.maxLines != null && t.overflow == TextOverflow.ellipsis,
+        );
+        expect(hasEllipsisText, isTrue);
+        expect(find.byKey(const Key('message_status_row')), findsOneWidget);
+      });
+
+      testWidgets('uses finite-height truncated layout without rendering errors', (tester) async {
+        final veryLongText = List.filled(800, 'long-token').join(' ');
+        await mountWidget(
+          SizedBox(
+            width: 180,
+            height: 110,
+            child: WnMessageBubble(
+              direction: MessageDirection.outgoing,
+              isDeleted: false,
+              content: veryLongText,
+              timestamp: '12:00',
+              contentMaxLines: 2,
+              forceTightHeight: true,
+            ),
+          ),
+          tester,
+        );
+
+        expect(find.byKey(const Key('message_status_row')), findsOneWidget);
+        expect(tester.takeException(), isNull);
+      });
     });
 
     group('chat status', () {
@@ -1341,6 +1408,27 @@ void main() {
           tester,
         );
         expect(find.byKey(const Key('deleted_bubble_border')), findsNothing);
+      });
+
+      testWidgets('deleted bubble shape supports inner/outer paths and scale', (tester) async {
+        await mountWidget(
+          const WnMessageBubble(
+            direction: MessageDirection.incoming,
+            isDeleted: true,
+            deletedLabel: 'Deleted',
+            showTail: true,
+          ),
+          tester,
+        );
+
+        final container = tester.widget<Container>(find.byKey(const Key('deleted_bubble_border')));
+        final decoration = container.decoration! as ShapeDecoration;
+        final shape = decoration.shape;
+        const rect = Rect.fromLTWH(0, 0, 120, 60);
+
+        expect(shape.getInnerPath(rect).getBounds().isEmpty, isFalse);
+        expect(shape.getOuterPath(rect).getBounds().isEmpty, isFalse);
+        expect(shape.scale(0.5), isA<ShapeBorder>());
       });
     });
 


### PR DESCRIPTION
## Description

This PR fixes long message handling in the message actions modal.

The primary change ensures long messages no longer break the modal layout and are displayed safely within bounds.  
Additional adjustments were made only to resolve regressions that appeared during implementation.

Related:https://github.com/marmot-protocol/whitenoise/issues/485

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [x] 🧪 Tests

## Checklist

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter message-preview sizing in the actions modal: modal height now respects viewport and emoji-picker inset, reserves controls space, and truncates preview only when necessary so timestamps/status remain visible.
  * Message bubbles adapt width/height to better handle long content, avoiding overflow while preserving timestamp/status visibility.

* **Tests**
  * Added widget tests for modal preview constraints, truncation behavior, and emoji-picker interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->