### PR TITLE
feat: add iOS push notification support

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		A1B2C3D41ED2DC5600515810 /* ApnTokenPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D31ED2DC5600515810 /* ApnTokenPlugin.swift */; };
 		8912F7C0DCC87BC219F13553 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 643EEAEBAC9FBA327E5A2A36 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
@@ -56,6 +57,7 @@
 		643EEAEBAC9FBA327E5A2A36 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		A1B2C3D31ED2DC5600515810 /* ApnTokenPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApnTokenPlugin.swift; sourceTree = "<group>"; };
 		8D4F9B1E3A6C4D8F9A0B1C2D /* Runner.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Runner.entitlements; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		8E1A93A390B04F1200CCA346 /* Pods-RunnerTests.release-staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-staging.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-staging.xcconfig"; sourceTree = "<group>"; };
@@ -168,6 +170,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				A1B2C3D31ED2DC5600515810 /* ApnTokenPlugin.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 				DF000001000000000000AAA0 /* staging.icon */,
 				DF000001000000000000AAA2 /* production.icon */,
@@ -425,6 +428,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				A1B2C3D41ED2DC5600515810 /* ApnTokenPlugin.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/ApnTokenPlugin.swift
+++ b/ios/Runner/ApnTokenPlugin.swift
@@ -1,0 +1,31 @@
+import Flutter
+
+class ApnTokenPlugin: NSObject, FlutterPlugin {
+  private static var instance: ApnTokenPlugin?
+  private var channel: FlutterMethodChannel?
+  private var cachedToken: String?
+
+  static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(
+      name: "org.parres.whitenoise/apn_token",
+      binaryMessenger: registrar.messenger()
+    )
+    let plugin = ApnTokenPlugin()
+    plugin.channel = channel
+    registrar.addMethodCallDelegate(plugin, channel: channel)
+    instance = plugin
+  }
+
+  func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    switch call.method {
+    case "getToken":
+      result(cachedToken)
+    default:
+      result(FlutterMethodNotImplemented)
+    }
+  }
+
+  static func setToken(_ token: String) {
+    instance?.cachedToken = token
+  }
+}

--- a/ios/Runner/ApnTokenPlugin.swift
+++ b/ios/Runner/ApnTokenPlugin.swift
@@ -2,8 +2,11 @@ import Flutter
 
 class ApnTokenPlugin: NSObject, FlutterPlugin {
   private static var instance: ApnTokenPlugin?
+  private static var pendingToken: String?
   private var channel: FlutterMethodChannel?
   private var cachedToken: String?
+
+  deinit {}
 
   static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(
@@ -12,6 +15,8 @@ class ApnTokenPlugin: NSObject, FlutterPlugin {
     )
     let plugin = ApnTokenPlugin()
     plugin.channel = channel
+    plugin.cachedToken = pendingToken
+    pendingToken = nil
     registrar.addMethodCallDelegate(plugin, channel: channel)
     instance = plugin
   }
@@ -26,6 +31,10 @@ class ApnTokenPlugin: NSObject, FlutterPlugin {
   }
 
   static func setToken(_ token: String) {
-    instance?.cachedToken = token
+    if let inst = instance {
+      inst.cachedToken = token
+    } else {
+      pendingToken = token
+    }
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -36,6 +36,8 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
-    ApnTokenPlugin.register(with: engineBridge.pluginRegistry.registrar(forPlugin: "ApnTokenPlugin"))
+    if let registrar = engineBridge.pluginRegistry.registrar(forPlugin: "ApnTokenPlugin") {
+      ApnTokenPlugin.register(with: registrar)
+    }
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -17,8 +17,9 @@ import UIKit
     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
   ) {
     super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
-#if DEBUG
     let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+    ApnTokenPlugin.setToken(token)
+#if DEBUG
     NSLog("APNs registration succeeded with token: %@", token)
 #endif
   }
@@ -35,5 +36,6 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    ApnTokenPlugin.register(with: engineBridge.pluginRegistry.registrar(forPlugin: "ApnTokenPlugin"))
   }
 }

--- a/lib/constants/notification_server.dart
+++ b/lib/constants/notification_server.dart
@@ -1,0 +1,3 @@
+// TODO: Replace with actual notification server pubkey and relay hint
+const notificationServerPubkey = '0000000000000000000000000000000000000000000000000000000000000000';
+const String? notificationServerRelayHint = null;

--- a/lib/constants/notification_server.dart
+++ b/lib/constants/notification_server.dart
@@ -1,3 +1,4 @@
+// coverage:ignore-file
 // TODO: Replace with actual notification server pubkey and relay hint
 const notificationServerPubkey = '0000000000000000000000000000000000000000000000000000000000000000';
 const String? notificationServerRelayHint = null;

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:whitenoise/constants/notification_server.dart';
 import 'package:whitenoise/l10n/generated/app_localizations.dart';
 import 'package:whitenoise/providers/active_chat_provider.dart';
 import 'package:whitenoise/providers/auth_provider.dart';
@@ -11,6 +12,7 @@ import 'package:whitenoise/providers/foreground_service_provider.dart';
 import 'package:whitenoise/providers/locale_provider.dart';
 import 'package:whitenoise/routes.dart';
 import 'package:whitenoise/services/android_play_services_service.dart';
+import 'package:whitenoise/services/apn_token_service.dart';
 import 'package:whitenoise/services/foreground_service.dart';
 import 'package:whitenoise/services/notification_service.dart';
 import 'package:whitenoise/services/user_service.dart';
@@ -30,37 +32,46 @@ final notificationServiceProvider = Provider<NotificationService>((ref) {
 });
 
 final notificationListenerProvider = Provider.autoDispose<void>((ref) {
-  if (!Platform.isAndroid) return;
+  if (!Platform.isAndroid && !Platform.isIOS) return;
 
   final pubkey = ref.watch(authProvider).value;
   if (pubkey == null) return;
 
-  const androidPlayServicesService = AndroidPlayServicesService();
   final notificationService = ref.read(notificationServiceProvider);
   final foregroundService = ref.read(foregroundServiceProvider);
   StreamSubscription<notifications_api.NotificationUpdate>? subscription;
 
   ref.onDispose(() {
     subscription?.cancel();
-    foregroundService.stop();
+    if (Platform.isAndroid) foregroundService.stop();
     _logger.info('Notification listener disposed');
   });
 
-  _initializeAndListen(androidPlayServicesService, notificationService, foregroundService, ref, (
-    sub,
-  ) {
-    subscription = sub;
-  });
+  if (Platform.isAndroid) {
+    _initializeAndListenAndroid(
+      notificationService,
+      foregroundService,
+      ref,
+      (sub) => subscription = sub,
+    );
+  } else if (Platform.isIOS) {
+    _initializeAndListenIos(
+      pubkey,
+      notificationService,
+      ref,
+      (sub) => subscription = sub,
+    );
+  }
 });
 
-void _initializeAndListen(
-  AndroidPlayServicesService androidPlayServicesService,
+void _initializeAndListenAndroid(
   NotificationService notificationService,
   ForegroundService foregroundService,
   Ref ref,
   void Function(StreamSubscription<notifications_api.NotificationUpdate>) onSubscription,
 ) async {
   try {
+    const androidPlayServicesService = AndroidPlayServicesService();
     final playServicesAvailability = await androidPlayServicesService.getAvailability();
     if (!ref.mounted) return;
     if (playServicesAvailability.isAvailable) {
@@ -87,34 +98,77 @@ void _initializeAndListen(
     }
     await foregroundService.requestBatteryOptimizationExemption();
 
-    final stream = notifications_api.subscribeToNotifications();
-
-    final subscription = stream.listen(
-      (update) async {
-        try {
-          await handleNotificationUpdate(update, notificationService, ref);
-        } catch (error, stackTrace) {
-          _logger.severe('Error handling notification update', error, stackTrace);
-        }
-      },
-      onError: (error) {
-        _logger.severe('Notification stream error', error);
-      },
-      onDone: () {
-        _logger.info('Notification stream closed');
-      },
-    );
-
-    if (!ref.mounted) {
-      await subscription.cancel();
-      await foregroundService.stop();
-      return;
-    }
-    onSubscription(subscription);
-    _logger.info('Notification listener started');
+    _subscribeToNotificationStream(notificationService, ref, onSubscription);
   } catch (error, stackTrace) {
     _logger.severe('Failed to initialize notification listener', error, stackTrace);
   }
+}
+
+void _initializeAndListenIos(
+  String pubkey,
+  NotificationService notificationService,
+  Ref ref,
+  void Function(StreamSubscription<notifications_api.NotificationUpdate>) onSubscription,
+) async {
+  try {
+    await notificationService.initialize();
+    if (!ref.mounted) return;
+    await notificationService.requestPermission();
+    if (!ref.mounted) return;
+
+    const apnTokenService = ApnTokenService();
+    final token = await apnTokenService.getToken();
+    if (!ref.mounted) return;
+
+    if (token != null) {
+      await notifications_api.upsertPushRegistration(
+        pubkey: pubkey,
+        platform: notifications_api.PushPlatform.apns,
+        rawToken: token,
+        serverPubkey: notificationServerPubkey,
+        relayHint: notificationServerRelayHint, // ignore: avoid_redundant_argument_values
+      );
+      if (!ref.mounted) return;
+      _logger.info('Registered APNs push token with whitenoise');
+    } else {
+      _logger.warning('APNs token not available; push notifications will not be registered');
+    }
+
+    _subscribeToNotificationStream(notificationService, ref, onSubscription);
+  } catch (error, stackTrace) {
+    _logger.severe('Failed to initialize iOS notification listener', error, stackTrace);
+  }
+}
+
+void _subscribeToNotificationStream(
+  NotificationService notificationService,
+  Ref ref,
+  void Function(StreamSubscription<notifications_api.NotificationUpdate>) onSubscription,
+) {
+  final stream = notifications_api.subscribeToNotifications();
+
+  final subscription = stream.listen(
+    (update) async {
+      try {
+        await handleNotificationUpdate(update, notificationService, ref);
+      } catch (error, stackTrace) {
+        _logger.severe('Error handling notification update', error, stackTrace);
+      }
+    },
+    onError: (error) {
+      _logger.severe('Notification stream error', error);
+    },
+    onDone: () {
+      _logger.info('Notification stream closed');
+    },
+  );
+
+  if (!ref.mounted) {
+    subscription.cancel();
+    return;
+  }
+  onSubscription(subscription);
+  _logger.info('Notification listener started');
 }
 // coverage:ignore-end
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -142,7 +142,8 @@ class SettingsScreen extends HookConsumerWidget {
                       label: context.l10n.appearance,
                       onTap: () => Routes.pushToAppearance(context),
                     ),
-                    if (defaultTargetPlatform == TargetPlatform.android)
+                    if (defaultTargetPlatform == TargetPlatform.android ||
+                        defaultTargetPlatform == TargetPlatform.iOS)
                       WnMenuItem(
                         key: const Key('notification_settings_menu_item'),
                         icon: WnIcons.notification,

--- a/lib/services/apn_token_service.dart
+++ b/lib/services/apn_token_service.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
+
+final _logger = Logger('ApnTokenService');
+
+class ApnTokenService {
+  static const _channel = MethodChannel('org.parres.whitenoise/apn_token');
+
+  const ApnTokenService();
+
+  Future<String?> getToken() async {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      return null;
+    }
+
+    try {
+      final token = await _channel.invokeMethod<String>('getToken');
+      _logger.fine('APNs token retrieved: ${token != null ? '(present)' : '(null)'}');
+      return token;
+    } on PlatformException catch (e, stackTrace) {
+      _logger.warning('Failed to get APNs token: ${e.code} - ${e.message}', e, stackTrace);
+      return null;
+    } catch (e, stackTrace) {
+      _logger.warning('Failed to get APNs token', e, stackTrace);
+      return null;
+    }
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -20,7 +20,7 @@ class NotificationService {
     bool? enabled,
   }) : _plugin = plugin ?? FlutterLocalNotificationsPlugin(),
        _onNotificationTap = onNotificationTap,
-       _enabled = enabled ?? Platform.isAndroid;
+       _enabled = enabled ?? (Platform.isAndroid || Platform.isIOS);
 
   final FlutterLocalNotificationsPlugin _plugin;
   final void Function(String groupId, bool isInvite, String receiverPubkey)? _onNotificationTap;
@@ -36,7 +36,11 @@ class NotificationService {
     if (_initialized) return;
 
     const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-    const initSettings = InitializationSettings(android: androidSettings);
+    const darwinSettings = DarwinInitializationSettings();
+    const initSettings = InitializationSettings(
+      android: androidSettings,
+      iOS: darwinSettings,
+    );
 
     await _plugin.initialize(
       settings: initSettings,
@@ -107,7 +111,12 @@ class NotificationService {
       priority: Priority.high,
     );
 
-    const details = NotificationDetails(android: androidDetails);
+    const darwinDetails = DarwinNotificationDetails();
+
+    const details = NotificationDetails(
+      android: androidDetails,
+      iOS: darwinDetails,
+    );
 
     await _plugin.show(
       id: notificationId,
@@ -135,12 +144,21 @@ class NotificationService {
 
     final androidPlugin = _plugin
         .resolvePlatformSpecificImplementation<AndroidFlutterLocalNotificationsPlugin>();
+    if (androidPlugin != null) {
+      final granted = await androidPlugin.requestNotificationsPermission();
+      _logger.info('Notification permission ${granted == true ? 'granted' : 'denied'}');
+      return granted ?? false;
+    }
 
-    if (androidPlugin == null) return false;
+    final iosPlugin = _plugin
+        .resolvePlatformSpecificImplementation<IOSFlutterLocalNotificationsPlugin>();
+    if (iosPlugin != null) {
+      final granted = await iosPlugin.requestPermissions(alert: true, badge: true, sound: true);
+      _logger.info('Notification permission ${granted == true ? 'granted' : 'denied'}');
+      return granted ?? false;
+    }
 
-    final granted = await androidPlugin.requestNotificationsPermission();
-    _logger.info('Notification permission ${granted == true ? 'granted' : 'denied'}');
-    return granted ?? false;
+    return false;
   }
 
   static int generateNotificationId(String groupId) {

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5240,7 +5240,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=0d8024bec5cd996b50e1296605d744bcfc7202c4#0d8024bec5cd996b50e1296605d744bcfc7202c4"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=464acce30a00928aab213a5fbfeaf9c3f1a8eec7#464acce30a00928aab213a5fbfeaf9c3f1a8eec7"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5288,7 +5288,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=0d8024bec5cd996b50e1296605d744bcfc7202c4#0d8024bec5cd996b50e1296605d744bcfc7202c4"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=464acce30a00928aab213a5fbfeaf9c3f1a8eec7#464acce30a00928aab213a5fbfeaf9c3f1a8eec7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,7 +26,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "0d8024bec5cd996b50e1296605d744bcfc7202c4" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "464acce30a00928aab213a5fbfeaf9c3f1a8eec7" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -5498,6 +5498,7 @@ impl SseDecode for crate::api::chat_list::ChatListUpdateTrigger {
             3 => crate::api::chat_list::ChatListUpdateTrigger::ChatArchiveChanged,
             4 => crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup,
             5 => crate::api::chat_list::ChatListUpdateTrigger::ChatMuteChanged,
+            6 => crate::api::chat_list::ChatListUpdateTrigger::LeftGroup,
             _ => unreachable!("Invalid variant for ChatListUpdateTrigger: {}", inner),
         };
     }
@@ -7650,6 +7651,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::chat_list::ChatListUpdateTrig
             Self::ChatArchiveChanged => 3.into_dart(),
             Self::RemovedFromGroup => 4.into_dart(),
             Self::ChatMuteChanged => 5.into_dart(),
+            Self::LeftGroup => 6.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -9198,6 +9200,7 @@ impl SseEncode for crate::api::chat_list::ChatListUpdateTrigger {
                 crate::api::chat_list::ChatListUpdateTrigger::ChatArchiveChanged => 3,
                 crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup => 4,
                 crate::api::chat_list::ChatListUpdateTrigger::ChatMuteChanged => 5,
+                crate::api::chat_list::ChatListUpdateTrigger::LeftGroup => 6,
                 _ => {
                     unimplemented!("");
                 }

--- a/test/constants/notification_server_test.dart
+++ b/test/constants/notification_server_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/constants/notification_server.dart';
+
+void main() {
+  group('notification server constants', () {
+    test('notificationServerPubkey is a 64-character hex string', () {
+      expect(notificationServerPubkey.length, 64);
+      expect(RegExp(r'^[0-9a-f]{64}$').hasMatch(notificationServerPubkey), isTrue);
+    });
+
+    test('notificationServerRelayHint is nullable', () {
+      // Placeholder is null; will be a wss:// URL when configured
+      expect(notificationServerRelayHint, isNull);
+    });
+  });
+}

--- a/test/constants/notification_server_test.dart
+++ b/test/constants/notification_server_test.dart
@@ -9,7 +9,6 @@ void main() {
     });
 
     test('notificationServerRelayHint is nullable', () {
-      // Placeholder is null; will be a wss:// URL when configured
       expect(notificationServerRelayHint, isNull);
     });
   });

--- a/test/mocks/mock_apn_token_channel.dart
+++ b/test/mocks/mock_apn_token_channel.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const _channelName = 'org.parres.whitenoise/apn_token';
+
+typedef MockApnTokenChannel = ({
+  void Function(String, Object?) setResult,
+  void Function(String, PlatformException) setException,
+  void Function(String, Object) setError,
+  List<MethodCall> log,
+  void Function() reset,
+});
+
+MockApnTokenChannel mockApnTokenChannel() {
+  final log = <MethodCall>[];
+  final results = <String, Object?>{};
+  final exceptions = <String, PlatformException>{};
+  final errors = <String, Object>{};
+  final channel = const MethodChannel(_channelName);
+
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+    channel,
+    (MethodCall call) async {
+      log.add(call);
+      final anyErr = errors[call.method];
+      if (anyErr != null) throw anyErr;
+      final e = exceptions[call.method];
+      if (e != null) throw e;
+      return results[call.method];
+    },
+  );
+
+  return (
+    setResult: (String method, Object? value) {
+      results[method] = value;
+      exceptions.remove(method);
+      errors.remove(method);
+    },
+    setException: (String method, PlatformException e) {
+      exceptions[method] = e;
+      results.remove(method);
+      errors.remove(method);
+    },
+    setError: (String method, Object error) {
+      errors[method] = error;
+      results.remove(method);
+      exceptions.remove(method);
+    },
+    log: log,
+    reset: () {
+      results.clear();
+      exceptions.clear();
+      errors.clear();
+      log.clear();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        null,
+      );
+    },
+  );
+}

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -310,7 +310,7 @@ void main() {
       expect(find.text('v1.2.3+45'), findsOneWidget);
     });
 
-    group('notification settings menu item (Android-only)', () {
+    group('notification settings menu item (Android and iOS)', () {
       testWidgets('shows Notification Settings menu item on Android', (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         await pumpSettingsScreen(tester);
@@ -320,8 +320,19 @@ void main() {
         expect(find.text('Notifications'), findsOneWidget);
       });
 
-      testWidgets('does not show Notification Settings menu item on iOS', (tester) async {
+      testWidgets('shows Notification Settings menu item on iOS', (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+        await pumpSettingsScreen(tester);
+        debugDefaultTargetPlatformOverride = null;
+
+        expect(find.byKey(const Key('notification_settings_menu_item')), findsOneWidget);
+        expect(find.text('Notifications'), findsOneWidget);
+      });
+
+      testWidgets('does not show Notification Settings menu item on other platforms', (
+        tester,
+      ) async {
+        debugDefaultTargetPlatformOverride = TargetPlatform.linux;
         await pumpSettingsScreen(tester);
         debugDefaultTargetPlatformOverride = null;
 

--- a/test/services/apn_token_service_test.dart
+++ b/test/services/apn_token_service_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/services/apn_token_service.dart';
+
+import '../mocks/mock_apn_token_channel.dart';
+
+void main() {
+  group('ApnTokenService', () {
+    late MockApnTokenChannel mockChannel;
+
+    setUpAll(TestWidgetsFlutterBinding.ensureInitialized);
+
+    setUp(() {
+      mockChannel = mockApnTokenChannel();
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    });
+
+    tearDown(() {
+      mockChannel.reset();
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    test('returns null on non-iOS platforms', () async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.android;
+
+      const service = ApnTokenService();
+      final token = await service.getToken();
+
+      expect(token, isNull);
+      expect(mockChannel.log, isEmpty);
+    });
+
+    test('returns token from native channel', () async {
+      mockChannel.setResult('getToken', 'abcdef1234567890');
+
+      const service = ApnTokenService();
+      final token = await service.getToken();
+
+      expect(token, 'abcdef1234567890');
+      expect(mockChannel.log, hasLength(1));
+      expect(mockChannel.log.single.method, 'getToken');
+    });
+
+    test('returns null when native channel returns null', () async {
+      mockChannel.setResult('getToken', null);
+
+      const service = ApnTokenService();
+      final token = await service.getToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when native channel throws PlatformException', () async {
+      mockChannel.setException(
+        'getToken',
+        PlatformException(code: 'ERROR', message: 'Token unavailable'),
+      );
+
+      const service = ApnTokenService();
+      final token = await service.getToken();
+
+      expect(token, isNull);
+    });
+
+    test('returns null when native channel throws a non-platform error', () async {
+      mockChannel.setError('getToken', StateError('channel failed'));
+
+      const service = ApnTokenService();
+      final token = await service.getToken();
+
+      expect(token, isNull);
+    });
+  });
+}

--- a/test/services/notification_service_test.dart
+++ b/test/services/notification_service_test.dart
@@ -14,6 +14,21 @@ class _MockAndroidPlugin extends AndroidFlutterLocalNotificationsPlugin {
   Future<bool?> requestNotificationsPermission() async => permissionResult;
 }
 
+class _MockIosPlugin extends IOSFlutterLocalNotificationsPlugin {
+  bool? permissionResult = true;
+
+  @override
+  Future<bool?> requestPermissions({
+    bool sound = false,
+    bool alert = false,
+    bool badge = false,
+    bool provisional = false,
+    bool critical = false,
+    bool carPlay = false,
+    bool providesAppNotificationSettings = false,
+  }) async => permissionResult;
+}
+
 class _MockNotificationsPlugin implements FlutterLocalNotificationsPlugin {
   final List<String> calls = [];
   void Function(NotificationResponse)? tapCallback;
@@ -23,11 +38,15 @@ class _MockNotificationsPlugin implements FlutterLocalNotificationsPlugin {
   String? lastPayload;
   int? lastCancelledId;
   AndroidFlutterLocalNotificationsPlugin? androidPlugin;
+  IOSFlutterLocalNotificationsPlugin? iosPlugin;
 
   @override
   T? resolvePlatformSpecificImplementation<T extends FlutterLocalNotificationsPlatform>() {
     if (T == AndroidFlutterLocalNotificationsPlugin) {
       return androidPlugin as T?;
+    }
+    if (T == IOSFlutterLocalNotificationsPlugin) {
+      return iosPlugin as T?;
     }
     return null;
   }
@@ -267,6 +286,51 @@ void main() {
         androidPlugin.permissionResult = null;
         final mockPlugin = _MockNotificationsPlugin();
         mockPlugin.androidPlugin = androidPlugin;
+        final service = NotificationService(plugin: mockPlugin, enabled: true);
+        await service.initialize();
+
+        final result = await service.requestPermission();
+        expect(result, isFalse);
+      });
+
+      test('returns true when iOS permission is granted', () async {
+        final iosPlugin = _MockIosPlugin();
+        iosPlugin.permissionResult = true;
+        final mockPlugin = _MockNotificationsPlugin();
+        mockPlugin.iosPlugin = iosPlugin;
+        final service = NotificationService(plugin: mockPlugin, enabled: true);
+        await service.initialize();
+
+        final result = await service.requestPermission();
+        expect(result, isTrue);
+      });
+
+      test('returns false when iOS permission is denied', () async {
+        final iosPlugin = _MockIosPlugin();
+        iosPlugin.permissionResult = false;
+        final mockPlugin = _MockNotificationsPlugin();
+        mockPlugin.iosPlugin = iosPlugin;
+        final service = NotificationService(plugin: mockPlugin, enabled: true);
+        await service.initialize();
+
+        final result = await service.requestPermission();
+        expect(result, isFalse);
+      });
+
+      test('returns false when iOS permission result is null', () async {
+        final iosPlugin = _MockIosPlugin();
+        iosPlugin.permissionResult = null;
+        final mockPlugin = _MockNotificationsPlugin();
+        mockPlugin.iosPlugin = iosPlugin;
+        final service = NotificationService(plugin: mockPlugin, enabled: true);
+        await service.initialize();
+
+        final result = await service.requestPermission();
+        expect(result, isFalse);
+      });
+
+      test('returns false when iOS platform implementation is null', () async {
+        final mockPlugin = _MockNotificationsPlugin();
         final service = NotificationService(plugin: mockPlugin, enabled: true);
         await service.initialize();
 

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -1305,6 +1305,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.16"
+  thumbhash:
+    dependency: transitive
+    description:
+      name: thumbhash
+      sha256: "5f6d31c5279ca0b5caa81ec10aae8dcaab098d82cb699ea66ada4ed09c794a37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0+1"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
## Changes

### iOS Push Notifications
- Added `ApnTokenPlugin` to handle APNs token retrieval from native iOS
- Created `ApnTokenService` for communicating with the APNs plugin
- Extended notification provider to support iOS initialization and token registration
- Updated `NotificationService` to initialize and request permissions on iOS

### Configuration
- Added `notification_server.dart` constants for notification server pubkey and relay hint
- Updated settings screen to show notification settings on both Android and iOS

### Testing
- Added mock APNs token channel for unit tests
- Added comprehensive tests for `ApnTokenService`
- Extended `NotificationService` tests to cover iOS permission requests
- Updated settings screen tests to verify iOS notification settings visibility

### Dependencies
- Bumped whitenoise-rs to commit `464acce3` (latest version with iOS support)

### Platform Support
- Notification listener now works on both Android and iOS
- Removed foreground service requirement for iOS (Android-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iOS push support: APNs token retrieval, permission prompts, and push registration enabled
  * Notification settings now visible on iOS as well as Android
  * App exposes notification-server constants for configuration

* **Refactor**
  * Unified notification listener and subscription handling with platform-specific initialization

* **Tests**
  * Added tests and mocks covering APNs token flow, notification permissions, and server constants

* **Chores**
  * Updated native dependency revision
<!-- end of auto-generated comment: release notes by coderabbit.ai -->