### PR TITLE
feat: expose removed_at and RemovedFromGroup trigger in Rust bridge

### DIFF
--- a/lib/hooks/use_chat_list.dart
+++ b/lib/hooks/use_chat_list.dart
@@ -55,6 +55,8 @@ ChatListResult useChatList(String pubkey) {
                     chatMap.value.remove(id);
                     chatMap.value[id] = update.item;
                   }
+                case ChatListUpdateTrigger.removedFromGroup:
+                  chatMap.value[id] = update.item;
               }
               return chatMap.value;
             },

--- a/lib/src/rust/api/chat_list.dart
+++ b/lib/src/rust/api/chat_list.dart
@@ -109,6 +109,9 @@ enum ChatListUpdateTrigger {
 
   /// The chat's archive status changed.
   chatArchiveChanged,
+
+  /// This account was removed from the group by an admin.
+  removedFromGroup,
 }
 
 class ChatSummary {
@@ -145,6 +148,10 @@ class ChatSummary {
   /// When this chat was archived, if at all.
   final DateTime? archivedAt;
 
+  /// When this account was removed from the group by an admin, if at all.
+  /// `Some` means the group is read-only; the user must archive/delete to hide it.
+  final DateTime? removedAt;
+
   /// Number of unread messages in this chat
   final BigInt unreadCount;
 
@@ -168,6 +175,7 @@ class ChatSummary {
     required this.pendingConfirmation,
     this.welcomerPubkey,
     this.archivedAt,
+    this.removedAt,
     required this.unreadCount,
     this.pinOrder,
     this.dmPeerPubkey,
@@ -185,6 +193,7 @@ class ChatSummary {
       pendingConfirmation.hashCode ^
       welcomerPubkey.hashCode ^
       archivedAt.hashCode ^
+      removedAt.hashCode ^
       unreadCount.hashCode ^
       pinOrder.hashCode ^
       dmPeerPubkey.hashCode;
@@ -204,6 +213,7 @@ class ChatSummary {
           pendingConfirmation == other.pendingConfirmation &&
           welcomerPubkey == other.welcomerPubkey &&
           archivedAt == other.archivedAt &&
+          removedAt == other.removedAt &&
           unreadCount == other.unreadCount &&
           pinOrder == other.pinOrder &&
           dmPeerPubkey == other.dmPeerPubkey;

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -5042,7 +5042,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   ChatSummary dco_decode_chat_summary(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 13) throw Exception('unexpected arr length: expect 13 but see ${arr.length}');
+    if (arr.length != 14) throw Exception('unexpected arr length: expect 14 but see ${arr.length}');
     return ChatSummary(
       mlsGroupId: dco_decode_String(arr[0]),
       name: dco_decode_opt_String(arr[1]),
@@ -5054,9 +5054,10 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pendingConfirmation: dco_decode_bool(arr[7]),
       welcomerPubkey: dco_decode_opt_String(arr[8]),
       archivedAt: dco_decode_opt_box_autoadd_Chrono_Utc(arr[9]),
-      unreadCount: dco_decode_u_64(arr[10]),
-      pinOrder: dco_decode_opt_box_autoadd_i_64(arr[11]),
-      dmPeerPubkey: dco_decode_opt_String(arr[12]),
+      removedAt: dco_decode_opt_box_autoadd_Chrono_Utc(arr[10]),
+      unreadCount: dco_decode_u_64(arr[11]),
+      pinOrder: dco_decode_opt_box_autoadd_i_64(arr[12]),
+      dmPeerPubkey: dco_decode_opt_String(arr[13]),
     );
   }
 
@@ -6560,6 +6561,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     final var_pendingConfirmation = sse_decode_bool(deserializer);
     final var_welcomerPubkey = sse_decode_opt_String(deserializer);
     final var_archivedAt = sse_decode_opt_box_autoadd_Chrono_Utc(deserializer);
+    final var_removedAt = sse_decode_opt_box_autoadd_Chrono_Utc(deserializer);
     final var_unreadCount = sse_decode_u_64(deserializer);
     final var_pinOrder = sse_decode_opt_box_autoadd_i_64(deserializer);
     final var_dmPeerPubkey = sse_decode_opt_String(deserializer);
@@ -6574,6 +6576,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
       pendingConfirmation: var_pendingConfirmation,
       welcomerPubkey: var_welcomerPubkey,
       archivedAt: var_archivedAt,
+      removedAt: var_removedAt,
       unreadCount: var_unreadCount,
       pinOrder: var_pinOrder,
       dmPeerPubkey: var_dmPeerPubkey,
@@ -8445,6 +8448,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
     sse_encode_bool(self.pendingConfirmation, serializer);
     sse_encode_opt_String(self.welcomerPubkey, serializer);
     sse_encode_opt_box_autoadd_Chrono_Utc(self.archivedAt, serializer);
+    sse_encode_opt_box_autoadd_Chrono_Utc(self.removedAt, serializer);
     sse_encode_u_64(self.unreadCount, serializer);
     sse_encode_opt_box_autoadd_i_64(self.pinOrder, serializer);
     sse_encode_opt_String(self.dmPeerPubkey, serializer);

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5367,7 +5367,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=60770fdb15b2fb86327a926918d02a64612fa1cb#60770fdb15b2fb86327a926918d02a64612fa1cb"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=b5c9e8b#b5c9e8bd7539f83c7c878ca9d67fcdb16ca580ec"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5415,7 +5415,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=60770fdb15b2fb86327a926918d02a64612fa1cb#60770fdb15b2fb86327a926918d02a64612fa1cb"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=b5c9e8b#b5c9e8bd7539f83c7c878ca9d67fcdb16ca580ec"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "60770fdb15b2fb86327a926918d02a64612fa1cb" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "b5c9e8b" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/chat_list.rs
+++ b/rust/src/api/chat_list.rs
@@ -38,6 +38,9 @@ pub struct ChatSummary {
     pub welcomer_pubkey: Option<String>,
     /// When this chat was archived, if at all.
     pub archived_at: Option<DateTime<Utc>>,
+    /// When this account was removed from the group by an admin, if at all.
+    /// `Some` means the group is read-only; the user must archive/delete to hide it.
+    pub removed_at: Option<DateTime<Utc>>,
     /// Number of unread messages in this chat
     pub unread_count: u64,
     /// Pin order for chat list sorting.
@@ -64,6 +67,7 @@ impl From<WhitenoiseChatListItem> for ChatSummary {
             pending_confirmation: item.pending_confirmation,
             welcomer_pubkey: item.welcomer_pubkey.map(|pk| pk.to_hex()),
             archived_at: item.archived_at,
+            removed_at: item.removed_at,
             unread_count: item.unread_count as u64,
             pin_order: item.pin_order,
             dm_peer_pubkey: item.dm_peer_pubkey.map(|pk| pk.to_hex()),
@@ -83,6 +87,8 @@ pub enum ChatListUpdateTrigger {
     LastMessageDeleted,
     /// The chat's archive status changed.
     ChatArchiveChanged,
+    /// This account was removed from the group by an admin.
+    RemovedFromGroup,
 }
 
 impl From<WhitenoiseChatListUpdateTrigger> for ChatListUpdateTrigger {
@@ -92,6 +98,7 @@ impl From<WhitenoiseChatListUpdateTrigger> for ChatListUpdateTrigger {
             WhitenoiseChatListUpdateTrigger::NewLastMessage => Self::NewLastMessage,
             WhitenoiseChatListUpdateTrigger::LastMessageDeleted => Self::LastMessageDeleted,
             WhitenoiseChatListUpdateTrigger::ChatArchiveChanged => Self::ChatArchiveChanged,
+            WhitenoiseChatListUpdateTrigger::RemovedFromGroup => Self::RemovedFromGroup,
         }
     }
 }
@@ -262,5 +269,12 @@ mod tests {
         let trigger: ChatListUpdateTrigger =
             WhitenoiseChatListUpdateTrigger::ChatArchiveChanged.into();
         assert_eq!(trigger, ChatListUpdateTrigger::ChatArchiveChanged);
+    }
+
+    #[test]
+    fn test_chat_list_update_trigger_conversion_removed_from_group() {
+        let trigger: ChatListUpdateTrigger =
+            WhitenoiseChatListUpdateTrigger::RemovedFromGroup.into();
+        assert_eq!(trigger, ChatListUpdateTrigger::RemovedFromGroup);
     }
 }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -4980,6 +4980,7 @@ impl SseDecode for crate::api::chat_list::ChatListUpdateTrigger {
             1 => crate::api::chat_list::ChatListUpdateTrigger::NewLastMessage,
             2 => crate::api::chat_list::ChatListUpdateTrigger::LastMessageDeleted,
             3 => crate::api::chat_list::ChatListUpdateTrigger::ChatArchiveChanged,
+            4 => crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup,
             _ => unreachable!("Invalid variant for ChatListUpdateTrigger: {}", inner),
         };
     }
@@ -5056,6 +5057,7 @@ impl SseDecode for crate::api::chat_list::ChatSummary {
         let mut var_pendingConfirmation = <bool>::sse_decode(deserializer);
         let mut var_welcomerPubkey = <Option<String>>::sse_decode(deserializer);
         let mut var_archivedAt = <Option<chrono::DateTime<chrono::Utc>>>::sse_decode(deserializer);
+        let mut var_removedAt = <Option<chrono::DateTime<chrono::Utc>>>::sse_decode(deserializer);
         let mut var_unreadCount = <u64>::sse_decode(deserializer);
         let mut var_pinOrder = <Option<i64>>::sse_decode(deserializer);
         let mut var_dmPeerPubkey = <Option<String>>::sse_decode(deserializer);
@@ -5070,6 +5072,7 @@ impl SseDecode for crate::api::chat_list::ChatSummary {
             pending_confirmation: var_pendingConfirmation,
             welcomer_pubkey: var_welcomerPubkey,
             archived_at: var_archivedAt,
+            removed_at: var_removedAt,
             unread_count: var_unreadCount,
             pin_order: var_pinOrder,
             dm_peer_pubkey: var_dmPeerPubkey,
@@ -6951,6 +6954,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::chat_list::ChatListUpdateTrig
             Self::NewLastMessage => 1.into_dart(),
             Self::LastMessageDeleted => 2.into_dart(),
             Self::ChatArchiveChanged => 3.into_dart(),
+            Self::RemovedFromGroup => 4.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -7037,6 +7041,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::chat_list::ChatSummary {
             self.pending_confirmation.into_into_dart().into_dart(),
             self.welcomer_pubkey.into_into_dart().into_dart(),
             self.archived_at.into_into_dart().into_dart(),
+            self.removed_at.into_into_dart().into_dart(),
             self.unread_count.into_into_dart().into_dart(),
             self.pin_order.into_into_dart().into_dart(),
             self.dm_peer_pubkey.into_into_dart().into_dart(),
@@ -8409,6 +8414,7 @@ impl SseEncode for crate::api::chat_list::ChatListUpdateTrigger {
                 crate::api::chat_list::ChatListUpdateTrigger::NewLastMessage => 1,
                 crate::api::chat_list::ChatListUpdateTrigger::LastMessageDeleted => 2,
                 crate::api::chat_list::ChatListUpdateTrigger::ChatArchiveChanged => 3,
+                crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup => 4,
                 _ => {
                     unimplemented!("");
                 }
@@ -8468,6 +8474,7 @@ impl SseEncode for crate::api::chat_list::ChatSummary {
         <bool>::sse_encode(self.pending_confirmation, serializer);
         <Option<String>>::sse_encode(self.welcomer_pubkey, serializer);
         <Option<chrono::DateTime<chrono::Utc>>>::sse_encode(self.archived_at, serializer);
+        <Option<chrono::DateTime<chrono::Utc>>>::sse_encode(self.removed_at, serializer);
         <u64>::sse_encode(self.unread_count, serializer);
         <Option<i64>>::sse_encode(self.pin_order, serializer);
         <Option<String>>::sse_encode(self.dm_peer_pubkey, serializer);

--- a/test/hooks/use_chat_list_test.dart
+++ b/test/hooks/use_chat_list_test.dart
@@ -11,6 +11,7 @@ ChatSummary _chatSummary(
   DateTime createdAt, {
   bool pendingConfirmation = false,
   DateTime? archivedAt,
+  DateTime? removedAt,
 }) => ChatSummary(
   mlsGroupId: 'mls_$id',
   name: 'Chat $id',
@@ -18,6 +19,7 @@ ChatSummary _chatSummary(
   createdAt: createdAt,
   pendingConfirmation: pendingConfirmation,
   archivedAt: archivedAt,
+  removedAt: removedAt,
   unreadCount: BigInt.zero,
 );
 
@@ -298,6 +300,32 @@ void main() {
 
         final ids = getResult().chats.map((c) => c.mlsGroupId).toList();
         expect(ids, ['mls_c2', 'mls_c1']);
+      });
+    });
+
+    group('removedFromGroup trigger', () {
+      testWidgets('keeps removed group in the list with removedAt set', (tester) async {
+        final getResult = await _pump(tester, testPubkeyA);
+
+        _api.emitInitialSnapshot([
+          _chatSummary('c1', DateTime(2024)),
+          _chatSummary('c2', DateTime(2024, 1, 2)),
+        ]);
+        await tester.pumpAndSettle();
+
+        final removedAt = DateTime(2024, 1, 3);
+        _api.emitUpdate(
+          ChatListUpdateTrigger.removedFromGroup,
+          _chatSummary('c2', DateTime(2024, 1, 2), removedAt: removedAt),
+        );
+        await tester.pumpAndSettle();
+
+        final chats = getResult().chats;
+        expect(chats.map((c) => c.mlsGroupId), containsAll(['mls_c1', 'mls_c2']));
+        expect(
+          chats.firstWhere((c) => c.mlsGroupId == 'mls_c2').removedAt,
+          removedAt,
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

Bumps the `whitenoise-rs` dependency to [`b5c9e8b`](https://github.com/marmot-protocol/whitenoise-rs/commit/b5c9e8b) and regenerates the flutter_rust_bridge bindings to expose two new items needed for the "removed from group" feature.

### `rust/src/api/chat_list.rs` (bridge source)
- **`ChatSummary.removed_at`** — `Option<DateTime<Utc>>` surfacing when an admin removed this account from the group. `Some` means the group is read-only; the user must archive or delete to hide it.
- **`ChatListUpdateTrigger::RemovedFromGroup`** — new variant so the Flutter layer can react to involuntary removal in real time, distinct from the user-initiated `ChatArchiveChanged`.

### `lib/hooks/use_chat_list.dart`
- Handles the new `ChatListUpdateTrigger.removedFromGroup` in the stream switch — updates the chat item in place (keeps it visible with the `removedAt` timestamp).

### `test/hooks/use_chat_list_test.dart`
- Test coverage for the `removedFromGroup` trigger and `removedAt` field propagation.

### What this does NOT include
UI handling (input disabling, system notice, routing, l10n) — that will be a follow-up PR.

### Depends on
- whitenoise-rs PR: https://github.com/marmot-protocol/whitenoise-rs/pull/685

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🧪 Tests

## Checklist

- [x] Run `just precommit` to ensure that formatting and linting are correct
- [ ] Updated the `CHANGELOG.md` file with your changes (if they affect the user experience)