### PR TITLE
Replace default sloth emoji with beaver 🦫

### DIFF
--- a/lib/screens/message_actions_screen.dart
+++ b/lib/screens/message_actions_screen.dart
@@ -309,7 +309,7 @@ class MessageActionsModal extends StatelessWidget {
     '👎',
     '🤣',
     '🔥',
-    '🦥',
+    '🦫',
   ];
 
   double _controlsEstimatedHeight() {


### PR DESCRIPTION
Closes #624

The sloth 🦥 was a placeholder from the Flutter redesign phase (internal codename). Replaces it with the beaver 🦫, which fits the Marmot Protocol branding.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/626">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an emoji option in message action reactions: the last reaction emoji shown to users was changed from a sloth to a beaver. This adjusts the available reaction choices in message action menus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->