### PR TITLE
fix: skip comments on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         path: test-failures
 
     - name: Comment PR with test failures
-      if: github.event_name == 'pull_request' && steps.download_failures.outcome == 'success'
+      if: github.event_name == 'pull_request' && steps.download_failures.outcome == 'success' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       with:
         script: |
@@ -422,7 +422,7 @@ jobs:
         exit 1
 
     - name: Comment PR with coverage
-      if: github.event_name == 'pull_request' && always() && steps.master_coverage.outputs.baseline != '0'
+      if: github.event_name == 'pull_request' && always() && steps.master_coverage.outputs.baseline != '0' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       env:
         COVERAGE_PERCENTAGE: ${{ steps.coverage.outputs.percentage }}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

We only give read access for forks, no write access, so the comments in ci workflow are making some steps fail in PRs opened from forks. This tiny change should be enough (we only comment for PRs opened from the same repo)


This was happening in https://github.com/marmot-protocol/whitenoise/pull/531



<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## Checklist

<!-- Please make sure you've done the following before submitting your PR: -->

- [ ] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)
