### PR TITLE
Fix camera permission loop

### DIFF
--- a/lib/screens/scan_npub_screen.dart
+++ b/lib/screens/scan_npub_screen.dart
@@ -6,7 +6,7 @@ import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/routes.dart' show Routes;
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/utils/encoding.dart' show hexFromNpub;
-import 'package:whitenoise/widgets/wn_scan_box.dart' show WnScanBox;
+import 'package:whitenoise/widgets/qr_scanner.dart' show QrScanner;
 import 'package:whitenoise/widgets/wn_slate.dart';
 import 'package:whitenoise/widgets/wn_slate_navigation_header.dart';
 
@@ -43,7 +43,7 @@ class ScanNpubScreen extends HookWidget {
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
                 Expanded(
-                  child: WnScanBox(
+                  child: QrScanner(
                     onBarcodeDetected: onBarcodeDetected,
                   ),
                 ),

--- a/lib/screens/scan_nsec_screen.dart
+++ b/lib/screens/scan_nsec_screen.dart
@@ -5,7 +5,7 @@ import 'package:go_router/go_router.dart' show GoRouter;
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/routes.dart' show Routes;
 import 'package:whitenoise/theme.dart';
-import 'package:whitenoise/widgets/wn_scan_box.dart' show WnScanBox;
+import 'package:whitenoise/widgets/qr_scanner.dart' show QrScanner;
 import 'package:whitenoise/widgets/wn_slate.dart';
 import 'package:whitenoise/widgets/wn_slate_navigation_header.dart';
 
@@ -41,7 +41,7 @@ class ScanNsecScreen extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
                     Expanded(
-                      child: WnScanBox(
+                      child: QrScanner(
                         onBarcodeDetected: (value) => GoRouter.of(context).pop(value),
                       ),
                     ),

--- a/lib/widgets/qr_scanner.dart
+++ b/lib/widgets/qr_scanner.dart
@@ -40,6 +40,20 @@ void resetPermissionRequester() {
   _permissionRequester = _defaultPermissionRequester;
 }
 
+Future<PermissionStatus> Function() _permissionStatusChecker = _defaultPermissionStatusChecker;
+
+Future<PermissionStatus> _defaultPermissionStatusChecker() => Permission.camera.status;
+
+Future<PermissionStatus> checkCameraPermissionStatus() => _permissionStatusChecker();
+
+void setPermissionStatusChecker(Future<PermissionStatus> Function() checker) {
+  _permissionStatusChecker = checker;
+}
+
+void resetPermissionStatusChecker() {
+  _permissionStatusChecker = _defaultPermissionStatusChecker;
+}
+
 enum ScannerState {
   loading,
   ready,
@@ -48,8 +62,8 @@ enum ScannerState {
   error,
 }
 
-class WnScanBox extends HookWidget {
-  const WnScanBox({
+class QrScanner extends HookWidget {
+  const QrScanner({
     super.key,
     required this.onBarcodeDetected,
     this.width,
@@ -66,8 +80,8 @@ class WnScanBox extends HookWidget {
     final isProcessing = useState(false);
     final scannerRetryKey = useState(UniqueKey());
     final isMounted = useRef(true);
-    final controllerStarted = useRef(false);
     final boxState = useState(ScannerState.loading);
+    final lastDeniedStatus = useRef<PermissionStatus?>(null);
 
     useEffect(() {
       isMounted.value = true;
@@ -80,8 +94,12 @@ class WnScanBox extends HookWidget {
         if (!isMounted.value) return;
 
         if (status.isGranted || status.isLimited) {
+          lastDeniedStatus.value = null;
           boxState.value = ScannerState.ready;
         } else {
+          final currentStatus = await checkCameraPermissionStatus();
+          if (!isMounted.value) return;
+          lastDeniedStatus.value = currentStatus;
           boxState.value = ScannerState.permissionDenied;
         }
       }
@@ -98,26 +116,24 @@ class WnScanBox extends HookWidget {
     useEffect(() {
       if (boxState.value != ScannerState.ready) return null;
 
+      var started = false;
+
       void handleBarcode(BarcodeCapture capture) {
         if (capture.barcodes.isEmpty) return;
         if (isProcessing.value) return;
-
         final barcode = capture.barcodes.first;
         final rawValue = barcode.rawValue ?? '';
         if (rawValue.isEmpty) return;
-
         isProcessing.value = true;
         onBarcodeDetected(rawValue.trim());
         Future.delayed(const Duration(milliseconds: 500), () {
-          if (isMounted.value) {
-            isProcessing.value = false;
-          }
+          if (isMounted.value) isProcessing.value = false;
         });
       }
 
       Future<void> startController() async {
-        if (controllerStarted.value) return;
-        controllerStarted.value = true;
+        if (started) return;
+        started = true;
         await controller.start();
       }
 
@@ -125,7 +141,6 @@ class WnScanBox extends HookWidget {
       unawaited(startController());
 
       return () {
-        controllerStarted.value = false;
         unawaited(subscription.cancel());
         controller.dispose();
       };
@@ -137,10 +152,20 @@ class WnScanBox extends HookWidget {
     }
 
     useOnAppLifecycleStateChange((previous, current) {
-      if (current == AppLifecycleState.resumed) {
-        if (isMounted.value) {
-          retryScanner();
-        }
+      if (current != AppLifecycleState.resumed || !isMounted.value) return;
+      if (boxState.value == ScannerState.permissionDenied) {
+        unawaited(() async {
+          final status = await checkCameraPermissionStatus();
+          if (!isMounted.value) return;
+          final snapshotWasDenied =
+              lastDeniedStatus.value != null &&
+              !(lastDeniedStatus.value!.isGranted || lastDeniedStatus.value!.isLimited);
+          if (snapshotWasDenied && (status.isGranted || status.isLimited)) {
+            retryScanner();
+          }
+        }());
+      } else if (boxState.value == ScannerState.ready) {
+        retryScanner();
       }
     });
 
@@ -148,7 +173,7 @@ class WnScanBox extends HookWidget {
     final isError = boxState.value != ScannerState.loading && !showScanner;
 
     return Container(
-      key: const Key('scan_box'),
+      key: const Key('qr_scanner'),
       width: width,
       height: height,
       decoration: BoxDecoration(
@@ -172,14 +197,14 @@ class WnScanBox extends HookWidget {
                       boxState.value = newState;
                     }
                   });
-                  return _ScannerError(
-                    scannerState: ScannerState.error,
+                  return _ScannerNotice(
+                    scannerState: newState,
                     onRetry: retryScanner,
                   );
                 },
               )
             : isError
-            ? _ScannerError(
+            ? _ScannerNotice(
                 scannerState: boxState.value,
                 onRetry: retryScanner,
               )
@@ -203,8 +228,8 @@ class _ScannerPlaceholder extends StatelessWidget {
   }
 }
 
-class _ScannerError extends StatelessWidget {
-  const _ScannerError({required this.scannerState, this.onRetry});
+class _ScannerNotice extends StatelessWidget {
+  const _ScannerNotice({required this.scannerState, this.onRetry});
 
   final ScannerState scannerState;
   final VoidCallback? onRetry;
@@ -215,11 +240,14 @@ class _ScannerError extends StatelessWidget {
     final l10n = context.l10n;
     final typography = context.typographyScaled;
     final isPermissionDenied = scannerState == ScannerState.permissionDenied;
-    final errorContentColor = colors.intentionErrorContent;
+    final noticeColor = isPermissionDenied
+        ? colors.intentionWarningContent
+        : colors.intentionErrorContent;
+    final icon = isPermissionDenied ? WnIcons.warningFilled : WnIcons.errorFilled;
 
     return Container(
-      key: const Key('scanner_placeholder'),
-      color: colors.intentionErrorBackground,
+      key: const Key('scanner_notice'),
+      color: colors.backgroundSecondary,
       child: Center(
         child: Padding(
           padding: EdgeInsets.all(16.w),
@@ -227,17 +255,17 @@ class _ScannerError extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             children: [
               WnIcon(
-                WnIcons.errorFilled,
-                key: const Key('scanner_error_icon'),
+                icon,
+                key: const Key('scanner_notice_icon'),
                 size: 20.w,
-                color: errorContentColor,
+                color: noticeColor,
               ),
               Gap(8.h),
               Text(
                 isPermissionDenied ? l10n.cameraPermissionDenied : l10n.scannerError,
                 key: const Key('scanner_error_title'),
                 textAlign: TextAlign.center,
-                style: typography.bold14.copyWith(color: errorContentColor),
+                style: typography.bold14.copyWith(color: noticeColor),
               ),
               Gap(4.h),
               Text(
@@ -246,17 +274,18 @@ class _ScannerError extends StatelessWidget {
                     : l10n.scannerErrorDescription,
                 key: const Key('scanner_error_description'),
                 textAlign: TextAlign.center,
-                style: typography.medium14.copyWith(
-                  color: colors.backgroundContentQuaternary,
+                style: typography.medium12.copyWith(
+                  color: colors.backgroundContentSecondary,
                 ),
               ),
-              Gap(8.h),
+              Gap(12.h),
               if (isPermissionDenied)
                 WnButton(
                   key: const Key('open_settings_button'),
                   text: l10n.openSettings,
                   onPressed: openAppSettings,
                   size: WnButtonSize.small,
+                  type: WnButtonType.outline,
                 )
               else
                 WnButton(
@@ -264,6 +293,7 @@ class _ScannerError extends StatelessWidget {
                   text: l10n.retry,
                   onPressed: onRetry,
                   size: WnButtonSize.small,
+                  type: WnButtonType.outline,
                 ),
             ],
           ),

--- a/test/mocks/mock_scanner_controller.dart
+++ b/test/mocks/mock_scanner_controller.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
-import 'package:whitenoise/widgets/wn_scan_box.dart';
+import 'package:whitenoise/widgets/qr_scanner.dart';
 
 class MockScannerController implements MobileScannerController {
   MockScannerController();

--- a/test/screens/scan_npub_screen_test.dart
+++ b/test/screens/scan_npub_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:whitenoise/screens/share_profile_screen.dart';
 import 'package:whitenoise/screens/start_chat_screen.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart';
 import 'package:whitenoise/src/rust/frb_generated.dart';
-import 'package:whitenoise/widgets/wn_scan_box.dart';
+import 'package:whitenoise/widgets/qr_scanner.dart';
 
 import '../mocks/mock_secure_storage.dart';
 import '../mocks/mock_wn_api.dart';
@@ -81,7 +81,7 @@ void main() {
     group('UI', () {
       testWidgets('displays scan box', (tester) async {
         await pumpScanNpubScreen(tester);
-        expect(find.byType(WnScanBox), findsOneWidget);
+        expect(find.byType(QrScanner), findsOneWidget);
       });
 
       testWidgets('displays mobile scanner', (tester) async {
@@ -115,7 +115,7 @@ void main() {
       ) async {
         await pumpScanNpubScreen(tester);
 
-        final scanBox = tester.widget<WnScanBox>(find.byType(WnScanBox));
+        final scanBox = tester.widget<QrScanner>(find.byType(QrScanner));
         scanBox.onBarcodeDetected(testNpubB);
         await tester.pumpAndSettle();
 
@@ -125,22 +125,22 @@ void main() {
       testWidgets('calling onBarcodeDetected with non-npub value does nothing', (tester) async {
         await pumpScanNpubScreen(tester);
 
-        final scanBox = tester.widget<WnScanBox>(find.byType(WnScanBox));
+        final scanBox = tester.widget<QrScanner>(find.byType(QrScanner));
         scanBox.onBarcodeDetected('https://example.com');
         await tester.pumpAndSettle();
 
-        expect(find.byType(WnScanBox), findsOneWidget);
+        expect(find.byType(QrScanner), findsOneWidget);
         expect(find.text('Scan a contact\'s QR code.'), findsOneWidget);
       });
 
       testWidgets('calling onBarcodeDetected with invalid npub shows error', (tester) async {
         await pumpScanNpubScreen(tester);
 
-        final scanBox = tester.widget<WnScanBox>(find.byType(WnScanBox));
+        final scanBox = tester.widget<QrScanner>(find.byType(QrScanner));
         scanBox.onBarcodeDetected('npub1invalidkey');
         await tester.pumpAndSettle();
 
-        expect(find.byType(WnScanBox), findsOneWidget);
+        expect(find.byType(QrScanner), findsOneWidget);
         expect(find.text('Invalid public key. Please try again.'), findsOneWidget);
       });
     });
@@ -162,7 +162,7 @@ void main() {
       await tester.tap(find.byKey(const Key('scan_qr_button')));
       await tester.pumpAndSettle();
 
-      expect(find.byType(WnScanBox), findsOneWidget);
+      expect(find.byType(QrScanner), findsOneWidget);
     });
   });
 }

--- a/test/screens/scan_nsec_screen_test.dart
+++ b/test/screens/scan_nsec_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:whitenoise/screens/login_screen.dart';
 import 'package:whitenoise/src/rust/api/accounts.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart';
 import 'package:whitenoise/src/rust/frb_generated.dart';
-import 'package:whitenoise/widgets/wn_scan_box.dart';
+import 'package:whitenoise/widgets/qr_scanner.dart';
 import '../mocks/mock_wn_api.dart';
 import '../test_helpers.dart';
 
@@ -81,7 +81,7 @@ void main() {
     group('UI', () {
       testWidgets('displays scan box', (tester) async {
         await pumpScanNsecScreen(tester);
-        expect(find.byType(WnScanBox), findsOneWidget);
+        expect(find.byType(QrScanner), findsOneWidget);
       });
 
       testWidgets('displays mobile scanner', (tester) async {
@@ -120,7 +120,7 @@ void main() {
       testWidgets('calling onBarcodeDetected pops with scanned value', (tester) async {
         await pumpScanNsecScreen(tester);
 
-        final scanBox = tester.widget<WnScanBox>(find.byType(WnScanBox));
+        final scanBox = tester.widget<QrScanner>(find.byType(QrScanner));
         scanBox.onBarcodeDetected('nsec1scannedvalue');
         await tester.pumpAndSettle();
 
@@ -145,7 +145,7 @@ void main() {
       await tester.tap(find.byKey(const Key('scan_button')));
       await tester.pumpAndSettle();
 
-      expect(find.byType(WnScanBox), findsOneWidget);
+      expect(find.byType(QrScanner), findsOneWidget);
     });
   });
 }

--- a/test/widgets/qr_scanner_test.dart
+++ b/test/widgets/qr_scanner_test.dart
@@ -4,22 +4,24 @@ import 'package:flutter/material.dart' show Key, SizedBox;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:permission_handler/permission_handler.dart';
-import 'package:whitenoise/widgets/wn_scan_box.dart';
+import 'package:whitenoise/widgets/qr_scanner.dart';
 import '../mocks/mock_scanner_controller.dart';
 import '../test_helpers.dart' show mountWidget;
 
 void main() {
-  group('WnScanBox', () {
+  group('QrScanner', () {
     late MockScannerController mockController;
 
     setUp(() {
       mockController = setupMockScannerController();
       setPermissionRequester(() async => PermissionStatus.granted);
+      setPermissionStatusChecker(() async => PermissionStatus.granted);
     });
 
     tearDown(() {
       tearDownMockScannerController();
       resetPermissionRequester();
+      resetPermissionStatusChecker();
     });
 
     testWidgets('shows loading placeholder before permission resolves', (tester) async {
@@ -32,7 +34,7 @@ void main() {
       });
 
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
 
@@ -45,7 +47,7 @@ void main() {
 
     testWidgets('renders scanner container after permission granted', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -57,12 +59,12 @@ void main() {
       setPermissionRequester(() async => PermissionStatus.denied);
 
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
 
-      expect(find.byKey(const Key('scanner_placeholder')), findsOneWidget);
+      expect(find.byKey(const Key('scanner_notice')), findsOneWidget);
       expect(find.byType(MobileScanner), findsNothing);
     });
 
@@ -70,12 +72,12 @@ void main() {
       setPermissionRequester(() async => PermissionStatus.denied);
 
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
 
-      expect(find.byKey(const Key('scanner_error_icon')), findsOneWidget);
+      expect(find.byKey(const Key('scanner_notice_icon')), findsOneWidget);
       expect(find.text('Camera permission denied'), findsOneWidget);
       expect(
         find.text('Please enable camera access in your device settings to scan QR codes.'),
@@ -94,12 +96,12 @@ void main() {
       });
 
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
 
       expect(find.byKey(const Key('scanner_placeholder')), findsOneWidget);
-      expect(find.byKey(const Key('scanner_error_icon')), findsNothing);
+      expect(find.byKey(const Key('scanner_notice_icon')), findsNothing);
 
       resolvePermission = true;
       await tester.pump(const Duration(milliseconds: 50));
@@ -108,7 +110,7 @@ void main() {
 
     testWidgets('uses custom dimensions when provided', (tester) async {
       await mountWidget(
-        WnScanBox(
+        QrScanner(
           onBarcodeDetected: (_) {},
           width: 200,
           height: 300,
@@ -124,7 +126,7 @@ void main() {
 
     testWidgets('does not show scan button key by default', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -134,7 +136,7 @@ void main() {
 
     testWidgets('scanner is configured for qrCode format', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -145,7 +147,7 @@ void main() {
 
     testWidgets('controller has autoStart disabled', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -156,7 +158,7 @@ void main() {
 
     testWidgets('calls start on controller when mounted', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -166,7 +168,7 @@ void main() {
 
     testWidgets('disposes controller on unmount', (tester) async {
       await mountWidget(
-        WnScanBox(onBarcodeDetected: (_) {}),
+        QrScanner(onBarcodeDetected: (_) {}),
         tester,
       );
       await tester.pump();
@@ -184,7 +186,7 @@ void main() {
         String? detectedValue;
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValue = value),
+          QrScanner(onBarcodeDetected: (value) => detectedValue = value),
           tester,
         );
         await tester.pump();
@@ -201,7 +203,7 @@ void main() {
         String? detectedValue;
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValue = value),
+          QrScanner(onBarcodeDetected: (value) => detectedValue = value),
           tester,
         );
         await tester.pump();
@@ -216,7 +218,7 @@ void main() {
         String? detectedValue;
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValue = value),
+          QrScanner(onBarcodeDetected: (value) => detectedValue = value),
           tester,
         );
         await tester.pump();
@@ -231,7 +233,7 @@ void main() {
         String? detectedValue;
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValue = value),
+          QrScanner(onBarcodeDetected: (value) => detectedValue = value),
           tester,
         );
         await tester.pump();
@@ -248,7 +250,7 @@ void main() {
         final detectedValues = <String>[];
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValues.add(value)),
+          QrScanner(onBarcodeDetected: (value) => detectedValues.add(value)),
           tester,
         );
         await tester.pump();
@@ -267,7 +269,7 @@ void main() {
         final detectedValues = <String>[];
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (value) => detectedValues.add(value)),
+          QrScanner(onBarcodeDetected: (value) => detectedValues.add(value)),
           tester,
         );
         await tester.pump();
@@ -287,8 +289,10 @@ void main() {
 
     group('lifecycle', () {
       testWidgets('recreates scanner on resume', (tester) async {
+        setPermissionStatusChecker(() async => PermissionStatus.granted);
+
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -299,16 +303,109 @@ void main() {
         tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
         await tester.pump();
         await tester.pump();
+        await tester.pump();
 
         final newScanner = tester.widget<MobileScanner>(find.byType(MobileScanner));
         expect(newScanner.key, isNot(equals(initialKey)));
       });
+
+      testWidgets('does not re-request permission on resume when denied', (tester) async {
+        var requestCount = 0;
+        setPermissionRequester(() async {
+          requestCount++;
+          return PermissionStatus.denied;
+        });
+        setPermissionStatusChecker(() async => PermissionStatus.denied);
+
+        await mountWidget(QrScanner(onBarcodeDetected: (_) {}), tester);
+        await tester.pump();
+
+        expect(requestCount, 1);
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+
+        expect(requestCount, 1);
+      });
+
+      testWidgets('shows error UI after denial when lifecycle resume fires', (tester) async {
+        setPermissionRequester(() async => PermissionStatus.denied);
+        setPermissionStatusChecker(() async => PermissionStatus.denied);
+
+        await mountWidget(QrScanner(onBarcodeDetected: (_) {}), tester);
+        await tester.pump();
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byKey(const Key('scanner_notice_icon')), findsOneWidget);
+        expect(find.byKey(const Key('open_settings_button')), findsOneWidget);
+        expect(find.byType(MobileScanner), findsNothing);
+      });
+
+      testWidgets('retries scanner on resume after user grants permission in settings', (
+        tester,
+      ) async {
+        setPermissionRequester(() async => PermissionStatus.denied);
+        setPermissionStatusChecker(() async => PermissionStatus.denied);
+
+        await mountWidget(QrScanner(onBarcodeDetected: (_) {}), tester);
+        await tester.pump();
+
+        expect(find.byKey(const Key('open_settings_button')), findsOneWidget);
+
+        setPermissionRequester(() async => PermissionStatus.granted);
+        setPermissionStatusChecker(() async => PermissionStatus.granted);
+
+        tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.byType(MobileScanner), findsOneWidget);
+      });
+
+      testWidgets(
+        'does not retry permission on resume after dialog dismissal even if status returns granted',
+        (tester) async {
+          var requestCount = 0;
+          setPermissionRequester(() async {
+            requestCount++;
+            return PermissionStatus.denied;
+          });
+          setPermissionStatusChecker(() async => PermissionStatus.granted);
+
+          await mountWidget(QrScanner(onBarcodeDetected: (_) {}), tester);
+          await tester.pump();
+
+          expect(requestCount, 1);
+          expect(find.byKey(const Key('open_settings_button')), findsOneWidget);
+
+          tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+          await tester.pump();
+          await tester.pump();
+          await tester.pump();
+
+          expect(
+            requestCount,
+            1,
+            reason:
+                'must not retry permission on lifecycle resume just because the cached '
+                'status checker returned granted; only an explicit settings trip should retry',
+          );
+          expect(find.byKey(const Key('open_settings_button')), findsOneWidget);
+        },
+      );
     });
 
     group('error handling', () {
       testWidgets('errorBuilder returns placeholder widget', (tester) async {
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -327,7 +424,7 @@ void main() {
         tester,
       ) async {
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -341,13 +438,14 @@ void main() {
         scanner.errorBuilder!(context, error);
         await tester.pumpAndSettle();
 
+        expect(find.byKey(const Key('scanner_notice_icon')), findsOneWidget);
         expect(find.text('Camera permission denied'), findsOneWidget);
         expect(find.byKey(const Key('open_settings_button')), findsOneWidget);
       });
 
       testWidgets('shows scanner error UI with retry after generic error', (tester) async {
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -361,6 +459,7 @@ void main() {
         scanner.errorBuilder!(context, error);
         await tester.pumpAndSettle();
 
+        expect(find.byKey(const Key('scanner_notice_icon')), findsOneWidget);
         expect(find.text('Scanner error'), findsOneWidget);
         expect(find.byKey(const Key('retry_scanner_button')), findsOneWidget);
       });
@@ -369,7 +468,7 @@ void main() {
     group('start guard', () {
       testWidgets('does not call start twice on the same controller', (tester) async {
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -378,8 +477,10 @@ void main() {
       });
 
       testWidgets('resets start guard on retry', (tester) async {
+        setPermissionStatusChecker(() async => PermissionStatus.granted);
+
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
@@ -387,6 +488,7 @@ void main() {
         expect(mockController.startCallCount, 1);
 
         tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+        await tester.pump();
         await tester.pump();
         await tester.pump();
 
@@ -399,12 +501,12 @@ void main() {
         setPermissionRequester(() async => PermissionStatus.permanentlyDenied);
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();
 
-        expect(find.byKey(const Key('scanner_placeholder')), findsOneWidget);
+        expect(find.byKey(const Key('scanner_notice')), findsOneWidget);
         expect(find.byType(MobileScanner), findsNothing);
       });
 
@@ -412,7 +514,7 @@ void main() {
         setPermissionRequester(() async => PermissionStatus.limited);
 
         await mountWidget(
-          WnScanBox(onBarcodeDetected: (_) {}),
+          QrScanner(onBarcodeDetected: (_) {}),
           tester,
         );
         await tester.pump();


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
This PR fixes the loop requesting access to camera permission when the permission is denied. (#611 ). Also renames WnScanBox to QrScanner (as it was more complex that just a design system widget  with just UI)

<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This
I tested this on android. 

- Delete staging app (to make sure I haven't granted permissions)
- Build an staging apk an install
- Sign up
- Go to start chat
- Press qr scanner icon
- Deny permission
- Check that loop doesn't happen anymore

Also checked that scanning works by going to start chat flow and scanning an npub qr


## Checklist

- [ ] `just precommit` passes
- [x] Related issue linked (`Closes #NNN`)
- [x] `CHANGELOG.md` updated (if user-visible change)
- [ ] Screenshots added (for UI changes)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved camera permission handling with explicit status checking and automatic retry on permission state changes.
  * Added new UI states for permission denial and scanner errors with contextual actions.

* **Refactor**
  * Updated QR scanner widget with enhanced lifecycle management and permission tracking.

* **Tests**
  * Updated test suite to cover new permission flows, UI states, and scanner behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->