### PR TITLE
Increase timeout for APK build from 30 to 90 minutes

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -43,7 +43,7 @@ jobs:
   build-apk:
     name: Build Staging APK
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 90
     needs: [check-team]
     env:
       ARTIFACT_SUFFIX: unknown


### PR DESCRIPTION
<img src="https://blossom.primal.net/00a9cee8559834a8e7c0e95781c13678b6030a92a9668ea20ce1abdc82af1ae6.jpg" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process stability to allow additional time for app compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->