### PR TITLE
Update donate Lightning address to whitenoise@donate.ipf.dev

### DIFF
--- a/lib/screens/donate_screen.dart
+++ b/lib/screens/donate_screen.dart
@@ -13,7 +13,7 @@ import 'package:whitenoise/widgets/wn_system_notice.dart';
 class DonateScreen extends HookWidget {
   const DonateScreen({super.key});
 
-  static const _lightningAddress = 'whitenoise@npub.cash';
+  static const _lightningAddress = 'whitenoise@donate.ipf.dev';
   static const _bitcoinAddress =
       'sp1qqvp56mxcj9pz9xudvlch5g4ah5hrc8rj6neu25p34rc9gxhp38cwqqlmld28u57w2srgckr34dkyg3q02phu8tm05cyj483q026xedp0s5f5j40p';
 

--- a/test/screens/donate_screen_test.dart
+++ b/test/screens/donate_screen_test.dart
@@ -72,7 +72,7 @@ void main() {
     testWidgets('displays lightning address copyable field', (tester) async {
       await pumpDonateScreen(tester);
       expect(find.text('Lightning Address'), findsOneWidget);
-      expect(find.text('whitenoise@npub.cash'), findsOneWidget);
+      expect(find.text('whitenoise@donate.ipf.dev'), findsOneWidget);
     });
 
     testWidgets('displays bitcoin silent payment copyable field', (tester) async {
@@ -122,7 +122,7 @@ void main() {
       );
       await tester.tap(lightningCopyButton);
       await tester.pump();
-      expect(getClipboard(), 'whitenoise@npub.cash');
+      expect(getClipboard(), 'whitenoise@donate.ipf.dev');
       expect(find.byType(WnSystemNotice), findsOneWidget);
       expect(find.textContaining('Thank you'), findsOneWidget);
     });


### PR DESCRIPTION
Replaces the old `whitenoise@npub.cash` Lightning address with `whitenoise@donate.ipf.dev`. Updates the test file to match.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/628">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->