### PR TITLE
Leave group from chatlist UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to Calendar Versioning (CalVer).
 - No internet notice [PR #565](https://github.com/marmot-protocol/whitenoise/pull/565), [PR #576](https://github.com/marmot-protocol/whitenoise/pull/576), [PR #586](https://github.com/marmot-protocol/whitenoise/pull/586)
 - Block/unblock users [PR #573](https://github.com/marmot-protocol/whitenoise/pull/573), [PR #574](https://github.com/marmot-protocol/whitenoise/pull/574)
 - Video media attachment support[PR #574](https://github.com/marmot-protocol/whitenoise/pull/574)
+- Leave group from chat list (but disabled with a feature flag) [PR #604](https://github.com/marmot-protocol/whitenoise/pull/604), [PR #600](https://github.com/marmot-protocol/whitenoise/pull/600), [PR #571](https://github.com/marmot-protocol/whitenoise/pull/571)
 
 ### Changed
 - Update System Notice colors [PR #579](https://github.com/marmot-protocol/whitenoise/pull/579)
@@ -44,6 +45,7 @@ and this project adheres to Calendar Versioning (CalVer).
 - Show an error screen when bridge initialization fails instead of hanging on splash [PR #477](https://github.com/marmot-protocol/whitenoise/pull/477)
 - UI Polish: Signup Screen, Callout, IconButton [PR #519](https://github.com/marmot-protocol/whitenoise/pull/519)
 - Replaced delete all key packages with delete legacy key packages method. [PR #585](https://github.com/marmot-protocol/whitenoise/pull/585)
+- Renamed "contact" wording to "follows" [PR #595](https://github.com/marmot-protocol/whitenoise/pull/595)
 
 ### Deprecated
 

--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -99,9 +99,20 @@ class ChatListScreen extends HookConsumerWidget {
     required String? updateVersion,
     required VoidCallback onUpdateDismiss,
     required VoidCallback onWelcomeDismiss,
+    required String? noticeMessage,
+    required WnSystemNoticeType noticeType,
+    required VoidCallback onNoticeDismiss,
   }) {
     if (isOffline) {
       return const OfflineSystemNotice();
+    }
+    if (noticeMessage != null) {
+      return WnSystemNotice(
+        key: ValueKey(noticeMessage),
+        title: noticeMessage,
+        type: noticeType,
+        onDismiss: onNoticeDismiss,
+      );
     }
     if (updateVersion != null) {
       return WnSystemNotice(
@@ -296,21 +307,14 @@ class ChatListScreen extends HookConsumerWidget {
                       welcomeNoticeDismissed.value = true;
                     }
                   },
+                  noticeMessage: notice.noticeMessage,
+                  noticeType: notice.noticeType,
+                  onNoticeDismiss: notice.dismissNotice,
                 ),
                 header: const ChatListHeader(),
               ),
             ),
           ),
-          if (notice.noticeMessage != null)
-            SafeArea(
-              bottom: false,
-              child: WnSystemNotice(
-                key: ValueKey(notice.noticeMessage),
-                title: notice.noticeMessage!,
-                type: notice.noticeType,
-                onDismiss: notice.dismissNotice,
-              ),
-            ),
         ],
       ),
     );

--- a/lib/widgets/chat_list_menu.dart
+++ b/lib/widgets/chat_list_menu.dart
@@ -6,29 +6,42 @@ import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/widgets/wn_button.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
+import 'package:whitenoise/widgets/wn_slate_navigation_header.dart';
 
 const _animationDuration = Duration(milliseconds: 150);
 
-class WnChatListContextMenuAction {
+class _BackObserver extends WidgetsBindingObserver {
+  final bool Function() _onPop;
+  _BackObserver({required bool Function() onPop}) : _onPop = onPop;
+
+  @override
+  Future<bool> didPopRoute() async => _onPop();
+}
+
+class ChatListAction {
   final String id;
   final String label;
   final WnIcons icon;
-  final VoidCallback? onTap;
+  final Future<void> Function()? onTap;
   final bool isDestructive;
+  final bool autoDismiss;
 
-  const WnChatListContextMenuAction({
+  const ChatListAction({
     required this.id,
     required this.label,
     required this.icon,
     this.onTap,
     this.isDestructive = false,
+    this.autoDismiss = true,
   });
 }
 
-class WnChatListContextMenuController {
+class ChatListMenuController {
   OverlayEntry? _overlay;
   Future<void> Function()? _animatedDismiss;
   bool _dismissing = false;
+  void Function(List<ChatListAction>, Widget?, String?, VoidCallback?)? _applyUpdate;
+  VoidCallback? _onBack;
 
   bool get isShowing => _overlay != null;
 
@@ -50,16 +63,18 @@ class WnChatListContextMenuController {
     }
   }
 
-  void dispose() {
-    _animatedDismiss = null;
-    _overlay?.remove();
-    _overlay = null;
-    _dismissing = false;
+  void updateState(
+    List<ChatListAction> actions, {
+    Widget? middleContent,
+    String? title,
+    VoidCallback? onBack,
+  }) {
+    _applyUpdate?.call(actions, middleContent, title, onBack);
   }
 }
 
-class WnChatListContextMenu extends HookWidget {
-  const WnChatListContextMenu({
+class ChatListMenu extends HookWidget {
+  const ChatListMenu({
     super.key,
     required this.child,
     required this.itemPosition,
@@ -72,24 +87,24 @@ class WnChatListContextMenu extends HookWidget {
   final Widget child;
   final Offset itemPosition;
   final double itemHeight;
-  final List<WnChatListContextMenuAction> actions;
+  final List<ChatListAction> actions;
   final VoidCallback onDismiss;
-  final WnChatListContextMenuController controller;
+  final ChatListMenuController controller;
 
-  static WnChatListContextMenuController show(
+  static ChatListMenuController show(
     BuildContext context, {
     required Widget child,
     required RenderBox childRenderBox,
-    required List<WnChatListContextMenuAction> actions,
+    required List<ChatListAction> actions,
   }) {
-    final menuController = WnChatListContextMenuController();
+    final menuController = ChatListMenuController();
 
     final position = childRenderBox.localToGlobal(Offset.zero);
     final height = childRenderBox.size.height;
     final overlay = Overlay.of(context);
 
     final entry = OverlayEntry(
-      builder: (_) => WnChatListContextMenu(
+      builder: (_) => ChatListMenu(
         itemPosition: position,
         itemHeight: height,
         actions: actions,
@@ -107,6 +122,10 @@ class WnChatListContextMenu extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+    final actionsState = useState(actions);
+    final titleState = useState<String?>(null);
+    final middleContentState = useState<Widget?>(null);
+
     final colors = context.colors;
     final mediaQuery = MediaQuery.of(context);
     final screenHeight = mediaQuery.size.height;
@@ -119,12 +138,24 @@ class WnChatListContextMenu extends HookWidget {
     final containerGap = 12.h;
     final menuHorizontalInset = 10.w;
 
-    final buttonCount = actions.length;
+    final currentActions = actionsState.value;
+    final currentTitle = titleState.value;
+    final currentMiddleContent = middleContentState.value;
+
+    final buttonCount = currentActions.length;
     final estimatedButtonHeight = 44.h;
     final totalButtonsHeight =
         (estimatedButtonHeight * buttonCount) + (buttonSpacing * (buttonCount - 1));
+    final estimatedHeaderHeight = currentTitle != null ? 80.h : 0.0;
+    final estimatedMiddleContentHeight = currentMiddleContent != null ? 80.h : 0.0;
     final menuContentHeight =
-        menuPadding + itemHeight + containerGap + totalButtonsHeight + menuPadding;
+        menuPadding +
+        estimatedHeaderHeight +
+        itemHeight +
+        containerGap +
+        estimatedMiddleContentHeight +
+        totalButtonsHeight +
+        menuPadding;
 
     final idealTop = itemPosition.dy - menuPadding;
     final minTop = safeTop;
@@ -132,7 +163,7 @@ class WnChatListContextMenu extends HookWidget {
     final clampedTop = idealTop.clamp(minTop, maxTop);
 
     final menuWidth = screenWidth - (menuHorizontalInset * 2);
-    final itemCenterInMenu = menuPadding + (itemHeight / 2);
+    final itemCenterInMenu = menuPadding + estimatedHeaderHeight + (itemHeight / 2);
     final alignX = (itemPosition.dx - menuHorizontalInset) / menuWidth;
     final alignY = (itemCenterInMenu / menuContentHeight) * 2 - 1;
 
@@ -145,8 +176,27 @@ class WnChatListContextMenu extends HookWidget {
     useEffect(() {
       animController.forward();
       controller._animatedDismiss = () => animController.reverse();
+      controller._applyUpdate = (newActions, middleContent, title, onBack) {
+        actionsState.value = newActions;
+        middleContentState.value = middleContent;
+        titleState.value = title;
+        controller._onBack = onBack;
+      };
+      final backObserver = _BackObserver(
+        onPop: () {
+          if (controller._onBack != null) {
+            controller._onBack!();
+          } else {
+            onDismiss();
+          }
+          return true;
+        },
+      );
+      WidgetsBinding.instance.addObserver(backObserver);
       return () {
         controller._animatedDismiss = null;
+        controller._applyUpdate = null;
+        WidgetsBinding.instance.removeObserver(backObserver);
         curvedAnimation.dispose();
       };
     }, const []);
@@ -157,16 +207,18 @@ class WnChatListContextMenu extends HookWidget {
         key: const Key('context_menu_dismiss'),
         behavior: HitTestBehavior.opaque,
         onTap: onDismiss,
-        onVerticalDragStart: (_) => onDismiss(),
         child: Stack(
           children: [
             Positioned.fill(
-              child: FadeTransition(
-                opacity: curvedAnimation,
-                child: BackdropFilter(
-                  key: const Key('context_menu_overlay'),
-                  filter: ImageFilter.blur(sigmaX: 10.0.r, sigmaY: 10.0.r),
-                  child: ColoredBox(color: colors.overlaySecondary),
+              child: GestureDetector(
+                onVerticalDragStart: (_) => onDismiss(),
+                child: FadeTransition(
+                  opacity: curvedAnimation,
+                  child: BackdropFilter(
+                    key: const Key('context_menu_overlay'),
+                    filter: ImageFilter.blur(sigmaX: 10.0.r, sigmaY: 10.0.r),
+                    child: ColoredBox(color: colors.overlaySecondary),
+                  ),
                 ),
               ),
             ),
@@ -201,24 +253,44 @@ class WnChatListContextMenu extends HookWidget {
                           ),
                         ],
                       ),
-                      padding: EdgeInsets.all(menuPadding),
+                      padding: EdgeInsets.symmetric(vertical: menuPadding),
                       child: Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
-                          Container(
-                            decoration: BoxDecoration(
-                              color: colors.backgroundPrimary,
-                              borderRadius: BorderRadius.circular(8.r),
-                              border: Border.all(color: colors.borderTertiary),
+                          if (currentTitle != null)
+                            WnSlateNavigationHeader(
+                              key: const Key('context_menu_navigation_header'),
+                              title: currentTitle,
+                              onNavigate: controller._onBack,
                             ),
-                            child: IgnorePointer(child: child),
+                          Padding(
+                            padding: EdgeInsets.symmetric(horizontal: menuPadding),
+                            child: Container(
+                              decoration: BoxDecoration(
+                                color: colors.backgroundPrimary,
+                                borderRadius: BorderRadius.circular(8.r),
+                                border: Border.all(color: colors.borderTertiary),
+                              ),
+                              child: IgnorePointer(child: child),
+                            ),
                           ),
                           SizedBox(height: containerGap),
-                          ...List.generate(actions.length, (index) {
-                            final action = actions[index];
+                          if (currentMiddleContent != null) ...[
+                            Padding(
+                              padding: EdgeInsets.symmetric(horizontal: menuPadding),
+                              child: currentMiddleContent,
+                            ),
+                            SizedBox(height: containerGap),
+                          ],
+                          ...List.generate(currentActions.length, (index) {
+                            final action = currentActions[index];
 
                             return Padding(
-                              padding: EdgeInsets.only(top: index > 0 ? buttonSpacing : 0),
+                              padding: EdgeInsets.only(
+                                top: index > 0 ? buttonSpacing : 0,
+                                left: menuPadding,
+                                right: menuPadding,
+                              ),
                               child: SizedBox(
                                 key: Key('context_menu_action_${action.id}'),
                                 width: double.infinity,
@@ -231,7 +303,7 @@ class WnChatListContextMenu extends HookWidget {
                                   size: WnButtonSize.medium,
                                   onPressed: action.onTap != null
                                       ? () {
-                                          onDismiss();
+                                          if (action.autoDismiss) onDismiss();
                                           action.onTap!();
                                         }
                                       : null,

--- a/lib/widgets/chat_list_tile.dart
+++ b/lib/widgets/chat_list_tile.dart
@@ -3,8 +3,11 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:logging/logging.dart';
+import 'package:whitenoise/constants/feature_flags.dart';
+import 'package:whitenoise/hooks/use_leave_group.dart';
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
+import 'package:whitenoise/providers/feature_flags_provider.dart';
 import 'package:whitenoise/providers/locale_provider.dart';
 import 'package:whitenoise/routes.dart' show Routes;
 import 'package:whitenoise/services/user_service.dart';
@@ -14,13 +17,27 @@ import 'package:whitenoise/src/rust/api/groups.dart' show GroupType;
 import 'package:whitenoise/src/rust/api/messages.dart' show ChatMessageSummary;
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/utils/metadata.dart';
+import 'package:whitenoise/widgets/chat_list_menu.dart';
 import 'package:whitenoise/widgets/wn_avatar.dart';
-import 'package:whitenoise/widgets/wn_chat_list_context_menu.dart';
 import 'package:whitenoise/widgets/wn_chat_list_item.dart';
 import 'package:whitenoise/widgets/wn_chat_status.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 
 final _logger = Logger('ChatListTile');
+
+typedef _TileDisplay = ({
+  String title,
+  String subtitle,
+  String? prefixSubtitle,
+  String? pictureUrl,
+  String? avatarName,
+  AvatarColor avatarColor,
+  String formattedTime,
+  ChatStatusType? status,
+  int unreadCount,
+  Widget? subtitleIcon,
+  bool showPinned,
+});
 
 ({String subtitle, Widget? icon})? _mediaSubtitle(
   BuildContext context,
@@ -41,6 +58,174 @@ final _logger = Logger('ChatListTile');
     ),
   );
 }
+
+_TileDisplay _buildTileDisplay({
+  required BuildContext context,
+  required ChatSummary chatSummary,
+  required String myPubkey,
+  required String? welcomerName,
+  required String? welcomerPicture,
+  required String formattedTime,
+  required String? searchSnippet,
+}) {
+  final isDm = chatSummary.groupType == GroupType.directMessage;
+  final isPending = chatSummary.pendingConfirmation;
+  final hasGroupName = chatSummary.name?.isNotEmpty ?? false;
+
+  final String title;
+  final String? pictureUrl;
+  final String subtitle;
+  final String? avatarName;
+  Widget? subtitleIcon;
+
+  final media = _mediaSubtitle(context, chatSummary.lastMessage);
+
+  if (isPending) {
+    final hasMessages = chatSummary.lastMessage != null;
+    if (isDm) {
+      title = welcomerName ?? chatSummary.name ?? context.l10n.unknownUser;
+      pictureUrl = welcomerPicture ?? chatSummary.groupImageUrl;
+      avatarName = welcomerName ?? chatSummary.name;
+      if (media != null) {
+        subtitle = media.subtitle;
+        subtitleIcon = media.icon;
+      } else if (hasMessages) {
+        subtitle = chatSummary.lastMessage!.content;
+      } else {
+        subtitle = context.l10n.hasInvitedYouToSecureChat;
+      }
+    } else {
+      title = hasGroupName ? chatSummary.name! : context.l10n.unknownGroup;
+      pictureUrl = chatSummary.groupImagePath;
+      avatarName = hasGroupName ? chatSummary.name! : null;
+      if (media != null) {
+        subtitle = media.subtitle;
+        subtitleIcon = media.icon;
+      } else if (hasMessages) {
+        subtitle = chatSummary.lastMessage!.content;
+      } else if (welcomerName != null) {
+        subtitle = context.l10n.userInvitedYouToSecureChat(welcomerName);
+      } else {
+        subtitle = context.l10n.youHaveBeenInvitedToSecureChat;
+      }
+    }
+  } else {
+    if (isDm) {
+      title = hasGroupName ? chatSummary.name! : context.l10n.unknownUser;
+      pictureUrl = chatSummary.groupImageUrl;
+    } else {
+      title = hasGroupName ? chatSummary.name! : context.l10n.unknownGroup;
+      pictureUrl = chatSummary.groupImagePath;
+    }
+    avatarName = hasGroupName ? chatSummary.name! : null;
+    if (chatSummary.selfRemoved) {
+      subtitle = context.l10n.youLeftTheGroup;
+    } else if (media != null) {
+      subtitle = media.subtitle;
+      subtitleIcon = media.icon;
+    } else {
+      subtitle = chatSummary.lastMessage?.content ?? '';
+    }
+  }
+
+  final unreadCount = chatSummary.unreadCount.toInt();
+  ChatStatusType? status;
+  if (isPending) {
+    status = ChatStatusType.request;
+  } else if (unreadCount > 0) {
+    status = ChatStatusType.unreadCount;
+  }
+
+  String? prefixSubtitle;
+  if (!isPending && !chatSummary.selfRemoved && chatSummary.lastMessage != null) {
+    if (chatSummary.lastMessage!.author == myPubkey) {
+      prefixSubtitle = '${context.l10n.you}: ';
+    } else if (!isDm) {
+      final authorName = chatSummary.lastMessage!.authorDisplayName;
+      if (authorName != null && authorName.isNotEmpty) {
+        prefixSubtitle = '$authorName: ';
+      }
+    }
+  }
+
+  final String displaySubtitle;
+  final String? displayPrefixSubtitle;
+  final Widget? displaySubtitleIcon;
+  if (searchSnippet != null) {
+    displaySubtitle = searchSnippet;
+    displayPrefixSubtitle = null;
+    displaySubtitleIcon = null;
+  } else {
+    displaySubtitle = subtitle;
+    displayPrefixSubtitle = prefixSubtitle;
+    displaySubtitleIcon = subtitleIcon;
+  }
+
+  final avatarColorKey = isDm
+      ? (chatSummary.dmPeerPubkey ?? chatSummary.mlsGroupId)
+      : chatSummary.mlsGroupId;
+
+  return (
+    title: title,
+    subtitle: displaySubtitle,
+    prefixSubtitle: displayPrefixSubtitle,
+    pictureUrl: pictureUrl,
+    avatarName: avatarName,
+    avatarColor: AvatarColor.fromPubkey(avatarColorKey),
+    formattedTime: formattedTime,
+    status: status,
+    unreadCount: unreadCount,
+    subtitleIcon: displaySubtitleIcon,
+    showPinned: chatSummary.pinOrder != null,
+  );
+}
+
+Future<void> _runAction({
+  required Future<void> Function() action,
+  required VoidCallback onSuccess,
+  required void Function(String) onError,
+  required Logger logger,
+  required String errorMessage,
+  required String logMessage,
+}) async {
+  try {
+    await action();
+    onSuccess();
+  } catch (e, st) {
+    logger.severe(logMessage, e, st);
+    onError(errorMessage);
+  }
+}
+
+List<ChatListAction> _buildLeaveConfirmationActions({
+  required AppLocalizations l10n,
+  required BuildContext context,
+  required Future<void> Function() leaveGroup,
+  required VoidCallback onSuccess,
+  required void Function(String) onError,
+  required VoidCallback onBack,
+}) => [
+  ChatListAction(
+    id: 'cancel_leave',
+    label: l10n.cancel,
+    icon: WnIcons.closeLarge,
+    onTap: () async {},
+  ),
+  ChatListAction(
+    id: 'confirm_leave_group',
+    label: l10n.leave,
+    icon: WnIcons.leave,
+    isDestructive: true,
+    onTap: () => _runAction(
+      action: leaveGroup,
+      onSuccess: onSuccess,
+      onError: onError,
+      logger: _logger,
+      errorMessage: l10n.failedToLeaveGroup,
+      logMessage: 'Failed to leave group',
+    ),
+  ),
+];
 
 class ChatListTile extends HookConsumerWidget {
   final ChatSummary chatSummary;
@@ -63,9 +248,18 @@ class ChatListTile extends HookConsumerWidget {
     final itemKey = useMemoized(GlobalKey.new);
     final formatters = ref.watch(localeFormattersProvider);
     final myPubkey = ref.watch(accountPubkeyProvider);
-    final isDm = chatSummary.groupType == GroupType.directMessage;
     final isPending = chatSummary.pendingConfirmation;
     final hasWelcomer = chatSummary.welcomerPubkey != null;
+
+    final leaveGroupEnabled = ref.watch(featureFlagProvider(FeatureFlag.leaveGroup));
+    final leaveGroupState = useLeaveGroup(
+      accountPubkey: myPubkey,
+      groupId: chatSummary.mlsGroupId,
+      featureEnabled: leaveGroupEnabled,
+      groupType: chatSummary.groupType,
+      pendingConfirmation: chatSummary.pendingConfirmation,
+      selfRemoved: chatSummary.selfRemoved,
+    );
 
     final welcomerStream = useMemoized(() {
       if (!isPending || !hasWelcomer) return null;
@@ -73,177 +267,116 @@ class ChatListTile extends HookConsumerWidget {
     }, [chatSummary.welcomerPubkey, isPending, hasWelcomer]);
     final welcomerSnapshot = useStream(welcomerStream);
 
-    final hasGroupName = chatSummary.name?.isNotEmpty ?? false;
     final welcomerName = presentName(welcomerSnapshot.data);
 
-    final String title;
-    final String? pictureUrl;
-    final String subtitle;
-    final String? avatarName;
-    Widget? subtitleIcon;
-
-    final media = _mediaSubtitle(context, chatSummary.lastMessage);
-
-    if (isPending) {
-      final hasMessages = chatSummary.lastMessage != null;
-      if (isDm) {
-        title = welcomerName ?? chatSummary.name ?? context.l10n.unknownUser;
-        pictureUrl = welcomerSnapshot.data?.picture ?? chatSummary.groupImageUrl;
-        avatarName = welcomerName ?? chatSummary.name;
-        if (media != null) {
-          subtitle = media.subtitle;
-          subtitleIcon = media.icon;
-        } else if (hasMessages) {
-          subtitle = chatSummary.lastMessage!.content;
-        } else {
-          subtitle = context.l10n.hasInvitedYouToSecureChat;
-        }
-      } else {
-        title = hasGroupName ? chatSummary.name! : context.l10n.unknownGroup;
-        pictureUrl = chatSummary.groupImagePath;
-        avatarName = hasGroupName ? chatSummary.name! : null;
-        if (media != null) {
-          subtitle = media.subtitle;
-          subtitleIcon = media.icon;
-        } else if (hasMessages) {
-          subtitle = chatSummary.lastMessage!.content;
-        } else if (welcomerName != null) {
-          subtitle = context.l10n.userInvitedYouToSecureChat(welcomerName);
-        } else {
-          subtitle = context.l10n.youHaveBeenInvitedToSecureChat;
-        }
-      }
-    } else {
-      if (isDm) {
-        title = hasGroupName ? chatSummary.name! : context.l10n.unknownUser;
-        pictureUrl = chatSummary.groupImageUrl;
-      } else {
-        title = hasGroupName ? chatSummary.name! : context.l10n.unknownGroup;
-        pictureUrl = chatSummary.groupImagePath;
-      }
-      avatarName = hasGroupName ? chatSummary.name! : null;
-      if (media != null) {
-        subtitle = media.subtitle;
-        subtitleIcon = media.icon;
-      } else {
-        subtitle = chatSummary.lastMessage?.content ?? '';
-      }
-    }
-
     final timestamp = chatSummary.lastMessage?.createdAt ?? chatSummary.createdAt;
-    final formattedTime = formatters.formatRelativeTime(
-      timestamp,
-      context.l10n,
+    final formattedTime = formatters.formatRelativeTime(timestamp, context.l10n);
+
+    final display = _buildTileDisplay(
+      context: context,
+      chatSummary: chatSummary,
+      myPubkey: myPubkey,
+      welcomerName: welcomerName,
+      welcomerPicture: welcomerSnapshot.data?.picture,
+      formattedTime: formattedTime,
+      searchSnippet: searchSnippet,
     );
-
-    ChatStatusType? status;
-    final unreadCount = chatSummary.unreadCount.toInt();
-    if (isPending) {
-      status = ChatStatusType.request;
-    } else if (unreadCount > 0) {
-      status = ChatStatusType.unreadCount;
-    }
-
-    String? prefixSubtitle;
-    if (!isPending && chatSummary.lastMessage != null) {
-      if (chatSummary.lastMessage!.author == myPubkey) {
-        prefixSubtitle = '${context.l10n.you}: ';
-      } else if (!isDm) {
-        final authorName = chatSummary.lastMessage!.authorDisplayName;
-        if (authorName != null && authorName.isNotEmpty) {
-          prefixSubtitle = '$authorName: ';
-        }
-      }
-    }
-
-    final String displaySubtitle;
-    final String? displayPrefixSubtitle;
-    final Widget? displaySubtitleIcon;
-    if (searchSnippet != null) {
-      displaySubtitle = searchSnippet!;
-      displayPrefixSubtitle = null;
-      displaySubtitleIcon = null;
-    } else {
-      displaySubtitle = subtitle;
-      displayPrefixSubtitle = prefixSubtitle;
-      displaySubtitleIcon = subtitleIcon;
-    }
-
-    final avatarColorKey = isDm
-        ? (chatSummary.dmPeerPubkey ?? chatSummary.mlsGroupId)
-        : chatSummary.mlsGroupId;
 
     void showContextMenu() {
       final renderBox = itemKey.currentContext?.findRenderObject() as RenderBox?;
       if (renderBox == null || !renderBox.hasSize) return;
 
       final l10n = context.l10n;
-
       final isPinned = chatSummary.pinOrder != null;
 
-      WnChatListContextMenu.show(
+      ChatListMenuController? menuController;
+
+      List<ChatListAction> buildInitialActions() => [
+        ChatListAction(
+          id: isPinned ? 'unpin' : 'pin',
+          label: isPinned ? l10n.unpin : l10n.pin,
+          icon: isPinned ? WnIcons.unpin : WnIcons.pin,
+          onTap: () => _runAction(
+            action: () => setChatPinOrder(
+              accountPubkey: myPubkey,
+              mlsGroupId: chatSummary.mlsGroupId,
+              pinOrder: isPinned ? null : 0,
+            ),
+            onSuccess: () => onChatListChanged?.call(),
+            onError: (msg) => onError?.call(msg),
+            logger: _logger,
+            errorMessage: l10n.failedToPinChat,
+            logMessage: 'Failed to update pin order',
+          ),
+        ),
+        ChatListAction(
+          id: isArchived ? 'unarchive' : 'archive',
+          label: isArchived ? l10n.unarchive : l10n.archive,
+          icon: isArchived ? WnIcons.unarchive : WnIcons.archive,
+          onTap: () => _runAction(
+            action: () => isArchived
+                ? unarchiveChat(
+                    accountPubkey: myPubkey,
+                    mlsGroupId: chatSummary.mlsGroupId,
+                  )
+                : archiveChat(
+                    accountPubkey: myPubkey,
+                    mlsGroupId: chatSummary.mlsGroupId,
+                  ),
+            onSuccess: () => onChatListChanged?.call(),
+            onError: (msg) => onError?.call(msg),
+            logger: _logger,
+            errorMessage: isArchived ? l10n.failedToUnarchiveChat : l10n.failedToArchiveChat,
+            logMessage: 'Failed to archive/unarchive chat',
+          ),
+        ),
+        if (leaveGroupState.canLeave)
+          ChatListAction(
+            id: 'leave_group',
+            label: l10n.delete,
+            icon: WnIcons.trashCan,
+            isDestructive: true,
+            autoDismiss: false,
+            onTap: () async {
+              menuController?.updateState(
+                _buildLeaveConfirmationActions(
+                  l10n: l10n,
+                  context: context,
+                  leaveGroup: leaveGroupState.leaveGroup,
+                  onSuccess: () => onChatListChanged?.call(),
+                  onError: (msg) => onError?.call(msg),
+                  onBack: () => menuController?.updateState(buildInitialActions()),
+                ),
+                title: l10n.leaveGroup,
+                middleContent: Text(
+                  l10n.leaveGroupWarning,
+                  style: context.typographyScaled.medium14.copyWith(
+                    color: context.colors.backgroundContentPrimary,
+                  ),
+                ),
+                onBack: () => menuController?.updateState(buildInitialActions()),
+              );
+            },
+          ),
+      ];
+
+      menuController = ChatListMenu.show(
         context,
         childRenderBox: renderBox,
         child: WnChatListItem(
-          title: title,
-          subtitle: displaySubtitle,
-          timestamp: formattedTime,
-          avatarUrl: pictureUrl,
-          avatarName: avatarName,
-          avatarColor: AvatarColor.fromPubkey(avatarColorKey),
-          showPinned: isPinned,
-          status: status,
-          unreadCount: unreadCount,
-          prefixSubtitle: displayPrefixSubtitle,
-          subtitleIcon: displaySubtitleIcon,
+          title: display.title,
+          subtitle: display.subtitle,
+          timestamp: display.formattedTime,
+          avatarUrl: display.pictureUrl,
+          avatarName: display.avatarName,
+          avatarColor: display.avatarColor,
+          showPinned: display.showPinned,
+          status: display.status,
+          unreadCount: display.unreadCount,
+          prefixSubtitle: display.prefixSubtitle,
+          subtitleIcon: display.subtitleIcon,
         ),
-        actions: [
-          WnChatListContextMenuAction(
-            id: isPinned ? 'unpin' : 'pin',
-            label: isPinned ? l10n.unpin : l10n.pin,
-            icon: isPinned ? WnIcons.unpin : WnIcons.pin,
-            onTap: () async {
-              try {
-                await setChatPinOrder(
-                  accountPubkey: myPubkey,
-                  mlsGroupId: chatSummary.mlsGroupId,
-                  pinOrder: isPinned ? null : 0,
-                );
-                onChatListChanged?.call();
-              } catch (e, st) {
-                _logger.severe('Failed to update pin order', e, st);
-                onError?.call(l10n.failedToPinChat);
-              }
-            },
-          ),
-          WnChatListContextMenuAction(
-            id: isArchived ? 'unarchive' : 'archive',
-            label: isArchived ? l10n.unarchive : l10n.archive,
-            icon: isArchived ? WnIcons.unarchive : WnIcons.archive,
-            onTap: () async {
-              try {
-                if (isArchived) {
-                  await unarchiveChat(
-                    accountPubkey: myPubkey,
-                    mlsGroupId: chatSummary.mlsGroupId,
-                  );
-                  onChatListChanged?.call();
-                } else {
-                  await archiveChat(
-                    accountPubkey: myPubkey,
-                    mlsGroupId: chatSummary.mlsGroupId,
-                  );
-                  onChatListChanged?.call();
-                }
-              } catch (e, st) {
-                _logger.severe('Failed to archive/unarchive chat', e, st);
-                onError?.call(
-                  isArchived ? l10n.failedToUnarchiveChat : l10n.failedToArchiveChat,
-                );
-              }
-            },
-          ),
-        ],
+        actions: buildInitialActions(),
       );
     }
 
@@ -253,17 +386,17 @@ class ChatListTile extends HookConsumerWidget {
           ? () => Routes.pushToInvite(context, chatSummary.mlsGroupId)
           : () => Routes.goToChat(context, chatSummary.mlsGroupId),
       onLongPress: isPending ? null : showContextMenu,
-      title: title,
-      subtitle: displaySubtitle,
-      timestamp: formattedTime,
-      avatarUrl: pictureUrl,
-      avatarName: avatarName,
-      avatarColor: AvatarColor.fromPubkey(avatarColorKey),
-      showPinned: chatSummary.pinOrder != null,
-      status: status,
-      unreadCount: unreadCount,
-      prefixSubtitle: displayPrefixSubtitle,
-      subtitleIcon: displaySubtitleIcon,
+      title: display.title,
+      subtitle: display.subtitle,
+      timestamp: display.formattedTime,
+      avatarUrl: display.pictureUrl,
+      avatarName: display.avatarName,
+      avatarColor: display.avatarColor,
+      showPinned: display.showPinned,
+      status: display.status,
+      unreadCount: display.unreadCount,
+      prefixSubtitle: display.prefixSubtitle,
+      subtitleIcon: display.subtitleIcon,
     );
   }
 }

--- a/test/widgets/chat_list_menu_test.dart
+++ b/test/widgets/chat_list_menu_test.dart
@@ -1,22 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:whitenoise/widgets/wn_chat_list_context_menu.dart';
+import 'package:whitenoise/widgets/chat_list_menu.dart';
 import 'package:whitenoise/widgets/wn_icon.dart';
 
 import '../test_helpers.dart' show mountWidget;
 
 void main() {
-  group('WnChatListContextMenu', () {
-    WnChatListContextMenuController? activeController;
+  group('ChatListMenu', () {
+    ChatListMenuController? activeController;
 
     tearDown(() {
-      activeController?.dispose();
+      activeController?.dismiss();
       activeController = null;
     });
 
     Future<void> openContextMenu(
       WidgetTester tester, {
-      required List<WnChatListContextMenuAction> actions,
+      required List<ChatListAction> actions,
       String childText = 'Chat Item',
     }) async {
       final triggerKey = GlobalKey();
@@ -30,7 +30,7 @@ void main() {
                 behavior: HitTestBehavior.opaque,
                 onTap: () {
                   final renderBox = triggerKey.currentContext!.findRenderObject() as RenderBox;
-                  activeController = WnChatListContextMenu.show(
+                  activeController = ChatListMenu.show(
                     context,
                     childRenderBox: renderBox,
                     child: Text(childText),
@@ -58,11 +58,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -77,11 +77,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
           childText: 'My Chat Preview',
@@ -94,23 +94,23 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'archive',
               label: 'Archive',
               icon: WnIcons.archive,
-              onTap: () {},
+              onTap: () async {},
             ),
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'delete',
               label: 'Delete',
               icon: WnIcons.trashCan,
-              onTap: () {},
+              onTap: () async {},
               isDestructive: true,
             ),
           ],
@@ -125,17 +125,17 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'archive',
               label: 'Archive',
               icon: WnIcons.archive,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -154,11 +154,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'delete',
               label: 'Delete',
               icon: WnIcons.trashCan,
-              onTap: () {},
+              onTap: () async {},
               isDestructive: true,
             ),
           ],
@@ -175,11 +175,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -191,11 +191,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'mute',
               label: 'Mute',
               icon: WnIcons.notificationOff,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -214,11 +214,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () => pinCalled = true,
+              onTap: () async => pinCalled = true,
             ),
           ],
         );
@@ -235,11 +235,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -264,11 +264,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -291,11 +291,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
           childText: 'Card Content',
@@ -324,23 +324,23 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () => pinCalled = true,
+              onTap: () async => pinCalled = true,
             ),
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'archive',
               label: 'Archive',
               icon: WnIcons.archive,
-              onTap: () => archiveCalled = true,
+              onTap: () async => archiveCalled = true,
             ),
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'delete',
               label: 'Delete',
               icon: WnIcons.trashCan,
-              onTap: () => deleteCalled = true,
+              onTap: () async => deleteCalled = true,
               isDestructive: true,
             ),
           ],
@@ -362,17 +362,17 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
 
         expect(
-          find.byType(WnChatListContextMenu),
+          find.byType(ChatListMenu),
           findsOneWidget,
         );
         expect(
@@ -389,11 +389,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -415,7 +415,7 @@ void main() {
 
     group('controller', () {
       test('isShowing returns false when no overlay is set', () {
-        final controller = WnChatListContextMenuController();
+        final controller = ChatListMenuController();
         expect(controller.isShowing, isFalse);
       });
 
@@ -423,11 +423,11 @@ void main() {
         await openContextMenu(
           tester,
           actions: [
-            WnChatListContextMenuAction(
+            ChatListAction(
               id: 'pin',
               label: 'Pin',
               icon: WnIcons.pin,
-              onTap: () {},
+              onTap: () async {},
             ),
           ],
         );
@@ -436,14 +436,8 @@ void main() {
       });
 
       test('dismiss on fresh controller is a no-op', () {
-        final controller = WnChatListContextMenuController();
+        final controller = ChatListMenuController();
         controller.dismiss();
-        expect(controller.isShowing, isFalse);
-      });
-
-      test('dispose on fresh controller is a no-op', () {
-        final controller = WnChatListContextMenuController();
-        controller.dispose();
         expect(controller.isShowing, isFalse);
       });
 
@@ -453,11 +447,11 @@ void main() {
           await openContextMenu(
             tester,
             actions: [
-              WnChatListContextMenuAction(
+              ChatListAction(
                 id: 'pin',
                 label: 'Pin',
                 icon: WnIcons.pin,
-                onTap: () {},
+                onTap: () async {},
               ),
             ],
           );
@@ -472,24 +466,35 @@ void main() {
       );
     });
 
-    group('WnChatListContextMenuAction', () {
+    group('ChatListAction', () {
       test('defaults isDestructive to false', () {
-        final action = WnChatListContextMenuAction(
+        final action = ChatListAction(
           id: 'pin',
           label: 'Pin',
           icon: WnIcons.pin,
-          onTap: () {},
+          onTap: () async {},
         );
 
         expect(action.isDestructive, isFalse);
       });
 
+      test('defaults autoDismiss to true', () {
+        final action = ChatListAction(
+          id: 'pin',
+          label: 'Pin',
+          icon: WnIcons.pin,
+          onTap: () async {},
+        );
+
+        expect(action.autoDismiss, isTrue);
+      });
+
       test('stores id, label and icon', () {
-        final action = WnChatListContextMenuAction(
+        final action = ChatListAction(
           id: 'archive',
           label: 'Archive',
           icon: WnIcons.archive,
-          onTap: () {},
+          onTap: () async {},
         );
 
         expect(action.id, 'archive');
@@ -498,15 +503,284 @@ void main() {
       });
 
       test('stores isDestructive when set to true', () {
-        final action = WnChatListContextMenuAction(
+        final action = ChatListAction(
           id: 'delete',
           label: 'Delete',
           icon: WnIcons.trashCan,
-          onTap: () {},
+          onTap: () async {},
           isDestructive: true,
         );
 
         expect(action.isDestructive, isTrue);
+      });
+
+      test('stores autoDismiss when set to false', () {
+        final action = ChatListAction(
+          id: 'leave_group',
+          label: 'Leave group',
+          icon: WnIcons.leave,
+          onTap: () async {},
+          autoDismiss: false,
+        );
+
+        expect(action.autoDismiss, isFalse);
+      });
+    });
+
+    group('PopScope / Android back', () {
+      testWidgets('Android back dismisses overlay when no onBack registered', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        expect(find.byKey(const Key('context_menu_card')), findsOneWidget);
+
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_card')), findsNothing);
+      });
+
+      testWidgets('Android back calls onBack when registered', (tester) async {
+        var onBackCalled = false;
+
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        activeController!.updateState(
+          [
+            ChatListAction(
+              id: 'confirm',
+              label: 'Confirm',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+          title: 'Step 2',
+          onBack: () => onBackCalled = true,
+        );
+        await tester.pumpAndSettle();
+
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        expect(onBackCalled, isTrue);
+        expect(find.byKey(const Key('context_menu_card')), findsOneWidget);
+      });
+    });
+
+    group('title header', () {
+      testWidgets('no title renders no navigation header', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        expect(
+          find.byKey(const Key('context_menu_navigation_header')),
+          findsNothing,
+        );
+      });
+
+      testWidgets('title renders header text after updateState', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        activeController!.updateState(
+          [
+            ChatListAction(
+              id: 'confirm',
+              label: 'Confirm',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+          title: 'Leave group',
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_navigation_header')), findsOneWidget);
+        expect(find.text('Leave group'), findsOneWidget);
+      });
+
+      testWidgets('title back arrow calls onBack', (tester) async {
+        var onBackCalled = false;
+
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        activeController!.updateState(
+          [
+            ChatListAction(
+              id: 'confirm',
+              label: 'Confirm',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+          title: 'Step 2',
+          onBack: () => onBackCalled = true,
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('slate_back_button')));
+        await tester.pumpAndSettle();
+
+        expect(onBackCalled, isTrue);
+      });
+
+      testWidgets('no back arrow when title set but no onBack', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        activeController!.updateState(
+          [
+            ChatListAction(
+              id: 'confirm',
+              label: 'Confirm',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+          title: 'Step 2',
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('slate_back_button')), findsNothing);
+      });
+    });
+
+    group('updateState', () {
+      testWidgets('updateState replaces action buttons', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        expect(find.byKey(const Key('context_menu_action_pin')), findsOneWidget);
+
+        activeController!.updateState([
+          ChatListAction(
+            id: 'confirm',
+            label: 'Confirm action',
+            icon: WnIcons.pin,
+            onTap: () async {},
+          ),
+        ]);
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_action_pin')), findsNothing);
+        expect(find.byKey(const Key('context_menu_action_confirm')), findsOneWidget);
+      });
+
+      testWidgets('action with autoDismiss false does not dismiss on tap', (tester) async {
+        var tapCalled = false;
+
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'no_dismiss',
+              label: 'No dismiss',
+              icon: WnIcons.pin,
+              autoDismiss: false,
+              onTap: () async => tapCalled = true,
+            ),
+          ],
+        );
+
+        await tester.tap(find.byKey(const Key('context_menu_action_no_dismiss')));
+        await tester.pumpAndSettle();
+
+        expect(tapCalled, isTrue);
+        expect(find.byKey(const Key('context_menu_card')), findsOneWidget);
+      });
+
+      testWidgets('middleContent is shown after updateState', (tester) async {
+        await openContextMenu(
+          tester,
+          actions: [
+            ChatListAction(
+              id: 'pin',
+              label: 'Pin',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+        );
+
+        activeController!.updateState(
+          [
+            ChatListAction(
+              id: 'confirm',
+              label: 'Confirm',
+              icon: WnIcons.pin,
+              onTap: () async {},
+            ),
+          ],
+          middleContent: const Text('Warning message'),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.text('Warning message'), findsOneWidget);
       });
     });
   });

--- a/test/widgets/chat_list_tile_test.dart
+++ b/test/widgets/chat_list_tile_test.dart
@@ -5,17 +5,20 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart' show
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:whitenoise/constants/feature_flags.dart' show FeatureFlag;
 import 'package:whitenoise/l10n/generated/app_localizations.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
+import 'package:whitenoise/providers/feature_flags_provider.dart';
 import 'package:whitenoise/src/rust/api/chat_list.dart';
 import 'package:whitenoise/src/rust/api/groups.dart' show GroupType;
 import 'package:whitenoise/src/rust/api/messages.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart';
 import 'package:whitenoise/src/rust/frb_generated.dart';
+import 'package:whitenoise/widgets/chat_list_menu.dart';
 import 'package:whitenoise/widgets/chat_list_tile.dart';
 import 'package:whitenoise/widgets/wn_avatar.dart';
-import 'package:whitenoise/widgets/wn_chat_list_context_menu.dart';
 import 'package:whitenoise/widgets/wn_chat_list_item.dart';
+import 'package:whitenoise/widgets/wn_slate_navigation_header.dart';
 
 import '../mocks/mock_wn_api.dart';
 import '../test_helpers.dart';
@@ -24,6 +27,7 @@ ChatSummary _chatSummary({
   String? name,
   GroupType groupType = GroupType.group,
   bool pendingConfirmation = false,
+  bool selfRemoved = false,
   String? lastMessageContent,
   String? lastMessageAuthor,
   String? lastMessageAuthorDisplayName,
@@ -39,7 +43,7 @@ ChatSummary _chatSummary({
   groupType: groupType,
   createdAt: DateTime(2024),
   pendingConfirmation: pendingConfirmation,
-  selfRemoved: false,
+  selfRemoved: selfRemoved,
   unreadCount: BigInt.zero,
   groupImagePath: groupImagePath,
   groupImageUrl: groupImageUrl,
@@ -112,12 +116,14 @@ void main() {
     bool settle = true,
     void Function(String)? onError,
     bool isArchived = false,
+    List extraOverrides = const [],
   }) async {
     await mountWidget(
       ChatListTile(chatSummary: chatSummary, onError: onError, isArchived: isArchived),
       tester,
       overrides: [
         accountPubkeyProvider.overrideWith(MockAccountPubkeyNotifier.new),
+        ...extraOverrides,
       ],
     );
     if (settle) {
@@ -546,6 +552,49 @@ void main() {
         expect(item.subtitleIcon, isNull);
       });
 
+      group('selfRemoved', () {
+        testWidgets('shows "You left the group" when selfRemoved is true', (tester) async {
+          await pumpTile(tester, _chatSummary(selfRemoved: true));
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.subtitle, 'You left the group');
+        });
+
+        testWidgets('suppresses author prefix when selfRemoved is true', (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(
+              selfRemoved: true,
+              lastMessageContent: 'Last message before leaving',
+              lastMessageAuthor: testPubkeyA,
+            ),
+          );
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.prefixSubtitle, isNull);
+        });
+
+        testWidgets('overrides last message content when selfRemoved is true', (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(
+              selfRemoved: true,
+              lastMessageContent: 'Last message before leaving',
+            ),
+          );
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.subtitle, 'You left the group');
+          expect(item.subtitle, isNot(contains('Last message before leaving')));
+        });
+
+        testWidgets('shows last message normally when selfRemoved is false', (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(lastMessageContent: 'Regular message'),
+          );
+          final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+          expect(item.subtitle, 'Regular message');
+        });
+      });
+
       group('searchSnippet', () {
         testWidgets('overrides subtitle with the snippet text', (tester) async {
           await mountWidget(
@@ -789,7 +838,7 @@ void main() {
         await tester.longPress(find.byType(WnChatListItem));
         await tester.pumpAndSettle();
 
-        expect(find.byType(WnChatListContextMenu), findsOneWidget);
+        expect(find.byType(ChatListMenu), findsOneWidget);
       });
 
       testWidgets('pending chat has no onLongPress handler', (tester) async {
@@ -806,9 +855,13 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byKey(const Key('context_menu_card')), findsOneWidget);
-        final contextMenuFinder = find.byType(WnChatListContextMenu);
-        final contextMenu = tester.widget<WnChatListContextMenu>(contextMenuFinder);
-        expect(contextMenu.child, isA<WnChatListItem>());
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('context_menu_card')),
+            matching: find.text('Preview Chat'),
+          ),
+          findsOneWidget,
+        );
       });
 
       testWidgets('context menu is dismissed when tapping outside', (tester) async {
@@ -817,12 +870,12 @@ void main() {
         await tester.longPress(find.byType(WnChatListItem));
         await tester.pumpAndSettle();
 
-        expect(find.byType(WnChatListContextMenu), findsOneWidget);
+        expect(find.byType(ChatListMenu), findsOneWidget);
 
         await tester.tapAt(Offset.zero);
         await tester.pumpAndSettle();
 
-        expect(find.byType(WnChatListContextMenu), findsNothing);
+        expect(find.byType(ChatListMenu), findsNothing);
       });
 
       testWidgets('shows Pin label and icon for unpinned chat', (tester) async {
@@ -877,11 +930,13 @@ void main() {
         await tester.longPress(find.byType(WnChatListItem));
         await tester.pumpAndSettle();
 
-        final contextMenu = tester.widget<WnChatListContextMenu>(
-          find.byType(WnChatListContextMenu),
+        expect(
+          find.descendant(
+            of: find.byKey(const Key('context_menu_card')),
+            matching: find.byKey(const Key('avatar_pin_badge')),
+          ),
+          findsOneWidget,
         );
-        final previewItem = contextMenu.child as WnChatListItem;
-        expect(previewItem.showPinned, isTrue);
       });
 
       testWidgets('calls onError when setChatPinOrder fails', (tester) async {
@@ -1078,6 +1133,249 @@ void main() {
 
         expect(errorMessage, isNotNull);
         expect(errorMessage, contains('unarchive'));
+      });
+    });
+
+    group('leave group context menu', () {
+      testWidgets('does not show Leave group while kLeaveGroupEnabled is false', (
+        tester,
+      ) async {
+        await pumpTile(
+          tester,
+          _chatSummary(name: 'My Group'),
+          extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(false)],
+        );
+
+        await tester.longPress(find.byType(WnChatListItem));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_action_leave_group')), findsNothing);
+      });
+
+      testWidgets('does not show Leave group for DMs', (tester) async {
+        await pumpTile(
+          tester,
+          _chatSummary(name: 'Alice', groupType: GroupType.directMessage),
+          extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+        );
+
+        await tester.longPress(find.byType(WnChatListItem));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_action_leave_group')), findsNothing);
+      });
+
+      testWidgets(
+        'tapping Leave group transitions overlay to confirmation',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.byKey(const Key('context_menu_action_confirm_leave_group')),
+            findsOneWidget,
+          );
+          expect(find.byKey(const Key('context_menu_action_cancel_leave')), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'confirmation shows leave warning text',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(
+            find.text(
+              'Are you sure you want to leave this group? The chat will stay in your list '
+              "if you don't delete it, but you won't be able to send or receive new messages "
+              'unless someone re-invites you.',
+            ),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'confirmation title is "Leave group"',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const Key('context_menu_navigation_header')), findsOneWidget);
+          expect(
+            find.descendant(
+              of: find.byType(WnSlateNavigationHeader),
+              matching: find.text('Leave group'),
+            ),
+            findsOneWidget,
+          );
+        },
+      );
+
+      testWidgets(
+        'Cancel on confirmation dismisses overlay',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_cancel_leave')));
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const Key('context_menu_card')), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'back arrow on confirmation returns to initial menu',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const Key('slate_back_button')), findsOneWidget);
+          await tester.tap(find.byKey(const Key('slate_back_button')));
+          await tester.pumpAndSettle();
+
+          expect(find.byKey(const Key('context_menu_action_leave_group')), findsOneWidget);
+          expect(find.byKey(const Key('context_menu_navigation_header')), findsNothing);
+        },
+      );
+
+      testWidgets(
+        'confirming Leave calls leaveGroup with correct args',
+        (tester) async {
+          await pumpTile(
+            tester,
+            _chatSummary(name: 'My Group'),
+            extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+          );
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_confirm_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(_api.leaveGroupCallCount, 1);
+          expect(_api.lastLeaveGroupId, testGroupId);
+          expect(_api.lastLeaveGroupPubkey, testPubkeyA);
+        },
+      );
+
+      testWidgets(
+        'confirming Leave calls onChatListChanged',
+        (tester) async {
+          var refreshCalled = false;
+
+          await mountWidget(
+            ChatListTile(
+              chatSummary: _chatSummary(name: 'My Group'),
+              onChatListChanged: () => refreshCalled = true,
+            ),
+            tester,
+            overrides: [
+              accountPubkeyProvider.overrideWith(MockAccountPubkeyNotifier.new),
+              featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true),
+            ],
+          );
+          await tester.pumpAndSettle();
+
+          await tester.longPress(find.byType(WnChatListItem));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+          await tester.pumpAndSettle();
+
+          await tester.tap(find.byKey(const Key('context_menu_action_confirm_leave_group')));
+          await tester.pumpAndSettle();
+
+          expect(refreshCalled, isTrue);
+        },
+      );
+
+      testWidgets('does not show Leave group when selfRemoved is true', (tester) async {
+        await pumpTile(
+          tester,
+          _chatSummary(name: 'My Group', selfRemoved: true),
+          extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+        );
+
+        await tester.longPress(find.byType(WnChatListItem));
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('context_menu_action_leave_group')), findsNothing);
+      });
+
+      testWidgets('leaveGroup failure calls onError', (tester) async {
+        _api.shouldFailLeaveGroup = true;
+        String? errorMessage;
+
+        await pumpTile(
+          tester,
+          _chatSummary(name: 'My Group'),
+          onError: (msg) => errorMessage = msg,
+          extraOverrides: [featureFlagProvider(FeatureFlag.leaveGroup).overrideWithValue(true)],
+        );
+
+        await tester.longPress(find.byType(WnChatListItem));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('context_menu_action_leave_group')));
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.byKey(const Key('context_menu_action_confirm_leave_group')));
+        await tester.pumpAndSettle();
+
+        expect(errorMessage, isNotNull);
+        expect(errorMessage, contains('leave'));
       });
     });
   });


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

- Adds leave option to chat list tile menu.
- Shows "You left the group" in chat list tile. 
- Renames and simplifies the `WnChatListContextMenu`
- Fixes notice positioning in chat list screen

⚠️ This PR does not solve the admin scenarios cases, so those are expected to fail an in the meantime, for a release this feature should be kept hidden by the feature flag (which is the default behavior)




<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [x] ✨ New feature (leave group from chat list
- [x] 🧹 Code refactor (renamed `WnChatListContextMenu `and extracted repeated logic to methods)
- [x] 🛠️ Bug fix (system notice positioning in chat list screen)
- [X] 🧪 Tests

## How I Tested This
For the following 3 scenarios I run the app with the feature flag enabled
`flutter run --release -d 'my device' --flavor staging --dart
-define LEAVE_GROUP_ENABLED=true`

**Scenario 1:** DMs
- Go to chat list
- Long press the DM tile
- Check that the "Delete" option is not visible

**Scenario 2:** Groups without leave capabilities
- From another device in last release (so without leave capabilities), send a group invite
- Accept the invite
- Go back to chatlist 
- Long press the DM tile
- Check that the "Delete" option is not visible


**Scenario 3:** Groups where I am not admin with leave capability
- From another device in the same branch, send a group invite
- Accept the invite
- Go back to chatlist 
- Long press the DM tile and chack that the "Delete" option visible
- Click Delete button
- Click Leave group
- Check that then the chat list tile shows "You left the group"
- Long press again the DM tile
- Check that the "Delete" option is not visible


A last scenario with the feature flag disabled (default bahaviour) `flutter run --release -d 'my device' --flavor staging 
`

**Scenario 4:** Groups where I am not admin with leave capability without leave feature flag enabled
- From another device in the same branch, send a group invite
- Accept the invite
- Go back to chatlist 
- Long press the DM tile and chack that the "Delete" option is not visible



<!-- Describe what you ran or manually verified and include device/OS/simulator details. -->

## Screenshots

<!-- Required for UI changes. Drag images here. Delete this section if UI is not affected -->
|Select delete| Leave| You have left the group|
|----|----|----|
|<img width="300" alt="leave" src="https://github.com/user-attachments/assets/d4c77d3c-bde2-4923-b284-8592dbeef1e2" />|<img width="300" alt="left" src="https://github.com/user-attachments/assets/8f8a381e-5c0d-4eb8-bf3f-b43230bf0dae" />|<img width="300" alt="delete" src="https://github.com/user-attachments/assets/7b078d36-6c05-4f2f-bc43-fcf2e5e205bb" />|




## Checklist

- [x] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [x] `CHANGELOG.md` updated (if user-visible change)
- [x] Screenshots added (for UI changes)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/604">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Leave group from the chat list with confirmation (feature-flag gated).
  * Shows a "You left the group" indicator for chats you left.

* **Refactor**
  * Consolidated system notice rendering.
  * Context menu supports dynamic title/middle content, back handling, and per-action auto-dismiss behavior.
  * Improved chat list subtitle logic and action handling (pin/archive/leave flows).

* **Tests**
  * Expanded tests for leave-group flows, context menu behaviors, and back/navigation handling.

* **Changed**
  * Wording updated from “contact” to “follows”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->