### PR TITLE
Search 2.0: cross-group message content search in chat list

### DIFF
--- a/lib/hooks/use_chat_list_search.dart
+++ b/lib/hooks/use_chat_list_search.dart
@@ -6,7 +6,7 @@ import 'package:whitenoise/src/rust/api/messages.dart';
 
 final _logger = Logger('useChatListSearch');
 
-const _searchDebounceMs = 300;
+const _searchDebounceMs = 150;
 
 typedef ChatListSearchResult = ({
   Map<String, String> messageSnippets,

--- a/lib/hooks/use_chat_list_search.dart
+++ b/lib/hooks/use_chat_list_search.dart
@@ -22,9 +22,10 @@ ChatListSearchResult useChatListSearch({
   final matchedGroupIds = useState<Set<String>>({});
   final isSearching = useState(false);
   final debouncedQuery = _useDebouncedValue(query, _searchDebounceMs);
+  final trimmedQuery = debouncedQuery.trim();
 
   useEffect(() {
-    if (debouncedQuery.isEmpty) {
+    if (trimmedQuery.isEmpty) {
       messageSnippets.value = {};
       matchedGroupIds.value = {};
       isSearching.value = false;
@@ -34,12 +35,12 @@ ChatListSearchResult useChatListSearch({
     isSearching.value = true;
     var cancelled = false;
 
-    searchMessages(pubkey: pubkey, query: debouncedQuery)
+    searchMessages(pubkey: pubkey, query: trimmedQuery)
         .then((results) {
           if (cancelled) return;
           _logger.info(
             'cross-group search completed '
-            'queryLength=${debouncedQuery.length} results=${results.length}',
+            'queryLength=${trimmedQuery.length} results=${results.length}',
           );
 
           final snippets = <String, String>{};
@@ -56,7 +57,7 @@ ChatListSearchResult useChatListSearch({
         .catchError((Object e, StackTrace st) {
           if (!cancelled) {
             _logger.severe(
-              'cross-group search failed queryLength=${debouncedQuery.length}',
+              'cross-group search failed queryLength=${trimmedQuery.length}',
               e,
               st,
             );
@@ -67,7 +68,7 @@ ChatListSearchResult useChatListSearch({
         });
 
     return () => cancelled = true;
-  }, [debouncedQuery, pubkey]);
+  }, [trimmedQuery, pubkey]);
 
   return (
     messageSnippets: messageSnippets.value,

--- a/lib/hooks/use_chat_list_search.dart
+++ b/lib/hooks/use_chat_list_search.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:logging/logging.dart';
+import 'package:whitenoise/src/rust/api/messages.dart';
+
+final _logger = Logger('useChatListSearch');
+
+const _searchDebounceMs = 300;
+
+typedef ChatListSearchResult = ({
+  Map<String, String> messageSnippets,
+  Set<String> matchedGroupIds,
+  bool isSearching,
+});
+
+ChatListSearchResult useChatListSearch({
+  required String pubkey,
+  required String query,
+}) {
+  final messageSnippets = useState<Map<String, String>>({});
+  final matchedGroupIds = useState<Set<String>>({});
+  final isSearching = useState(false);
+  final debouncedQuery = _useDebouncedValue(query, _searchDebounceMs);
+
+  useEffect(() {
+    if (debouncedQuery.isEmpty) {
+      messageSnippets.value = {};
+      matchedGroupIds.value = {};
+      isSearching.value = false;
+      return null;
+    }
+
+    isSearching.value = true;
+    var cancelled = false;
+
+    searchMessages(pubkey: pubkey, query: debouncedQuery)
+        .then((results) {
+          if (cancelled) return;
+          _logger.info(
+            'cross-group search completed '
+            'queryLength=${debouncedQuery.length} results=${results.length}',
+          );
+
+          final snippets = <String, String>{};
+          final groupIds = <String>{};
+          for (final result in results) {
+            groupIds.add(result.mlsGroupId);
+            snippets.putIfAbsent(result.mlsGroupId, () => result.message.content);
+          }
+
+          messageSnippets.value = snippets;
+          matchedGroupIds.value = groupIds;
+          isSearching.value = false;
+        })
+        .catchError((Object e, StackTrace st) {
+          if (!cancelled) {
+            _logger.severe(
+              'cross-group search failed queryLength=${debouncedQuery.length}',
+              e,
+              st,
+            );
+            messageSnippets.value = {};
+            matchedGroupIds.value = {};
+            isSearching.value = false;
+          }
+        });
+
+    return () => cancelled = true;
+  }, [debouncedQuery, pubkey]);
+
+  return (
+    messageSnippets: messageSnippets.value,
+    matchedGroupIds: matchedGroupIds.value,
+    isSearching: isSearching.value,
+  );
+}
+
+String _useDebouncedValue(String value, int milliseconds) {
+  final debounced = useState('');
+
+  useEffect(() {
+    final timer = Timer(Duration(milliseconds: milliseconds), () {
+      debounced.value = value;
+    });
+    return timer.cancel;
+  }, [value, milliseconds]);
+
+  return debounced.value;
+}

--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:whitenoise/hooks/use_chat_list.dart';
+import 'package:whitenoise/hooks/use_chat_list_search.dart';
 import 'package:whitenoise/hooks/use_system_notice.dart';
 import 'package:whitenoise/hooks/use_zapstore_update.dart';
 import 'package:whitenoise/l10n/l10n.dart';
@@ -171,6 +172,10 @@ class ChatListScreen extends HookConsumerWidget {
     final searchQuery = useState('');
     final welcomeNoticeDismissed = useState(false);
     final chatListTopPadding = useMemoized(() => ValueNotifier(safeAreaTop + _slateHeight.h));
+    final chatListSearch = useChatListSearch(
+      pubkey: pubkey,
+      query: searchQuery.value,
+    );
 
     useEffect(() {
       welcomeNoticeDismissed.value = false;
@@ -179,7 +184,11 @@ class ChatListScreen extends HookConsumerWidget {
 
     final isArchiveView = selectedFilter.value == ChatListFilter.archive;
     final activeChatList = isArchiveView ? archivedChatListResult.chats : chatListResult.chats;
-    final filteredChats = filterChatsBySearch(activeChatList, searchQuery.value);
+    final filteredChats = filterChatsBySearchWithMessageMatches(
+      activeChatList,
+      searchQuery.value,
+      chatListSearch.matchedGroupIds,
+    );
     final isLoading = isArchiveView ? archivedChatListResult.isLoading : chatListResult.isLoading;
     final isEmpty = activeChatList.isEmpty && !isLoading;
     final showWelcomeNotice = !isArchiveView && isEmpty && !welcomeNoticeDismissed.value;
@@ -198,6 +207,7 @@ class ChatListScreen extends HookConsumerWidget {
               topPadding: topPadding,
               header: WnSearchAndFilters(
                 onSearchChanged: (value) => searchQuery.value = value,
+                isLoading: chatListSearch.isSearching,
               ),
               headerHeight: _searchAndFiltersHeight.h,
               pinnedHeader: Padding(
@@ -251,6 +261,7 @@ class ChatListScreen extends HookConsumerWidget {
                   key: Key(chatSummary.mlsGroupId),
                   chatSummary: chatSummary,
                   isArchived: isArchiveView,
+                  searchSnippet: chatListSearch.messageSnippets[chatSummary.mlsGroupId],
                   onChatListChanged: isArchiveView
                       ? archivedChatListResult.refresh
                       : chatListResult.refresh,

--- a/lib/src/rust/api/messages.dart
+++ b/lib/src/rust/api/messages.dart
@@ -61,6 +61,22 @@ Future<List<SearchResult>> searchMessagesInGroup({
   limit: limit,
 );
 
+/// Search messages across all groups the account belongs to.
+///
+/// Like [`search_messages_in_group`] but without a group filter. Each result
+/// includes `mls_group_id` so callers can group results by conversation.
+/// Position is computed per-group so the frontend can still jump to the
+/// correct page within each conversation.
+Future<List<SearchResult>> searchMessages({
+  required String pubkey,
+  required String query,
+  int? limit,
+}) => RustLib.instance.api.crateApiMessagesSearchMessages(
+  pubkey: pubkey,
+  query: query,
+  limit: limit,
+);
+
 /// Fetch a paginated page of messages for a group.
 ///
 /// Returns messages in oldest-first order. Pass the `created_at` and `id` of the
@@ -426,21 +442,26 @@ class ReactionSummary {
 class SearchResult {
   final ChatMessage message;
 
+  /// The MLS group this message belongs to (hex-encoded).
+  final String mlsGroupId;
+
   /// One span per matched query token, in the order they appear in the content.
   final List<HighlightSpan> highlightSpans;
 
-  /// 0-based position of the message within the group (0 = newest),
+  /// 0-based position of the message within its group (0 = newest),
   /// matching the `created_at DESC, message_id DESC` ordering used by pagination.
   final BigInt position;
 
   const SearchResult({
     required this.message,
+    required this.mlsGroupId,
     required this.highlightSpans,
     required this.position,
   });
 
   @override
-  int get hashCode => message.hashCode ^ highlightSpans.hashCode ^ position.hashCode;
+  int get hashCode =>
+      message.hashCode ^ mlsGroupId.hashCode ^ highlightSpans.hashCode ^ position.hashCode;
 
   @override
   bool operator ==(Object other) =>
@@ -448,6 +469,7 @@ class SearchResult {
       other is SearchResult &&
           runtimeType == other.runtimeType &&
           message == other.message &&
+          mlsGroupId == other.mlsGroupId &&
           highlightSpans == other.highlightSpans &&
           position == other.position;
 }

--- a/lib/src/rust/frb_generated.dart
+++ b/lib/src/rust/frb_generated.dart
@@ -86,7 +86,7 @@ class RustLib extends BaseEntrypoint<RustLibApi, RustLibApiImpl, RustLibWire> {
   String get codegenVersion => '2.11.1';
 
   @override
-  int get rustContentHash => 799775460;
+  int get rustContentHash => 498499121;
 
   static const kDefaultExternalLibraryLoaderConfig = ExternalLibraryLoaderConfig(
     stem: 'rust_lib_whitenoise',
@@ -463,6 +463,12 @@ abstract class RustLibApi extends BaseApi {
     required String content,
     String? replyToId,
     required List<MediaFile> mediaAttachments,
+  });
+
+  Future<List<SearchResult>> crateApiMessagesSearchMessages({
+    required String pubkey,
+    required String query,
+    int? limit,
   });
 
   Future<List<SearchResult>> crateApiMessagesSearchMessagesInGroup({
@@ -3735,6 +3741,42 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   );
 
   @override
+  Future<List<SearchResult>> crateApiMessagesSearchMessages({
+    required String pubkey,
+    required String query,
+    int? limit,
+  }) {
+    return handler.executeNormal(
+      NormalTask(
+        callFfi: (port_) {
+          final serializer = SseSerializer(generalizedFrbRustBinding);
+          sse_encode_String(pubkey, serializer);
+          sse_encode_String(query, serializer);
+          sse_encode_opt_box_autoadd_u_32(limit, serializer);
+          pdeCallFfi(
+            generalizedFrbRustBinding,
+            serializer,
+            funcId: 92,
+            port: port_,
+          );
+        },
+        codec: SseCodec(
+          decodeSuccessData: sse_decode_list_search_result,
+          decodeErrorData: sse_decode_api_error,
+        ),
+        constMeta: kCrateApiMessagesSearchMessagesConstMeta,
+        argValues: [pubkey, query, limit],
+        apiImpl: this,
+      ),
+    );
+  }
+
+  TaskConstMeta get kCrateApiMessagesSearchMessagesConstMeta => const TaskConstMeta(
+    debugName: 'search_messages',
+    argNames: ['pubkey', 'query', 'limit'],
+  );
+
+  @override
   Future<List<SearchResult>> crateApiMessagesSearchMessagesInGroup({
     required String pubkey,
     required String groupId,
@@ -3752,7 +3794,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 92,
+            funcId: 93,
             port: port_,
           );
         },
@@ -3793,7 +3835,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 93,
+              funcId: 94,
               port: port_,
             );
           },
@@ -3849,7 +3891,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 94,
+            funcId: 95,
             port: port_,
           );
         },
@@ -3912,7 +3954,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 95,
+            funcId: 96,
             port: port_,
           );
         },
@@ -3948,7 +3990,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 96,
+            funcId: 97,
             port: port_,
           );
         },
@@ -3981,7 +4023,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 97,
+            funcId: 98,
             port: port_,
           );
         },
@@ -4016,7 +4058,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 98,
+              funcId: 99,
               port: port_,
             );
           },
@@ -4053,7 +4095,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 99,
+              funcId: 100,
               port: port_,
             );
           },
@@ -4092,7 +4134,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 100,
+              funcId: 101,
               port: port_,
             );
           },
@@ -4126,7 +4168,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 101,
+              funcId: 102,
               port: port_,
             );
           },
@@ -4163,7 +4205,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 102,
+              funcId: 103,
               port: port_,
             );
           },
@@ -4200,7 +4242,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
             pdeCallFfi(
               generalizedFrbRustBinding,
               serializer,
-              funcId: 103,
+              funcId: 104,
               port: port_,
             );
           },
@@ -4232,7 +4274,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 104,
+            funcId: 105,
             port: port_,
           );
         },
@@ -4262,7 +4304,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 105,
+            funcId: 106,
           )!;
         },
         codec: SseCodec(
@@ -4291,7 +4333,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 106,
+            funcId: 107,
           )!;
         },
         codec: SseCodec(
@@ -4320,7 +4362,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 107,
+            funcId: 108,
           )!;
         },
         codec: SseCodec(
@@ -4353,7 +4395,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           return pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 108,
+            funcId: 109,
           )!;
         },
         codec: SseCodec(
@@ -4386,7 +4428,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 109,
+            funcId: 110,
             port: port_,
           );
         },
@@ -4420,7 +4462,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 110,
+            funcId: 111,
             port: port_,
           );
         },
@@ -4454,7 +4496,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 111,
+            funcId: 112,
             port: port_,
           );
         },
@@ -4488,7 +4530,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 112,
+            funcId: 113,
             port: port_,
           );
         },
@@ -4521,7 +4563,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 113,
+            funcId: 114,
             port: port_,
           );
         },
@@ -4555,7 +4597,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 114,
+            funcId: 115,
             port: port_,
           );
         },
@@ -4588,7 +4630,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 115,
+            funcId: 116,
             port: port_,
           );
         },
@@ -4626,7 +4668,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 116,
+            funcId: 117,
             port: port_,
           );
         },
@@ -4662,7 +4704,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 117,
+            funcId: 118,
             port: port_,
           );
         },
@@ -4700,7 +4742,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 118,
+            funcId: 119,
             port: port_,
           );
         },
@@ -4740,7 +4782,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 119,
+            funcId: 120,
             port: port_,
           );
         },
@@ -4780,7 +4822,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 120,
+            funcId: 121,
             port: port_,
           );
         },
@@ -4814,7 +4856,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 121,
+            funcId: 122,
             port: port_,
           );
         },
@@ -4853,7 +4895,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 122,
+            funcId: 123,
             port: port_,
           );
         },
@@ -4885,7 +4927,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
           pdeCallFfi(
             generalizedFrbRustBinding,
             serializer,
-            funcId: 123,
+            funcId: 124,
             port: port_,
           );
         },
@@ -6352,11 +6394,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SearchResult dco_decode_search_result(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 3) throw Exception('unexpected arr length: expect 3 but see ${arr.length}');
+    if (arr.length != 4) throw Exception('unexpected arr length: expect 4 but see ${arr.length}');
     return SearchResult(
       message: dco_decode_chat_message(arr[0]),
-      highlightSpans: dco_decode_list_highlight_span(arr[1]),
-      position: dco_decode_u_64(arr[2]),
+      mlsGroupId: dco_decode_String(arr[1]),
+      highlightSpans: dco_decode_list_highlight_span(arr[2]),
+      position: dco_decode_u_64(arr[3]),
     );
   }
 
@@ -8341,10 +8384,12 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   SearchResult sse_decode_search_result(SseDeserializer deserializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     final var_message = sse_decode_chat_message(deserializer);
+    final var_mlsGroupId = sse_decode_String(deserializer);
     final var_highlightSpans = sse_decode_list_highlight_span(deserializer);
     final var_position = sse_decode_u_64(deserializer);
     return SearchResult(
       message: var_message,
+      mlsGroupId: var_mlsGroupId,
       highlightSpans: var_highlightSpans,
       position: var_position,
     );
@@ -10225,6 +10270,7 @@ class RustLibApiImpl extends RustLibApiImplPlatform implements RustLibApi {
   void sse_encode_search_result(SearchResult self, SseSerializer serializer) {
     // Codec=Sse (Serialization based), see doc to use other codecs
     sse_encode_chat_message(self.message, serializer);
+    sse_encode_String(self.mlsGroupId, serializer);
     sse_encode_list_highlight_span(self.highlightSpans, serializer);
     sse_encode_u_64(self.position, serializer);
   }

--- a/lib/utils/chat_search.dart
+++ b/lib/utils/chat_search.dart
@@ -8,3 +8,16 @@ List<ChatSummary> filterChatsBySearch(List<ChatSummary> chats, String query) {
     return name.contains(lowerQuery);
   }).toList();
 }
+
+List<ChatSummary> filterChatsBySearchWithMessageMatches(
+  List<ChatSummary> chats,
+  String query,
+  Set<String> messageMatchedGroupIds,
+) {
+  if (query.isEmpty) return chats;
+  final lowerQuery = query.toLowerCase();
+  return chats.where((chat) {
+    final name = chat.name?.toLowerCase() ?? '';
+    return name.contains(lowerQuery) || messageMatchedGroupIds.contains(chat.mlsGroupId);
+  }).toList();
+}

--- a/lib/utils/chat_search.dart
+++ b/lib/utils/chat_search.dart
@@ -5,8 +5,9 @@ List<ChatSummary> filterChatsBySearchWithMessageMatches(
   String query,
   Set<String> messageMatchedGroupIds,
 ) {
-  if (query.isEmpty) return chats;
-  final lowerQuery = query.toLowerCase();
+  final trimmedQuery = query.trim();
+  if (trimmedQuery.isEmpty) return chats;
+  final lowerQuery = trimmedQuery.toLowerCase();
   return chats.where((chat) {
     final name = chat.name?.toLowerCase() ?? '';
     return name.contains(lowerQuery) || messageMatchedGroupIds.contains(chat.mlsGroupId);

--- a/lib/utils/chat_search.dart
+++ b/lib/utils/chat_search.dart
@@ -1,14 +1,5 @@
 import 'package:whitenoise/src/rust/api/chat_list.dart';
 
-List<ChatSummary> filterChatsBySearch(List<ChatSummary> chats, String query) {
-  if (query.isEmpty) return chats;
-  final lowerQuery = query.toLowerCase();
-  return chats.where((chat) {
-    final name = chat.name?.toLowerCase() ?? '';
-    return name.contains(lowerQuery);
-  }).toList();
-}
-
 List<ChatSummary> filterChatsBySearchWithMessageMatches(
   List<ChatSummary> chats,
   String query,

--- a/lib/widgets/chat_list_tile.dart
+++ b/lib/widgets/chat_list_tile.dart
@@ -47,6 +47,7 @@ class ChatListTile extends HookConsumerWidget {
   final VoidCallback? onChatListChanged;
   final void Function(String message)? onError;
   final bool isArchived;
+  final String? searchSnippet;
 
   const ChatListTile({
     super.key,
@@ -54,6 +55,7 @@ class ChatListTile extends HookConsumerWidget {
     this.onChatListChanged,
     this.onError,
     this.isArchived = false,
+    this.searchSnippet,
   });
 
   @override
@@ -154,6 +156,19 @@ class ChatListTile extends HookConsumerWidget {
       }
     }
 
+    final String displaySubtitle;
+    final String? displayPrefixSubtitle;
+    final Widget? displaySubtitleIcon;
+    if (searchSnippet != null) {
+      displaySubtitle = searchSnippet!;
+      displayPrefixSubtitle = null;
+      displaySubtitleIcon = null;
+    } else {
+      displaySubtitle = subtitle;
+      displayPrefixSubtitle = prefixSubtitle;
+      displaySubtitleIcon = subtitleIcon;
+    }
+
     final avatarColorKey = isDm
         ? (chatSummary.dmPeerPubkey ?? chatSummary.mlsGroupId)
         : chatSummary.mlsGroupId;
@@ -171,7 +186,7 @@ class ChatListTile extends HookConsumerWidget {
         childRenderBox: renderBox,
         child: WnChatListItem(
           title: title,
-          subtitle: subtitle,
+          subtitle: displaySubtitle,
           timestamp: formattedTime,
           avatarUrl: pictureUrl,
           avatarName: avatarName,
@@ -179,8 +194,8 @@ class ChatListTile extends HookConsumerWidget {
           showPinned: isPinned,
           status: status,
           unreadCount: unreadCount,
-          prefixSubtitle: prefixSubtitle,
-          subtitleIcon: subtitleIcon,
+          prefixSubtitle: displayPrefixSubtitle,
+          subtitleIcon: displaySubtitleIcon,
         ),
         actions: [
           WnChatListContextMenuAction(
@@ -239,7 +254,7 @@ class ChatListTile extends HookConsumerWidget {
           : () => Routes.goToChat(context, chatSummary.mlsGroupId),
       onLongPress: isPending ? null : showContextMenu,
       title: title,
-      subtitle: subtitle,
+      subtitle: displaySubtitle,
       timestamp: formattedTime,
       avatarUrl: pictureUrl,
       avatarName: avatarName,
@@ -247,8 +262,8 @@ class ChatListTile extends HookConsumerWidget {
       showPinned: chatSummary.pinOrder != null,
       status: status,
       unreadCount: unreadCount,
-      prefixSubtitle: prefixSubtitle,
-      subtitleIcon: subtitleIcon,
+      prefixSubtitle: displayPrefixSubtitle,
+      subtitleIcon: displaySubtitleIcon,
     );
   }
 }

--- a/lib/widgets/wn_search_and_filters.dart
+++ b/lib/widgets/wn_search_and_filters.dart
@@ -8,9 +8,11 @@ class WnSearchAndFilters extends HookWidget {
   const WnSearchAndFilters({
     super.key,
     this.onSearchChanged,
+    this.isLoading = false,
   });
 
   final ValueChanged<String>? onSearchChanged;
+  final bool isLoading;
 
   @override
   Widget build(BuildContext context) {
@@ -39,6 +41,7 @@ class WnSearchAndFilters extends HookWidget {
           WnSearchField(
             placeholder: l10n.search,
             controller: searchController,
+            isLoading: isLoading,
           ),
         ],
       ),

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5245,7 +5245,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=51fef295746eab060afd97af4946b8238737e854#51fef295746eab060afd97af4946b8238737e854"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca#e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5293,7 +5293,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=51fef295746eab060afd97af4946b8238737e854#51fef295746eab060afd97af4946b8238737e854"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca#e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -326,16 +326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
-name = "base58ck"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
-dependencies = [
- "bitcoin-internals",
- "bitcoin_hashes",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,42 +361,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
 
 [[package]]
-name = "bitcoin"
-version = "0.32.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
-dependencies = [
- "base58ck",
- "bech32",
- "bitcoin-internals",
- "bitcoin-io",
- "bitcoin-units",
- "bitcoin_hashes",
- "hex-conservative",
- "hex_lit",
- "secp256k1",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-
-[[package]]
 name = "bitcoin-io"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
-
-[[package]]
-name = "bitcoin-units"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
-dependencies = [
- "bitcoin-internals",
-]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -1573,12 +1531,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2408,26 +2360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lightning-invoice"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11209f386879b97198b2bfc9e9c1e5d42870825c6bd4376f17f95357244d6600"
-dependencies = [
- "bech32",
- "bitcoin",
- "lightning-types",
-]
-
-[[package]]
-name = "lightning-types"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
-dependencies = [
- "bitcoin",
-]
-
-[[package]]
 name = "linux-keyutils"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,17 +2809,6 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "nwc"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f651e3c28dd9da0873151233e804a92b6240a1db1260f3c9d727950adb8e9036"
-dependencies = [
- "nostr",
- "nostr-relay-pool",
- "tracing",
 ]
 
 [[package]]
@@ -3989,7 +3910,6 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes",
  "rand 0.8.5",
  "secp256k1-sys",
  "serde",
@@ -5252,25 +5172,20 @@ dependencies = [
  "apple-native-keyring-store",
  "async-trait",
  "base64ct",
- "blurhash",
- "chacha20poly1305",
  "chrono",
  "dashmap 6.1.0",
- "dotenvy",
  "futures",
  "hex",
  "image",
  "indexmap",
  "infer",
  "keyring-core",
- "lightning-invoice",
  "linux-keyutils-keyring-store",
  "mdk-core",
  "mdk-sqlite-storage",
  "mdk-storage-traits",
  "nostr-blossom",
  "nostr-sdk",
- "nwc",
  "rand 0.9.2",
  "reqwest 0.13.2",
  "rustls",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "51fef295746eab060afd97af4946b8238737e854" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -170,9 +170,11 @@ pub struct HighlightSpan {
 #[derive(Debug, Clone)]
 pub struct SearchResult {
     pub message: ChatMessage,
+    /// The MLS group this message belongs to (hex-encoded).
+    pub mls_group_id: String,
     /// One span per matched query token, in the order they appear in the content.
     pub highlight_spans: Vec<HighlightSpan>,
-    /// 0-based position of the message within the group (0 = newest),
+    /// 0-based position of the message within its group (0 = newest),
     /// matching the `created_at DESC, message_id DESC` ordering used by pagination.
     pub position: u64,
 }
@@ -181,6 +183,7 @@ impl From<WhitenoiseSearchResult> for SearchResult {
     fn from(result: WhitenoiseSearchResult) -> Self {
         Self {
             message: (&result.message).into(),
+            mls_group_id: group_id_to_string(&result.mls_group_id),
             highlight_spans: result
                 .highlight_spans
                 .into_iter()
@@ -478,6 +481,24 @@ pub async fn search_messages_in_group(
     let results = whitenoise
         .search_messages_in_group(&pubkey, &group_id, &query, limit)
         .await?;
+    Ok(results.into_iter().map(|r| r.into()).collect())
+}
+
+/// Search messages across all groups the account belongs to.
+///
+/// Like [`search_messages_in_group`] but without a group filter. Each result
+/// includes `mls_group_id` so callers can group results by conversation.
+/// Position is computed per-group so the frontend can still jump to the
+/// correct page within each conversation.
+#[frb]
+pub async fn search_messages(
+    pubkey: String,
+    query: String,
+    limit: Option<u32>,
+) -> Result<Vec<SearchResult>, ApiError> {
+    let whitenoise = Whitenoise::get_instance()?;
+    let pubkey = PublicKey::parse(&pubkey)?;
+    let results = whitenoise.search_messages(&pubkey, &query, limit).await?;
     Ok(results.into_iter().map(|r| r.into()).collect())
 }
 

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -43,7 +43,7 @@ flutter_rust_bridge::frb_generated_boilerplate!(
     default_rust_auto_opaque = RustAutoOpaqueMoi,
 );
 pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_VERSION: &str = "2.11.1";
-pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 799775460;
+pub(crate) const FLUTTER_RUST_BRIDGE_CODEGEN_CONTENT_HASH: i32 = 498499121;
 
 // Section: executor
 
@@ -3593,6 +3593,46 @@ fn wire__crate__api__drafts__save_draft_impl(
         },
     )
 }
+fn wire__crate__api__messages__search_messages_impl(
+    port_: flutter_rust_bridge::for_generated::MessagePort,
+    ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
+    rust_vec_len_: i32,
+    data_len_: i32,
+) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap_async::<flutter_rust_bridge::for_generated::SseCodec, _, _, _>(
+        flutter_rust_bridge::for_generated::TaskInfo {
+            debug_name: "search_messages",
+            port: Some(port_),
+            mode: flutter_rust_bridge::for_generated::FfiCallMode::Normal,
+        },
+        move || {
+            let message = unsafe {
+                flutter_rust_bridge::for_generated::Dart2RustMessageSse::from_wire(
+                    ptr_,
+                    rust_vec_len_,
+                    data_len_,
+                )
+            };
+            let mut deserializer =
+                flutter_rust_bridge::for_generated::SseDeserializer::new(message);
+            let api_pubkey = <String>::sse_decode(&mut deserializer);
+            let api_query = <String>::sse_decode(&mut deserializer);
+            let api_limit = <Option<u32>>::sse_decode(&mut deserializer);
+            deserializer.end();
+            move |context| async move {
+                transform_result_sse::<_, crate::api::error::ApiError>(
+                    (move || async move {
+                        let output_ok =
+                            crate::api::messages::search_messages(api_pubkey, api_query, api_limit)
+                                .await?;
+                        Ok(output_ok)
+                    })()
+                    .await,
+                )
+            }
+        },
+    )
+}
 fn wire__crate__api__messages__search_messages_in_group_impl(
     port_: flutter_rust_bridge::for_generated::MessagePort,
     ptr_: flutter_rust_bridge::for_generated::PlatformGeneralizedUint8ListPtr,
@@ -6753,11 +6793,13 @@ impl SseDecode for crate::api::messages::SearchResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_decode(deserializer: &mut flutter_rust_bridge::for_generated::SseDeserializer) -> Self {
         let mut var_message = <crate::api::messages::ChatMessage>::sse_decode(deserializer);
+        let mut var_mlsGroupId = <String>::sse_decode(deserializer);
         let mut var_highlightSpans =
             <Vec<crate::api::messages::HighlightSpan>>::sse_decode(deserializer);
         let mut var_position = <u64>::sse_decode(deserializer);
         return crate::api::messages::SearchResult {
             message: var_message,
+            mls_group_id: var_mlsGroupId,
             highlight_spans: var_highlightSpans,
             position: var_position,
         };
@@ -7290,96 +7332,97 @@ fn pde_ffi_dispatcher_primary_impl(
             data_len,
         ),
         91 => wire__crate__api__drafts__save_draft_impl(port, ptr, rust_vec_len, data_len),
-        92 => wire__crate__api__messages__search_messages_in_group_impl(
+        92 => wire__crate__api__messages__search_messages_impl(port, ptr, rust_vec_len, data_len),
+        93 => wire__crate__api__messages__search_messages_in_group_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        93 => wire__crate__api__user_search__search_users_impl(port, ptr, rust_vec_len, data_len),
-        94 => wire__crate__api__bug_report__send_bug_report_impl(port, ptr, rust_vec_len, data_len),
-        95 => wire__crate__api__messages__send_message_to_group_impl(
+        94 => wire__crate__api__user_search__search_users_impl(port, ptr, rust_vec_len, data_len),
+        95 => wire__crate__api__bug_report__send_bug_report_impl(port, ptr, rust_vec_len, data_len),
+        96 => wire__crate__api__messages__send_message_to_group_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        96 => {
+        97 => {
             wire__crate__api__chat_list__set_chat_pin_order_impl(port, ptr, rust_vec_len, data_len)
         }
-        97 => {
+        98 => {
             wire__crate__api__utils__string_from_relay_url_impl(port, ptr, rust_vec_len, data_len)
         }
-        98 => wire__crate__api__chat_list__subscribe_to_archived_chat_list_impl(
+        99 => wire__crate__api__chat_list__subscribe_to_archived_chat_list_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        99 => wire__crate__api__chat_list__subscribe_to_chat_list_impl(
+        100 => wire__crate__api__chat_list__subscribe_to_chat_list_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        100 => wire__crate__api__messages__subscribe_to_group_messages_impl(
+        101 => wire__crate__api__messages__subscribe_to_group_messages_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        101 => wire__crate__api__notifications__subscribe_to_notifications_impl(
+        102 => wire__crate__api__notifications__subscribe_to_notifications_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        102 => {
+        103 => {
             wire__crate__api__logs__subscribe_to_rust_logs_impl(port, ptr, rust_vec_len, data_len)
         }
-        103 => wire__crate__api__users__subscribe_to_user_impl(port, ptr, rust_vec_len, data_len),
-        104 => wire__crate__api__utils__tag_from_vec_impl(port, ptr, rust_vec_len, data_len),
-        109 => {
+        104 => wire__crate__api__users__subscribe_to_user_impl(port, ptr, rust_vec_len, data_len),
+        105 => wire__crate__api__utils__tag_from_vec_impl(port, ptr, rust_vec_len, data_len),
+        110 => {
             wire__crate__api__account_groups__unarchive_chat_impl(port, ptr, rust_vec_len, data_len)
         }
-        110 => wire__crate__api__accounts__unfollow_user_impl(port, ptr, rust_vec_len, data_len),
-        111 => wire__crate__api__chat_list__unmute_chat_impl(port, ptr, rust_vec_len, data_len),
-        112 => wire__crate__api__accounts__update_account_metadata_impl(
+        111 => wire__crate__api__accounts__unfollow_user_impl(port, ptr, rust_vec_len, data_len),
+        112 => wire__crate__api__chat_list__unmute_chat_impl(port, ptr, rust_vec_len, data_len),
+        113 => wire__crate__api__accounts__update_account_metadata_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        113 => wire__crate__api__update_language_impl(port, ptr, rust_vec_len, data_len),
-        114 => wire__crate__api__accounts__update_notifications_enabled_impl(
+        114 => wire__crate__api__update_language_impl(port, ptr, rust_vec_len, data_len),
+        115 => wire__crate__api__accounts__update_notifications_enabled_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        115 => wire__crate__api__update_theme_mode_impl(port, ptr, rust_vec_len, data_len),
-        116 => wire__crate__api__accounts__upload_account_profile_picture_impl(
+        116 => wire__crate__api__update_theme_mode_impl(port, ptr, rust_vec_len, data_len),
+        117 => wire__crate__api__accounts__upload_account_profile_picture_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        117 => {
+        118 => {
             wire__crate__api__media_files__upload_chat_media_impl(port, ptr, rust_vec_len, data_len)
         }
-        118 => wire__crate__api__groups__upload_group_image_impl(port, ptr, rust_vec_len, data_len),
-        119 => wire__crate__api__notifications__upsert_push_registration_impl(
+        119 => wire__crate__api__groups__upload_group_image_impl(port, ptr, rust_vec_len, data_len),
+        120 => wire__crate__api__notifications__upsert_push_registration_impl(
             port,
             ptr,
             rust_vec_len,
             data_len,
         ),
-        120 => {
+        121 => {
             wire__crate__api__users__user_has_key_package_impl(port, ptr, rust_vec_len, data_len)
         }
-        121 => wire__crate__api__users__user_metadata_impl(port, ptr, rust_vec_len, data_len),
-        122 => wire__crate__api__users__user_relays_impl(port, ptr, rust_vec_len, data_len),
-        123 => wire__crate__api__groups__visible_groups_with_info_impl(
+        122 => wire__crate__api__users__user_metadata_impl(port, ptr, rust_vec_len, data_len),
+        123 => wire__crate__api__users__user_relays_impl(port, ptr, rust_vec_len, data_len),
+        124 => wire__crate__api__groups__visible_groups_with_info_impl(
             port,
             ptr,
             rust_vec_len,
@@ -7410,10 +7453,10 @@ fn pde_ffi_dispatcher_sync_impl(
         68 => wire__crate__api__utils__language_to_string_impl(ptr, rust_vec_len, data_len),
         69 => wire__crate__api__utils__language_turkish_impl(ptr, rust_vec_len, data_len),
         81 => wire__crate__api__utils__npub_from_hex_pubkey_impl(ptr, rust_vec_len, data_len),
-        105 => wire__crate__api__utils__theme_mode_dark_impl(ptr, rust_vec_len, data_len),
-        106 => wire__crate__api__utils__theme_mode_light_impl(ptr, rust_vec_len, data_len),
-        107 => wire__crate__api__utils__theme_mode_system_impl(ptr, rust_vec_len, data_len),
-        108 => wire__crate__api__utils__theme_mode_to_string_impl(ptr, rust_vec_len, data_len),
+        106 => wire__crate__api__utils__theme_mode_dark_impl(ptr, rust_vec_len, data_len),
+        107 => wire__crate__api__utils__theme_mode_light_impl(ptr, rust_vec_len, data_len),
+        108 => wire__crate__api__utils__theme_mode_system_impl(ptr, rust_vec_len, data_len),
+        109 => wire__crate__api__utils__theme_mode_to_string_impl(ptr, rust_vec_len, data_len),
         _ => unreachable!(),
     }
 }
@@ -8620,6 +8663,7 @@ impl flutter_rust_bridge::IntoDart for crate::api::messages::SearchResult {
     fn into_dart(self) -> flutter_rust_bridge::for_generated::DartAbi {
         [
             self.message.into_into_dart().into_dart(),
+            self.mls_group_id.into_into_dart().into_dart(),
             self.highlight_spans.into_into_dart().into_dart(),
             self.position.into_into_dart().into_dart(),
         ]
@@ -10288,6 +10332,7 @@ impl SseEncode for crate::api::messages::SearchResult {
     // Codec=Sse (Serialization based), see doc to use other codecs
     fn sse_encode(self, serializer: &mut flutter_rust_bridge::for_generated::SseSerializer) {
         <crate::api::messages::ChatMessage>::sse_encode(self.message, serializer);
+        <String>::sse_encode(self.mls_group_id, serializer);
         <Vec<crate::api::messages::HighlightSpan>>::sse_encode(self.highlight_spans, serializer);
         <u64>::sse_encode(self.position, serializer);
     }

--- a/test/hooks/use_chat_list_search_test.dart
+++ b/test/hooks/use_chat_list_search_test.dart
@@ -111,9 +111,9 @@ void main() {
         expect(api.searchCalls, isEmpty);
       });
 
-      testWidgets('calls search API after 300ms debounce', (tester) async {
+      testWidgets('calls search API after 150ms debounce', (tester) async {
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
 
         expect(api.searchCalls.length, 1);
@@ -134,7 +134,7 @@ void main() {
         ];
 
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
 
         expect(getState().matchedGroupIds, {testGroupId, otherTestGroupId});
@@ -150,7 +150,7 @@ void main() {
         ];
 
         await pump(tester, query: 'match');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
 
         expect(getState().messageSnippets[testGroupId], 'first match');
@@ -161,7 +161,7 @@ void main() {
         api.searchCompleter = Completer();
 
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
 
         expect(getState().isSearching, isTrue);
       });
@@ -172,12 +172,12 @@ void main() {
         ];
 
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
         expect(getState().matchedGroupIds, isNotEmpty);
 
         await pump(tester);
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
 
         expect(getState().messageSnippets, isEmpty);
@@ -189,7 +189,7 @@ void main() {
         api.shouldFailSearch = true;
 
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pumpAndSettle();
 
         expect(getState().messageSnippets, isEmpty);
@@ -201,7 +201,7 @@ void main() {
         api.searchCompleter = Completer();
 
         await pump(tester, query: 'hello');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         expect(getState().isSearching, isTrue);
 
         final staleCompleter = api.searchCompleter!;
@@ -212,7 +212,7 @@ void main() {
         ];
 
         await pump(tester, query: 'new');
-        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump(const Duration(milliseconds: 150));
         await tester.pump();
 
         staleCompleter.complete([

--- a/test/hooks/use_chat_list_search_test.dart
+++ b/test/hooks/use_chat_list_search_test.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:whitenoise/hooks/use_chat_list_search.dart';
+import 'package:whitenoise/src/rust/api/messages.dart';
+import 'package:whitenoise/src/rust/frb_generated.dart';
+
+import '../mocks/mock_wn_api.dart';
+import '../test_helpers.dart';
+
+ChatMessage _messageFactory(String id, String content) => ChatMessage(
+  id: id,
+  pubkey: testPubkeyA,
+  content: content,
+  createdAt: DateTime(2024),
+  tags: const [],
+  isReply: false,
+  isDeleted: false,
+  contentTokens: const [],
+  reactions: const ReactionSummary(byEmoji: [], userReactions: []),
+  mediaAttachments: const [],
+  kind: 1,
+);
+
+SearchResult _searchResultFactory(
+  String id,
+  String content, {
+  String groupId = testGroupId,
+  List<HighlightSpan> spans = const [],
+  int position = 0,
+}) => SearchResult(
+  message: _messageFactory(id, content),
+  mlsGroupId: groupId,
+  highlightSpans: spans,
+  position: BigInt.from(position),
+);
+
+class _MockApi extends MockWnApi {
+  List<SearchResult> searchResults = [];
+  bool shouldFailSearch = false;
+  Completer<List<SearchResult>>? searchCompleter;
+  final searchCalls = <({String pubkey, String query})>[];
+
+  @override
+  Future<List<SearchResult>> crateApiMessagesSearchMessages({
+    required String pubkey,
+    required String query,
+    int? limit,
+  }) {
+    searchCalls.add((pubkey: pubkey, query: query));
+    if (searchCompleter != null) return searchCompleter!.future;
+    if (shouldFailSearch) return Future.error(Exception('search failed'));
+    return Future.value(searchResults);
+  }
+
+  @override
+  void reset() {
+    super.reset();
+    searchResults = [];
+    shouldFailSearch = false;
+    searchCompleter = null;
+    searchCalls.clear();
+  }
+}
+
+void main() {
+  final api = _MockApi();
+  late ChatListSearchResult Function() getState;
+
+  setUpAll(() => RustLib.initMock(api: api));
+
+  setUp(() {
+    api.reset();
+  });
+
+  Future<void> pump(
+    WidgetTester tester, {
+    String pubkey = testPubkeyA,
+    String query = '',
+  }) async {
+    getState = await mountHook(
+      tester,
+      () => useChatListSearch(pubkey: pubkey, query: query),
+    );
+  }
+
+  group('useChatListSearch', () {
+    group('with empty query', () {
+      testWidgets('returns empty results and is not searching', (tester) async {
+        await pump(tester);
+        await tester.pump();
+
+        expect(getState().messageSnippets, isEmpty);
+        expect(getState().matchedGroupIds, isEmpty);
+        expect(getState().isSearching, isFalse);
+      });
+
+      testWidgets('does not call the search API', (tester) async {
+        await pump(tester);
+        await tester.pump();
+
+        expect(api.searchCalls, isEmpty);
+      });
+    });
+
+    group('debounce behavior', () {
+      testWidgets('does not call API before debounce period elapses', (tester) async {
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 100));
+
+        expect(api.searchCalls, isEmpty);
+      });
+
+      testWidgets('calls search API after 300ms debounce', (tester) async {
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        expect(api.searchCalls.length, 1);
+        expect(api.searchCalls[0].pubkey, testPubkeyA);
+        expect(api.searchCalls[0].query, 'hello');
+      });
+    });
+
+    group('with non-empty query', () {
+      testWidgets('returns message snippets and matched group IDs on success', (tester) async {
+        api.searchResults = [
+          _searchResultFactory('msg1', 'hello world'),
+          _searchResultFactory(
+            'msg2',
+            'say hello',
+            groupId: otherTestGroupId,
+          ),
+        ];
+
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        expect(getState().matchedGroupIds, {testGroupId, otherTestGroupId});
+        expect(getState().messageSnippets[testGroupId], 'hello world');
+        expect(getState().messageSnippets[otherTestGroupId], 'say hello');
+        expect(getState().isSearching, isFalse);
+      });
+
+      testWidgets('groups results by mlsGroupId keeping first match per group', (tester) async {
+        api.searchResults = [
+          _searchResultFactory('msg1', 'first match'),
+          _searchResultFactory('msg2', 'second match'),
+        ];
+
+        await pump(tester, query: 'match');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        expect(getState().messageSnippets[testGroupId], 'first match');
+        expect(getState().matchedGroupIds, {testGroupId});
+      });
+
+      testWidgets('isSearching is true while search is in flight', (tester) async {
+        api.searchCompleter = Completer();
+
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+
+        expect(getState().isSearching, isTrue);
+      });
+
+      testWidgets('clears results when query is cleared', (tester) async {
+        api.searchResults = [
+          _searchResultFactory('msg1', 'hello'),
+        ];
+
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+        expect(getState().matchedGroupIds, isNotEmpty);
+
+        await pump(tester);
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        expect(getState().messageSnippets, isEmpty);
+        expect(getState().matchedGroupIds, isEmpty);
+        expect(getState().isSearching, isFalse);
+      });
+
+      testWidgets('handles search errors gracefully', (tester) async {
+        api.shouldFailSearch = true;
+
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pumpAndSettle();
+
+        expect(getState().messageSnippets, isEmpty);
+        expect(getState().matchedGroupIds, isEmpty);
+        expect(getState().isSearching, isFalse);
+      });
+
+      testWidgets('cancels stale requests when query changes', (tester) async {
+        api.searchCompleter = Completer();
+
+        await pump(tester, query: 'hello');
+        await tester.pump(const Duration(milliseconds: 300));
+        expect(getState().isSearching, isTrue);
+
+        final staleCompleter = api.searchCompleter!;
+
+        api.searchCompleter = null;
+        api.searchResults = [
+          _searchResultFactory('msg2', 'new result', groupId: otherTestGroupId),
+        ];
+
+        await pump(tester, query: 'new');
+        await tester.pump(const Duration(milliseconds: 300));
+        await tester.pump();
+
+        staleCompleter.complete([
+          _searchResultFactory('msg1', 'stale'),
+        ]);
+        await tester.pump();
+
+        expect(getState().matchedGroupIds, {otherTestGroupId});
+        expect(getState().messageSnippets[otherTestGroupId], 'new result');
+        expect(getState().messageSnippets.containsKey(testGroupId), isFalse);
+      });
+    });
+  });
+}

--- a/test/hooks/use_chat_list_search_test.dart
+++ b/test/hooks/use_chat_list_search_test.dart
@@ -101,6 +101,17 @@ void main() {
 
         expect(api.searchCalls, isEmpty);
       });
+
+      testWidgets('treats whitespace-only query as empty', (tester) async {
+        await pump(tester, query: '   ');
+        await tester.pump(const Duration(milliseconds: 150));
+        await tester.pump();
+
+        expect(api.searchCalls, isEmpty);
+        expect(getState().messageSnippets, isEmpty);
+        expect(getState().matchedGroupIds, isEmpty);
+        expect(getState().isSearching, isFalse);
+      });
     });
 
     group('debounce behavior', () {

--- a/test/hooks/use_message_search_test.dart
+++ b/test/hooks/use_message_search_test.dart
@@ -29,6 +29,7 @@ SearchResult _searchResultFactory(
   int position = 0,
 }) => SearchResult(
   message: _messageFactory(id, content),
+  mlsGroupId: testGroupId,
   highlightSpans: spans,
   position: BigInt.from(position),
 );

--- a/test/screens/chat_screen_test.dart
+++ b/test/screens/chat_screen_test.dart
@@ -323,6 +323,7 @@ class _MockApi extends MockWnApi {
         .map(
           (entry) => SearchResult(
             message: entry.value,
+            mlsGroupId: groupId,
             highlightSpans: [
               HighlightSpan(
                 start: entry.value.content.toLowerCase().indexOf(query.toLowerCase()),
@@ -1947,11 +1948,13 @@ void main() {
         _api.searchOverride = (query) => [
           SearchResult(
             message: _api.initialMessages[0],
+            mlsGroupId: _testGroupId,
             highlightSpans: [const HighlightSpan(start: 0, end: 5)],
             position: BigInt.zero,
           ),
           SearchResult(
             message: _api.initialMessages[6],
+            mlsGroupId: _testGroupId,
             highlightSpans: [const HighlightSpan(start: 0, end: 5)],
             position: BigInt.from(6),
           ),

--- a/test/utils/chat_search_test.dart
+++ b/test/utils/chat_search_test.dart
@@ -27,6 +27,21 @@ void main() {
       expect(results, _chats);
     });
 
+    test('returns all chats when query is whitespace only', () {
+      final results = filterChatsBySearchWithMessageMatches(_chats, '   ', {'g1'});
+      expect(results, _chats);
+    });
+
+    test('trims whitespace around query before matching', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        '  Alice  ',
+        <String>{},
+      );
+      expect(results.length, 1);
+      expect(results.first.mlsGroupId, 'd1');
+    });
+
     test('matches by name only', () {
       final results = filterChatsBySearchWithMessageMatches(
         _chats,

--- a/test/utils/chat_search_test.dart
+++ b/test/utils/chat_search_test.dart
@@ -21,67 +21,6 @@ final _chats = [
 ];
 
 void main() {
-  group('filterChatsBySearch', () {
-    group('empty query', () {
-      test('returns all chats when query is empty', () {
-        expect(filterChatsBySearch(_chats, ''), _chats);
-      });
-    });
-
-    group('name matching', () {
-      test('filters by exact name match', () {
-        final results = filterChatsBySearch(_chats, 'Alice');
-        expect(results.length, 1);
-        expect(results.first.mlsGroupId, 'd1');
-      });
-
-      test('filters by partial name match', () {
-        final results = filterChatsBySearch(_chats, 'Team');
-        expect(results.length, 2);
-        expect(results.map((c) => c.mlsGroupId).toList(), ['g1', 'g2']);
-      });
-
-      test('is case-insensitive', () {
-        final results = filterChatsBySearch(_chats, 'alice');
-        expect(results.length, 1);
-        expect(results.first.mlsGroupId, 'd1');
-      });
-
-      test('returns empty list when no matches', () {
-        expect(filterChatsBySearch(_chats, 'Zorro'), isEmpty);
-      });
-
-      test('excludes chats with null name', () {
-        final results = filterChatsBySearch(_chats, 'Engineering');
-        expect(results.every((c) => c.name != null), isTrue);
-      });
-    });
-
-    group('edge cases', () {
-      test('returns empty list when chats list is empty', () {
-        expect(filterChatsBySearch([], 'Alice'), isEmpty);
-      });
-
-      test('preserves original order of matches', () {
-        final results = filterChatsBySearch(_chats, 'Team');
-        expect(results.first.mlsGroupId, 'g1');
-        expect(results.last.mlsGroupId, 'g2');
-      });
-
-      test('matches DM chats by peer display name', () {
-        final results = filterChatsBySearch(_chats, 'Bob');
-        expect(results.length, 1);
-        expect(results.first.groupType, GroupType.directMessage);
-      });
-
-      test('matches group chats by group name', () {
-        final results = filterChatsBySearch(_chats, 'Engineering');
-        expect(results.length, 1);
-        expect(results.first.groupType, GroupType.group);
-      });
-    });
-  });
-
   group('filterChatsBySearchWithMessageMatches', () {
     test('returns all chats when query is empty', () {
       final results = filterChatsBySearchWithMessageMatches(_chats, '', {'g1'});

--- a/test/utils/chat_search_test.dart
+++ b/test/utils/chat_search_test.dart
@@ -81,4 +81,60 @@ void main() {
       });
     });
   });
+
+  group('filterChatsBySearchWithMessageMatches', () {
+    test('returns all chats when query is empty', () {
+      final results = filterChatsBySearchWithMessageMatches(_chats, '', {'g1'});
+      expect(results, _chats);
+    });
+
+    test('matches by name only', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        'Alice',
+        <String>{},
+      );
+      expect(results.length, 1);
+      expect(results.first.mlsGroupId, 'd1');
+    });
+
+    test('matches by messageMatchedGroupIds even if name does not match', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        'Zorro',
+        {'g2', 'd2'},
+      );
+      expect(results.length, 2);
+      expect(results.map((c) => c.mlsGroupId).toSet(), {'g2', 'd2'});
+    });
+
+    test('matches by both name and message content without duplicates', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        'Alice',
+        {'d1', 'g1'},
+      );
+      expect(results.length, 2);
+      expect(results.map((c) => c.mlsGroupId).toSet(), {'d1', 'g1'});
+    });
+
+    test('returns empty when nothing matches', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        'Zorro',
+        <String>{},
+      );
+      expect(results, isEmpty);
+    });
+
+    test('preserves original order', () {
+      final results = filterChatsBySearchWithMessageMatches(
+        _chats,
+        'xyzzy',
+        {'d2', 'g1'},
+      );
+      expect(results.first.mlsGroupId, 'g1');
+      expect(results.last.mlsGroupId, 'd2');
+    });
+  });
 }

--- a/test/utils/search_context_test.dart
+++ b/test/utils/search_context_test.dart
@@ -20,6 +20,7 @@ ChatMessage _msg(String id, {DateTime? createdAt}) => ChatMessage(
 
 SearchResult _result(String id, {DateTime? createdAt, int position = 0}) => SearchResult(
   message: _msg(id, createdAt: createdAt),
+  mlsGroupId: testGroupId,
   highlightSpans: const [HighlightSpan(start: 0, end: 7)],
   position: BigInt.from(position),
 );

--- a/test/widgets/chat_list_tile_test.dart
+++ b/test/widgets/chat_list_tile_test.dart
@@ -544,6 +544,68 @@ void main() {
         expect(item.subtitle, 'Check this out');
         expect(item.subtitleIcon, isNull);
       });
+
+      group('searchSnippet', () {
+        testWidgets('overrides subtitle with the snippet text', (tester) async {
+          await mountWidget(
+            ChatListTile(
+              chatSummary: _chatSummary(
+                name: 'Dev Team',
+                lastMessageContent: 'Hello world',
+                lastMessageAuthor: testPubkeyA,
+              ),
+              searchSnippet: '...matched text...',
+            ),
+            tester,
+            overrides: [
+              accountPubkeyProvider.overrideWith(MockAccountPubkeyNotifier.new),
+            ],
+          );
+          await tester.pumpAndSettle();
+
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.subtitle, '...matched text...');
+        });
+
+        testWidgets('clears prefixSubtitle when snippet is provided', (tester) async {
+          await mountWidget(
+            ChatListTile(
+              chatSummary: _chatSummary(
+                name: 'Dev Team',
+                lastMessageContent: 'Hello world',
+                lastMessageAuthor: testPubkeyA,
+              ),
+              searchSnippet: '...matched text...',
+            ),
+            tester,
+            overrides: [
+              accountPubkeyProvider.overrideWith(MockAccountPubkeyNotifier.new),
+            ],
+          );
+          await tester.pumpAndSettle();
+
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.prefixSubtitle, isNull);
+        });
+
+        testWidgets('clears subtitleIcon when snippet is provided', (tester) async {
+          await mountWidget(
+            ChatListTile(
+              chatSummary: _chatSummary(lastMessageMediaAttachmentCount: 2),
+              searchSnippet: '...matched text...',
+            ),
+            tester,
+            overrides: [
+              accountPubkeyProvider.overrideWith(MockAccountPubkeyNotifier.new),
+            ],
+          );
+          await tester.pumpAndSettle();
+
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.subtitleIcon, isNull);
+          expect(find.byKey(const Key('media_subtitle_icon')), findsNothing);
+        });
+      });
     });
 
     group('avatar', () {

--- a/test/widgets/wn_search_and_filters_test.dart
+++ b/test/widgets/wn_search_and_filters_test.dart
@@ -23,6 +23,22 @@ void main() {
       });
     });
 
+    group('isLoading', () {
+      testWidgets('forwards isLoading=true to WnSearchField', (tester) async {
+        await mountWidget(const WnSearchAndFilters(isLoading: true), tester);
+        final field = tester.widget<WnSearchField>(find.byType(WnSearchField));
+        expect(field.isLoading, isTrue);
+        expect(find.byKey(const Key('search_loading_indicator')), findsOneWidget);
+      });
+
+      testWidgets('forwards isLoading=false to WnSearchField by default', (tester) async {
+        await mountWidget(const WnSearchAndFilters(), tester);
+        final field = tester.widget<WnSearchField>(find.byType(WnSearchField));
+        expect(field.isLoading, isFalse);
+        expect(find.byKey(const Key('search_loading_indicator')), findsNothing);
+      });
+    });
+
     group('search callback', () {
       testWidgets('calls onSearchChanged when text is entered', (tester) async {
         String? searchValue;


### PR DESCRIPTION
![marmot](https://blossom.primal.net/47de183d5336f22041f5c8fca61984de8172d4dcf5ac85667093f003d3bcd185.jpg)

This marmot dug through every burrow to find your messages.

## What changed

Chat list search now finds chats by message content, not just chat names. Type a query in the home screen search bar and chats containing matching messages appear in the results with the matched message shown as the subtitle.

## How it works

1. User types in the search bar
2. Name-matched chats appear instantly (synchronous client-side filter, same as before)
3. After a 300ms debounce, `searchMessages` fires a single SQL query across all groups via the Rust API
4. Chats with matching messages merge into the list, showing the matched snippet as subtitle

The search runs through whitenoise-rs `search_messages(pubkey, query, limit)` (commit 8605c2c), which queries `aggregated_messages` joined against `accounts_groups` to scope results to the user's chats. Position is computed per-group via `PARTITION BY mls_group_id` so the frontend can still jump to the right page within each conversation.

## Changes

**Rust layer**
- Bumped whitenoise-rs to 8605c2c (adds cross-group `search_messages`)
- Added `mls_group_id` to `SearchResult` struct (upstream breaking change)
- Added `search_messages` API function wrapping `whitenoise.search_messages`
- Updated `fetch_aggregated_messages_for_group` for new `PaginationOptions` struct

**Flutter layer**
- New `useChatListSearch` hook: debounced cross-group message search, returns `{messageSnippets, matchedGroupIds, isSearching}`
- New `filterChatsBySearchWithMessageMatches` function: merges name and message-content matches
- `ChatListTile` accepts optional `searchSnippet` that overrides the subtitle during search
- `ChatListScreen` wires the hook, new filter, snippets, and loading indicator
- `WnSearchAndFilters` passes `isLoading` through to the search field

**Tests**
- 10 new hook tests (debounce, cancellation, grouping, error handling)
- 6 new filter function tests
- Fixed pre-existing `SearchResult` compilation in 3 test files (missing `mlsGroupId`)

Closes #350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global message search across all chats with debounced queries.
  * Per-chat message snippets displayed in the chat list (first match per chat).
  * Chat filtering now considers both chat name and message-content matches.
  * Search field shows a loading indicator while searches run.

* **Bug Fixes / Reliability**
  * Prevents stale/in-flight results from overwriting newer searches; clears state on errors or empty queries.

* **Tests**
  * Added comprehensive tests for the search behavior, filtering, UI snippets, and loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->