### PR TITLE
fix: close bug report screen with success snackbar after submission

### DIFF
--- a/lib/screens/report_bug_screen.dart
+++ b/lib/screens/report_bug_screen.dart
@@ -41,7 +41,7 @@ class ReportBugScreen extends HookConsumerWidget {
     final frequency = useState<String?>(null);
     final includeNpub = useState(false);
     final isSending = useState(false);
-    final shouldPopOnDismiss = useState(false);
+    final shouldClearOnDismiss = useState(false);
     final notice = useSystemNotice();
     final descriptionError = useState<String?>(null);
 
@@ -88,7 +88,7 @@ class ReportBugScreen extends HookConsumerWidget {
         );
 
         if (!context.mounted) return;
-        shouldPopOnDismiss.value = true;
+        shouldClearOnDismiss.value = true;
         notice.showSuccessNotice(l10n.reportBugSuccess);
       } catch (e) {
         _logger.severe('send_bug_report failed', e);
@@ -117,11 +117,14 @@ class ReportBugScreen extends HookConsumerWidget {
                         title: notice.noticeMessage!,
                         type: notice.noticeType,
                         onDismiss: () {
-                          final shouldPop = shouldPopOnDismiss.value;
-                          shouldPopOnDismiss.value = false;
+                          final shouldClear = shouldClearOnDismiss.value;
+                          shouldClearOnDismiss.value = false;
                           notice.dismissNotice();
-                          if (shouldPop && context.mounted) {
-                            Routes.goBack(context);
+                          if (shouldClear && context.mounted) {
+                            description.clear();
+                            stepsToReproduce.clear();
+                            frequency.value = null;
+                            includeNpub.value = false;
                           }
                         },
                       )

--- a/lib/screens/report_bug_screen.dart
+++ b/lib/screens/report_bug_screen.dart
@@ -87,7 +87,13 @@ class ReportBugScreen extends HookConsumerWidget {
         );
 
         if (!context.mounted) return;
-        notice.showSuccessNotice(l10n.reportBugSuccess);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.reportBugSuccess),
+            duration: const Duration(seconds: 3),
+          ),
+        );
+        Routes.goBack(context);
       } catch (e) {
         _logger.severe('send_bug_report failed', e);
         if (!context.mounted) return;

--- a/lib/screens/report_bug_screen.dart
+++ b/lib/screens/report_bug_screen.dart
@@ -41,6 +41,7 @@ class ReportBugScreen extends HookConsumerWidget {
     final frequency = useState<String?>(null);
     final includeNpub = useState(false);
     final isSending = useState(false);
+    final shouldPopOnDismiss = useState(false);
     final notice = useSystemNotice();
     final descriptionError = useState<String?>(null);
 
@@ -87,13 +88,8 @@ class ReportBugScreen extends HookConsumerWidget {
         );
 
         if (!context.mounted) return;
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(l10n.reportBugSuccess),
-            duration: const Duration(seconds: 3),
-          ),
-        );
-        Routes.goBack(context);
+        shouldPopOnDismiss.value = true;
+        notice.showSuccessNotice(l10n.reportBugSuccess);
       } catch (e) {
         _logger.severe('send_bug_report failed', e);
         if (!context.mounted) return;
@@ -120,7 +116,14 @@ class ReportBugScreen extends HookConsumerWidget {
                         key: ValueKey(notice.noticeMessage),
                         title: notice.noticeMessage!,
                         type: notice.noticeType,
-                        onDismiss: notice.dismissNotice,
+                        onDismiss: () {
+                          final shouldPop = shouldPopOnDismiss.value;
+                          shouldPopOnDismiss.value = false;
+                          notice.dismissNotice();
+                          if (shouldPop && context.mounted) {
+                            Routes.goBack(context);
+                          }
+                        },
                       )
                     : null),
           child: KeyboardDismissOnTap(

--- a/test/screens/report_bug_screen_test.dart
+++ b/test/screens/report_bug_screen_test.dart
@@ -143,15 +143,21 @@ void main() {
     });
 
     testWidgets(
-      'shows success notice then navigates back after it auto-hides',
+      'clears the form after success notice auto-hides',
       (tester) async {
         await pumpScreen(tester);
-        expect(find.byType(ReportBugScreen), findsOneWidget);
 
         await tester.enterText(
           find.byKey(const Key('report_bug_description')),
           'Something broke',
         );
+        await tester.enterText(
+          find.byKey(const Key('report_bug_steps_to_reproduce')),
+          '1. Open app\n2. Crash',
+        );
+        await tester.tap(find.byKey(const Key('include_npub_checkbox')));
+        await tester.pumpAndSettle();
+
         await tester.tap(find.text('Send report'));
         await tester.pumpAndSettle();
 
@@ -161,7 +167,10 @@ void main() {
         await tester.pump(const Duration(seconds: 3));
         await tester.pumpAndSettle();
 
-        expect(find.byType(ReportBugScreen), findsNothing);
+        expect(find.byType(ReportBugScreen), findsOneWidget);
+        expect(find.text('Bug report sent. Thank you!'), findsNothing);
+        expect(find.text('Something broke'), findsNothing);
+        expect(find.text('1. Open app\n2. Crash'), findsNothing);
       },
     );
 

--- a/test/screens/report_bug_screen_test.dart
+++ b/test/screens/report_bug_screen_test.dart
@@ -142,20 +142,28 @@ void main() {
       expect(mockApi.lastBugReportAppVersion, appVersion);
     });
 
-    testWidgets('shows success snackbar and navigates back after successful send', (tester) async {
-      await pumpScreen(tester);
-      expect(find.byType(ReportBugScreen), findsOneWidget);
+    testWidgets(
+      'shows success notice then navigates back after it auto-hides',
+      (tester) async {
+        await pumpScreen(tester);
+        expect(find.byType(ReportBugScreen), findsOneWidget);
 
-      await tester.enterText(
-        find.byKey(const Key('report_bug_description')),
-        'Something broke',
-      );
-      await tester.tap(find.text('Send report'));
-      await tester.pumpAndSettle();
+        await tester.enterText(
+          find.byKey(const Key('report_bug_description')),
+          'Something broke',
+        );
+        await tester.tap(find.text('Send report'));
+        await tester.pumpAndSettle();
 
-      expect(find.byType(ReportBugScreen), findsNothing);
-      expect(find.widgetWithText(SnackBar, 'Bug report sent. Thank you!'), findsOneWidget);
-    });
+        expect(find.byType(ReportBugScreen), findsOneWidget);
+        expect(find.text('Bug report sent. Thank you!'), findsOneWidget);
+
+        await tester.pump(const Duration(seconds: 3));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ReportBugScreen), findsNothing);
+      },
+    );
 
     testWidgets('shows error notice when send fails', (tester) async {
       mockApi.sendBugReportShouldFail = true;

--- a/test/screens/report_bug_screen_test.dart
+++ b/test/screens/report_bug_screen_test.dart
@@ -142,15 +142,19 @@ void main() {
       expect(mockApi.lastBugReportAppVersion, appVersion);
     });
 
-    testWidgets('shows success notice after successful send', (tester) async {
+    testWidgets('shows success snackbar and navigates back after successful send', (tester) async {
       await pumpScreen(tester);
+      expect(find.byType(ReportBugScreen), findsOneWidget);
+
       await tester.enterText(
         find.byKey(const Key('report_bug_description')),
         'Something broke',
       );
       await tester.tap(find.text('Send report'));
       await tester.pumpAndSettle();
-      expect(find.text('Bug report sent. Thank you!'), findsOneWidget);
+
+      expect(find.byType(ReportBugScreen), findsNothing);
+      expect(find.widgetWithText(SnackBar, 'Bug report sent. Thank you!'), findsOneWidget);
     });
 
     testWidgets('shows error notice when send fails', (tester) async {


### PR DESCRIPTION
![marmot](https://blossom.primal.net/c559b29941fec25c2aa57a0b412dddc57bf120a0431e1926624aca559a21aa0e.jpg)

Closes #627

## What was wrong

After tapping Send on a bug report, the screen stayed open with the text
intact. Marmots assumed the submission failed and tapped Send a second
or third time.

## What changed

On a successful send, the screen now:

1. Shows a SnackBar (`Bug report sent. Thank you!`) via the root
   `ScaffoldMessenger`, so the message survives the navigation.
2. Pops back to the previous screen via `Routes.goBack(context)`.

The error path is unchanged: the in-screen notice still appears and the
screen stays open so the marmot can retry.

## Verified

- 4342 Flutter tests + Rust tests + lint/format all green.
- Manual run on Android emulator (staging flavor): tapped Send, saw the
  SnackBar, screen closed back to settings.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted bug report submission so the success notice is handled before clearing the form; the form is reset only after the notice is dismissed, keeping the report screen visible immediately after submission.

* **Tests**
  * Updated tests to verify the success notification appears, remains briefly, is dismissed, and then the form fields are cleared.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/639)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->