### PR TITLE
[codex] Update whitenoise-rs master ref

### DIFF
--- a/lib/hooks/use_chat_list.dart
+++ b/lib/hooks/use_chat_list.dart
@@ -63,6 +63,12 @@ ChatListResult useChatList(String pubkey, {bool archived = false}) {
                     chatMap.value[id] = update.item;
                   case ChatListUpdateTrigger.leftGroup:
                     chatMap.value[id] = update.item;
+                  case ChatListUpdateTrigger.chatCleared:
+                    chatMap.value[id] = update.item;
+                  case ChatListUpdateTrigger.chatDeleted:
+                    chatMap.value.remove(id);
+                  case ChatListUpdateTrigger.userBlockChanged:
+                    chatMap.value[id] = update.item;
                 }
                 return chatMap.value;
               },

--- a/lib/l10n/generated/app_localizations_es.dart
+++ b/lib/l10n/generated/app_localizations_es.dart
@@ -333,7 +333,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Asegúrate de haber respaldado tu llave privada en ';
 
   @override
-  String get signOutCalloutDescriptionLink => 'Ajustes → Llaves de perfil';
+  String get signOutCalloutDescriptionLink => 'Ajustes → Llaves del perfil';
 
   @override
   String get signOutCalloutDescriptionAfter => '. Sin ella, no podrás iniciar sesión de nuevo.';

--- a/lib/l10n/generated/app_localizations_tr.dart
+++ b/lib/l10n/generated/app_localizations_tr.dart
@@ -331,7 +331,7 @@ class AppLocalizationsTr extends AppLocalizations {
   String get signOutCalloutDescriptionBefore => 'Özel anahtarınızı ';
 
   @override
-  String get signOutCalloutDescriptionLink => 'Ayarlar → Profil Anahtarları';
+  String get signOutCalloutDescriptionLink => 'Ayarlar → Profil anahtarları';
 
   @override
   String get signOutCalloutDescriptionAfter =>

--- a/lib/src/rust/api/chat_list.dart
+++ b/lib/src/rust/api/chat_list.dart
@@ -149,6 +149,15 @@ enum ChatListUpdateTrigger {
 
   /// This account left the group.
   leftGroup,
+
+  /// All messages in the chat were cleared.
+  chatCleared,
+
+  /// The chat was deleted.
+  chatDeleted,
+
+  /// A user was blocked or unblocked.
+  userBlockChanged,
 }
 
 @freezed

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "mdk-core"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
 dependencies = [
  "base64",
  "blurhash",
@@ -2487,12 +2487,12 @@ dependencies = [
 [[package]]
 name = "mdk-macros"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
 
 [[package]]
 name = "mdk-sqlite-storage"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
 dependencies = [
  "getrandom 0.4.2",
  "hex",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "mdk-storage-traits"
 version = "0.7.1"
-source = "git+https://github.com/marmot-protocol/mdk?rev=fbd3a1bee99feae39e475ee00bf4634c4fe3443a#fbd3a1bee99feae39e475ee00bf4634c4fe3443a"
+source = "git+https://github.com/marmot-protocol/mdk?rev=8a8d06c19d617394b0e268f5f9adfad34db3cdf6#8a8d06c19d617394b0e268f5f9adfad34db3cdf6"
 dependencies = [
  "nostr",
  "openmls",
@@ -5165,10 +5165,9 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca#e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=9625bfdd103d18f61c4e058d3e60708722711e4a#9625bfdd103d18f61c4e058d3e60708722711e4a"
 dependencies = [
  "android-native-keyring-store",
- "anyhow",
  "apple-native-keyring-store",
  "async-trait",
  "base64ct",
@@ -5208,7 +5207,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca#e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=9625bfdd103d18f61c4e058d3e60708722711e4a#9625bfdd103d18f61c4e058d3e60708722711e4a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "e4e850dd815aa0dd31bbde45d6ee23d86e6b27ca" }
+whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "9625bfdd103d18f61c4e058d3e60708722711e4a" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/accounts.rs
+++ b/rust/src/api/accounts.rs
@@ -224,7 +224,9 @@ pub async fn upload_account_profile_picture(
 ) -> Result<String, ApiError> {
     let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let image_type = ImageType::try_from(image_type)?;
+    let image_type = ImageType::try_from(image_type).map_err(|error| ApiError::Other {
+        message: error.to_string(),
+    })?;
 
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let server = Url::parse(&server_url)?;

--- a/rust/src/api/chat_list.rs
+++ b/rust/src/api/chat_list.rs
@@ -133,6 +133,12 @@ pub enum ChatListUpdateTrigger {
     ChatMuteChanged,
     /// This account left the group.
     LeftGroup,
+    /// All messages in the chat were cleared.
+    ChatCleared,
+    /// The chat was deleted.
+    ChatDeleted,
+    /// A user was blocked or unblocked.
+    UserBlockChanged,
 }
 
 impl From<WhitenoiseChatListUpdateTrigger> for ChatListUpdateTrigger {
@@ -145,6 +151,9 @@ impl From<WhitenoiseChatListUpdateTrigger> for ChatListUpdateTrigger {
             WhitenoiseChatListUpdateTrigger::RemovedFromGroup => Self::RemovedFromGroup,
             WhitenoiseChatListUpdateTrigger::ChatMuteChanged => Self::ChatMuteChanged,
             WhitenoiseChatListUpdateTrigger::LeftGroup => Self::LeftGroup,
+            WhitenoiseChatListUpdateTrigger::ChatCleared => Self::ChatCleared,
+            WhitenoiseChatListUpdateTrigger::ChatDeleted => Self::ChatDeleted,
+            WhitenoiseChatListUpdateTrigger::UserBlockChanged => Self::UserBlockChanged,
         }
     }
 }
@@ -447,5 +456,24 @@ mod tests {
             MuteDuration::from(ChatMuteDuration::Custom { until: custom_time }),
             MuteDuration::Custom(custom_time)
         );
+    }
+
+    #[test]
+    fn test_chat_list_update_trigger_conversion_chat_cleared() {
+        let trigger: ChatListUpdateTrigger = WhitenoiseChatListUpdateTrigger::ChatCleared.into();
+        assert_eq!(trigger, ChatListUpdateTrigger::ChatCleared);
+    }
+
+    #[test]
+    fn test_chat_list_update_trigger_conversion_chat_deleted() {
+        let trigger: ChatListUpdateTrigger = WhitenoiseChatListUpdateTrigger::ChatDeleted.into();
+        assert_eq!(trigger, ChatListUpdateTrigger::ChatDeleted);
+    }
+
+    #[test]
+    fn test_chat_list_update_trigger_conversion_user_block_changed() {
+        let trigger: ChatListUpdateTrigger =
+            WhitenoiseChatListUpdateTrigger::UserBlockChanged.into();
+        assert_eq!(trigger, ChatListUpdateTrigger::UserBlockChanged);
     }
 }

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -613,9 +613,12 @@ pub async fn subscribe_to_group_messages(
     info!(group_id = %group_id_str, "subscribe_to_group_messages: subscribing");
 
     let parsed_pubkey = pubkey.as_deref().map(PublicKey::parse).transpose()?;
+    let subscription_pubkey = parsed_pubkey.as_ref().ok_or_else(|| ApiError::Other {
+        message: "pubkey is required to subscribe to group messages".to_string(),
+    })?;
 
     let subscription = whitenoise
-        .subscribe_to_group_messages(&group_id, None)
+        .subscribe_to_group_messages(subscription_pubkey, &group_id, None)
         .await?;
 
     // When a pubkey is provided, replace the subscription's initial snapshot with an

--- a/rust/src/frb_generated.rs
+++ b/rust/src/frb_generated.rs
@@ -5621,6 +5621,9 @@ impl SseDecode for crate::api::chat_list::ChatListUpdateTrigger {
             4 => crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup,
             5 => crate::api::chat_list::ChatListUpdateTrigger::ChatMuteChanged,
             6 => crate::api::chat_list::ChatListUpdateTrigger::LeftGroup,
+            7 => crate::api::chat_list::ChatListUpdateTrigger::ChatCleared,
+            8 => crate::api::chat_list::ChatListUpdateTrigger::ChatDeleted,
+            9 => crate::api::chat_list::ChatListUpdateTrigger::UserBlockChanged,
             _ => unreachable!("Invalid variant for ChatListUpdateTrigger: {}", inner),
         };
     }
@@ -7844,6 +7847,9 @@ impl flutter_rust_bridge::IntoDart for crate::api::chat_list::ChatListUpdateTrig
             Self::RemovedFromGroup => 4.into_dart(),
             Self::ChatMuteChanged => 5.into_dart(),
             Self::LeftGroup => 6.into_dart(),
+            Self::ChatCleared => 7.into_dart(),
+            Self::ChatDeleted => 8.into_dart(),
+            Self::UserBlockChanged => 9.into_dart(),
             _ => unreachable!(),
         }
     }
@@ -9437,6 +9443,9 @@ impl SseEncode for crate::api::chat_list::ChatListUpdateTrigger {
                 crate::api::chat_list::ChatListUpdateTrigger::RemovedFromGroup => 4,
                 crate::api::chat_list::ChatListUpdateTrigger::ChatMuteChanged => 5,
                 crate::api::chat_list::ChatListUpdateTrigger::LeftGroup => 6,
+                crate::api::chat_list::ChatListUpdateTrigger::ChatCleared => 7,
+                crate::api::chat_list::ChatListUpdateTrigger::ChatDeleted => 8,
+                crate::api::chat_list::ChatListUpdateTrigger::UserBlockChanged => 9,
                 _ => {
                     unimplemented!("");
                 }

--- a/test/hooks/use_chat_list_test.dart
+++ b/test/hooks/use_chat_list_test.dart
@@ -419,6 +419,71 @@ void main() {
       });
     });
 
+    group('chatCleared trigger', () {
+      testWidgets('updates chat data without changing order', (tester) async {
+        final getResult = await _pump(tester, testPubkeyA);
+
+        _api.emitInitialSnapshot([
+          _chatSummary('c1', DateTime(2024)),
+          _chatSummary('c2', DateTime(2024, 1, 2)),
+        ]);
+        await tester.pumpAndSettle();
+
+        _api.emitUpdate(
+          ChatListUpdateTrigger.chatCleared,
+          _chatSummary('c2', DateTime(2024, 1, 2), mutedUntil: DateTime(2025)),
+        );
+        await tester.pumpAndSettle();
+
+        final chats = getResult().chats;
+        expect(chats.map((c) => c.mlsGroupId).toList(), ['mls_c1', 'mls_c2']);
+        expect(chats[1].mutedUntil, DateTime(2025));
+      });
+    });
+
+    group('chatDeleted trigger', () {
+      testWidgets('removes deleted chat from the list', (tester) async {
+        final getResult = await _pump(tester, testPubkeyA);
+
+        _api.emitInitialSnapshot([
+          _chatSummary('c1', DateTime(2024)),
+          _chatSummary('c2', DateTime(2024, 1, 2)),
+        ]);
+        await tester.pumpAndSettle();
+
+        _api.emitUpdate(
+          ChatListUpdateTrigger.chatDeleted,
+          _chatSummary('c2', DateTime(2024, 1, 2)),
+        );
+        await tester.pumpAndSettle();
+
+        final ids = getResult().chats.map((c) => c.mlsGroupId).toList();
+        expect(ids, ['mls_c1']);
+      });
+    });
+
+    group('userBlockChanged trigger', () {
+      testWidgets('updates chat data without changing order', (tester) async {
+        final getResult = await _pump(tester, testPubkeyA);
+
+        _api.emitInitialSnapshot([
+          _chatSummary('c1', DateTime(2024)),
+          _chatSummary('c2', DateTime(2024, 1, 2)),
+        ]);
+        await tester.pumpAndSettle();
+
+        _api.emitUpdate(
+          ChatListUpdateTrigger.userBlockChanged,
+          _chatSummary('c2', DateTime(2024, 1, 2), mutedUntil: DateTime(2025)),
+        );
+        await tester.pumpAndSettle();
+
+        final chats = getResult().chats;
+        expect(chats.map((c) => c.mlsGroupId).toList(), ['mls_c1', 'mls_c2']);
+        expect(chats[1].mutedUntil, DateTime(2025));
+      });
+    });
+
     group('with archived true', () {
       testWidgets('adds archived chat on archive change', (tester) async {
         final getResult = await _pumpWithArchived(tester, testPubkeyA, archived: true);


### PR DESCRIPTION
## Summary

- Bump the `whitenoise-rs` dependency to upstream master `9625bfdd103d18f61c4e058d3e60708722711e4a`.
- Regenerate the Flutter/Rust bridge output.
- Adapt the app to upstream API changes: the message subscription now requires an account pubkey, image type parsing maps the now-private error at the callsite, and chat list streams handle `ChatCleared`, `ChatDeleted`, and `UserBlockChanged`.
- Add hook coverage for the new chat-list triggers.
- Refresh generated l10n output to match the ARB sources.

## Validation

- `just precommit`
- `flutter run --flavor staging -d iPhone 17 Pro --debug` launched successfully on the iOS simulator before the run session was quit cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat list management: chats can now be cleared and deleted, with improved handling of user blocks in chat lists.

* **Bug Fixes**
  * Improved error handling for profile picture uploads and stricter validation for group message subscriptions.

* **Tests**
  * Added comprehensive test coverage for new chat clearing, deletion, and user blocking update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->