### PR TITLE
Refactor: apply review feedback from #586

### DIFF
--- a/lib/screens/add_profile_screen.dart
+++ b/lib/screens/add_profile_screen.dart
@@ -20,13 +20,11 @@ class AddProfileScreen extends ConsumerWidget {
     final isOffline = ref.watch(offlineProvider).value ?? false;
 
     void navigateToLogin() {
-      if (isOffline) return;
       ref.read(isAddingAccountProvider.notifier).set(true);
       Routes.pushToLogin(context);
     }
 
     void navigateToSignup() {
-      if (isOffline) return;
       ref.read(isAddingAccountProvider.notifier).set(true);
       Routes.pushToSignup(context);
     }

--- a/lib/screens/edit_profile_screen.dart
+++ b/lib/screens/edit_profile_screen.dart
@@ -7,6 +7,7 @@ import 'package:logging/logging.dart';
 import 'package:whitenoise/hooks/use_edit_profile.dart'
     show EditProfileLoadingState, useEditProfile;
 import 'package:whitenoise/hooks/use_image_picker.dart';
+import 'package:whitenoise/hooks/use_system_notice.dart' show useSystemNotice;
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
 import 'package:whitenoise/providers/offline_provider.dart';
@@ -47,18 +48,14 @@ class EditProfileScreen extends HookConsumerWidget {
     final (:pickImage, error: imagePickerError, clearError: clearImagePickerError) = useImagePicker(
       onImageSelected: onImageSelected,
     );
-    final noticeMessage = useState<String?>(null);
-    final noticeType = useState(WnSystemNoticeType.success);
+    final (
+      :noticeMessage,
+      :noticeType,
+      :showErrorNotice,
+      :showSuccessNotice,
+      :dismissNotice,
+    ) = useSystemNotice();
     final privacyNoticeExpanded = useState(false);
-
-    void showNotice(String message, {WnSystemNoticeType type = WnSystemNoticeType.success}) {
-      noticeMessage.value = message;
-      noticeType.value = type;
-    }
-
-    void dismissNotice() {
-      noticeMessage.value = null;
-    }
 
     useEffect(() {
       loadProfile();
@@ -69,7 +66,7 @@ class EditProfileScreen extends HookConsumerWidget {
       if (imagePickerError != null) {
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (context.mounted) {
-            showNotice(context.l10n.imagePickerError, type: WnSystemNoticeType.error);
+            showErrorNotice(context.l10n.imagePickerError);
           }
         });
         clearImagePickerError();
@@ -89,11 +86,11 @@ class EditProfileScreen extends HookConsumerWidget {
           ),
           systemNotice: isOffline
               ? const OfflineSystemNotice()
-              : noticeMessage.value != null
+              : noticeMessage != null
               ? WnSystemNotice(
-                  key: ValueKey(noticeMessage.value),
-                  title: noticeMessage.value!,
-                  type: noticeType.value,
+                  key: ValueKey(noticeMessage),
+                  title: noticeMessage,
+                  type: noticeType,
                   onDismiss: dismissNotice,
                 )
               : null,
@@ -112,7 +109,7 @@ class EditProfileScreen extends HookConsumerWidget {
                           ? () async {
                               final success = await updateProfileData();
                               if (context.mounted && success) {
-                                showNotice(context.l10n.profileUpdatedSuccessfully);
+                                showSuccessNotice(context.l10n.profileUpdatedSuccessfully);
                               }
                             }
                           : null,

--- a/test/screens/switch_profile_screen_test.dart
+++ b/test/screens/switch_profile_screen_test.dart
@@ -178,22 +178,24 @@ void main() {
     });
 
     group('when offline', () {
-      testWidgets('offline notice appears during loading when offline', (tester) async {
-        mockApi.getAccountsCompleter = Completer();
-        await mountTestApp(
-          tester,
-          overrides: [
-            authProvider.overrideWith(() => _MockAuthNotifier()),
-            secureStorageProvider.overrideWithValue(MockSecureStorage()),
-            offlineProvider.overrideWith((ref) => Stream.value(true)),
-          ],
-        );
-        Routes.pushToSwitchProfile(tester.element(find.byType(Scaffold)));
-        await tester.pump();
-        expect(find.byKey(const Key('offline_notice')), findsOneWidget);
+      group('when loading', () {
+        testWidgets('offline notice appears', (tester) async {
+          mockApi.getAccountsCompleter = Completer();
+          await mountTestApp(
+            tester,
+            overrides: [
+              authProvider.overrideWith(() => _MockAuthNotifier()),
+              secureStorageProvider.overrideWithValue(MockSecureStorage()),
+              offlineProvider.overrideWith((ref) => Stream.value(true)),
+            ],
+          );
+          Routes.pushToSwitchProfile(tester.element(find.byType(Scaffold)));
+          await tester.pump();
+          expect(find.byKey(const Key('offline_notice')), findsOneWidget);
+        });
       });
 
-      testWidgets('offline notice appears when offline', (tester) async {
+      testWidgets('offline notice appears', (tester) async {
         await mountTestApp(
           tester,
           overrides: [

--- a/test/widgets/wn_auth_buttons_container_test.dart
+++ b/test/widgets/wn_auth_buttons_container_test.dart
@@ -99,18 +99,23 @@ void main() {
     });
 
     group('when disabled', () {
-      testWidgets('both buttons have disabled set to true', (tester) async {
+      testWidgets('login button has disabled set to true', (tester) async {
         const widget = WnAuthButtonsContainer(disabled: true);
         await mountWidget(widget, tester);
 
         final loginButton = tester.widget<WnButton>(
           find.widgetWithText(WnButton, 'Login'),
         );
+        expect(loginButton.disabled, isTrue);
+      });
+
+      testWidgets('sign up button has disabled set to true', (tester) async {
+        const widget = WnAuthButtonsContainer(disabled: true);
+        await mountWidget(widget, tester);
+
         final signupButton = tester.widget<WnButton>(
           find.widgetWithText(WnButton, 'Sign Up'),
         );
-
-        expect(loginButton.disabled, isTrue);
         expect(signupButton.disabled, isTrue);
       });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

This small PR solves some review comments of https://github.com/marmot-protocol/whitenoise/pull/586 that I said I'd fix later 😅 

<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This

**Switch profile screen**
Just tested that switch profile in offline mode keeps working as before (not navigating)

**Edit profile screen**
Tested that system notice in edit profile screen keeps showing up as before

## Checklist

- [ ] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [ ] `CHANGELOG.md` updated (if user-visible change)
- [ ] Screenshots added (for UI changes)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/618">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated offline handling in the auth flow by disabling auth buttons and showing an offline notice instead of early-return checks.
  * Centralized system notice management in profile editing to use a hook-based approach for consistent error/success messages.

* **Tests**
  * Adjusted widget tests: reorganized offline-notice scenarios and split disabled-button assertions into separate verifications for Login and Sign Up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->