### PR TITLE
Remove direct mdk-core dependency, use whitenoise re-exports

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3795,7 +3795,6 @@ dependencies = [
  "chrono",
  "flutter_rust_bridge",
  "hex",
- "mdk-core",
  "nostr-sdk",
  "serde_json",
  "thiserror 2.0.18",
@@ -5246,7 +5245,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4ab90900abd735629f6ecbb54f7de0bdb7ffb2b#e4ab90900abd735629f6ecbb54f7de0bdb7ffb2b"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=51fef295746eab060afd97af4946b8238737e854#51fef295746eab060afd97af4946b8238737e854"
 dependencies = [
  "android-native-keyring-store",
  "anyhow",
@@ -5294,7 +5293,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4ab90900abd735629f6ecbb54f7de0bdb7ffb2b#e4ab90900abd735629f6ecbb54f7de0bdb7ffb2b"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=51fef295746eab060afd97af4946b8238737e854#51fef295746eab060afd97af4946b8238737e854"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,10 +11,6 @@ anyhow = "1.0.99"
 chrono = { version = "0.4.40", features = ["serde"] }
 flutter_rust_bridge = { version = "=2.11.1", features = ["chrono"] }
 hex = "0.4"
-mdk-core = { version = "0.7.1", git = "https://github.com/marmot-protocol/mdk", rev = "fbd3a1bee99feae39e475ee00bf4634c4fe3443a", features = [
-    "mip04",
-    "mip05",
-] }
 nostr-sdk = { version = "0.44", features = [
     "nip04",
     "nip44",
@@ -26,7 +22,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "e4ab90900abd735629f6ecbb54f7de0bdb7ffb2b" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "51fef295746eab060afd97af4946b8238737e854" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/account_groups.rs
+++ b/rust/src/api/account_groups.rs
@@ -1,9 +1,9 @@
 use crate::api::{error::ApiError, utils::group_id_to_string};
 use flutter_rust_bridge::frb;
-use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::*;
 use whitenoise::AccountGroup as WhitenoiseAccountGroup;
 use whitenoise::Whitenoise;
+use whitenoise::mdk::GroupId;
 
 /// Represents the relationship between an account and an MLS group.
 ///

--- a/rust/src/api/chat_list.rs
+++ b/rust/src/api/chat_list.rs
@@ -5,8 +5,8 @@ use crate::api::utils::group_id_to_string;
 use crate::frb_generated::StreamSink;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
-use mdk_core::prelude::GroupId;
 use nostr_sdk::PublicKey;
+use whitenoise::mdk::GroupId;
 use whitenoise::whitenoise::chat_list::ChatListItem as WhitenoiseChatListItem;
 use whitenoise::{
     ChatListUpdate as WhitenoiseChatListUpdate,
@@ -198,7 +198,7 @@ pub async fn set_chat_pin_order(
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = hex::decode(&mls_group_id)?;
-    let group_id = mdk_core::prelude::GroupId::from_slice(&group_id_bytes);
+    let group_id = GroupId::from_slice(&group_id_bytes);
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
 
     whitenoise

--- a/rust/src/api/groups.rs
+++ b/rust/src/api/groups.rs
@@ -1,10 +1,9 @@
 use crate::api::{error::ApiError, group_id_from_string, group_id_to_string};
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
-use mdk_core::prelude::group_types::Group as WhitenoiseGroup;
-use mdk_core::prelude::group_types::GroupState as WhitenoiseGroupState;
-use mdk_core::prelude::{NostrGroupConfigData, NostrGroupDataUpdate};
 use nostr_sdk::prelude::*;
+use whitenoise::mdk::{Group as WhitenoiseGroup, GroupState as WhitenoiseGroupState};
+use whitenoise::mdk::{NostrGroupConfigData, NostrGroupDataUpdate};
 use whitenoise::{
     GroupInformation as WhitenoiseGroupInformation, GroupType as WhitenoiseGroupType,
     GroupWithInfoAndMembership as WhitenoiseGroupWithInfoAndMembership, Whitenoise,

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -10,6 +10,7 @@ use nostr_sdk::prelude::*;
 use tracing::{info, warn};
 use whitenoise::whitenoise::message_aggregator::ChatMessageSummary as WhitenoiseChatMessageSummary;
 use whitenoise::whitenoise::message_aggregator::SearchResult as WhitenoiseSearchResult;
+use whitenoise::whitenoise::messages::PaginationOptions;
 pub use whitenoise::{
     ChatMessage as WhitenoiseChatMessage, DeliveryStatus as WhitenoiseDeliveryStatus,
     EmojiReaction as WhitenoiseEmojiReaction, MediaFile as WhitenoiseMediaFile,
@@ -507,14 +508,13 @@ pub async fn fetch_aggregated_messages_for_group(
             Ok(Timestamp::from(ts as u64))
         })
         .transpose()?;
+    let options = PaginationOptions {
+        before: before_ts,
+        before_message_id,
+        ..Default::default()
+    };
     let messages = whitenoise
-        .fetch_aggregated_messages_for_group(
-            &pubkey,
-            &group_id,
-            before_ts,
-            before_message_id.as_deref(),
-            limit,
-        )
+        .fetch_aggregated_messages_for_group(&pubkey, &group_id, &options, limit)
         .await?;
     Ok(messages.into_iter().map(|m| m.into()).collect())
 }

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 pub use whitenoise::{AppSettings, Language, RelayType, ThemeMode, Whitenoise};
 
 // Re-export types that flutter_rust_bridge needs
-pub use mdk_core::prelude::GroupId;
 pub use nostr_sdk::{Event, PublicKey, RelayUrl, Tag};
+pub use whitenoise::mdk::GroupId;
 
 /// Flutter-compatible configuration structure that holds directory paths as strings.
 ///

--- a/rust/src/api/utils.rs
+++ b/rust/src/api/utils.rs
@@ -6,9 +6,9 @@
 use crate::api::error::ApiError;
 use crate::api::{Language, ThemeMode};
 use flutter_rust_bridge::frb;
-use mdk_core::prelude::GroupId;
 use nostr_sdk::prelude::*;
 pub use whitenoise::Whitenoise;
+use whitenoise::mdk::GroupId;
 
 #[frb(sync)]
 pub fn npub_from_hex_pubkey(hex_pubkey: &str) -> Result<String, ApiError> {


### PR DESCRIPTION
![marmot](https://blossom.primal.net/f480ec3d06e53289bbcced4244eeb60ae2ae993602719ac0101347b7f2955845.jpg)

The whitenoise crate now re-exports all mdk types we need through its `mdk` module. This PR drops the direct `mdk-core` dependency and points all imports at `whitenoise::mdk::*` instead.

**Changes:**

- Removed `mdk-core` from `rust/Cargo.toml`
- Replaced all `mdk_core::prelude::*` imports with `whitenoise::mdk::*` across 6 files
- Bumped whitenoise rev to `51fef29` (the commit that added the re-exports)
- Adapted `fetch_aggregated_messages_for_group` to the new `PaginationOptions` API introduced in the same rev

One dependency instead of two. One version to track instead of two. Less room for version drift between mdk-core and whitenoise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal dependencies by migrating core data types to the Whitenoise library, streamlining the codebase architecture.
  * Updated dependency versions to align with the refactored imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->