### PR TITLE
ci: remove Blacksmith runners, use standard GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name: Check
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   test:
     name: Test (${{ matrix.shard }}/4)
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
@@ -155,7 +155,7 @@ jobs:
     name: Coverage
     if: always()
     needs: test
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
       actions: read


### PR DESCRIPTION
![marmot](https://blossom.primal.net/3c5699b4d158a20ede02261c71a5b6ffea858f9dc56781966d99bdc8ef1b28e6.jpg)

Switches all three CI jobs (check, test, coverage) from Blacksmith self-hosted runners to standard GitHub-hosted `ubuntu-latest` runners.

Blacksmith charges per-minute on top of GitHub Actions costs. Standard runners are included in the plan and handle our CI workload without issues.

## Changes

- `ci.yml`: replaced `blacksmith-4vcpu-ubuntu-2404` with `ubuntu-latest` on the check, test, and coverage jobs
- No workflow logic changed; only the `runs-on` value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates only. No user-facing changes, new features, or bug fixes are included.

* **Chores**
  * Updated CI configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->