### PR TITLE
Dismiss chat list search on swipe-back instead of closing app

### DIFF
--- a/lib/screens/chat_list_screen.dart
+++ b/lib/screens/chat_list_screen.dart
@@ -188,6 +188,7 @@ class ChatListScreen extends HookConsumerWidget {
     final notice = useSystemNotice();
     final updateState = useZapstoreUpdate();
     final searchQuery = useState('');
+    final headerOpen = useState(false);
     final welcomeNoticeDismissed = useState(false);
     final chatListTopPadding = useMemoized(() => ValueNotifier(safeAreaTop + _slateHeight.h));
     final chatListSearch = useChatListSearch(
@@ -216,108 +217,120 @@ class ChatListScreen extends HookConsumerWidget {
     final showWelcomeNotice = !isArchiveView && isEmpty && !welcomeNoticeDismissed.value;
     final activeUpdateVersion = updateState.isDismissed ? null : updateState.availableVersion;
 
-    return Scaffold(
-      backgroundColor: colors.backgroundPrimary,
-      body: Stack(
-        children: [
-          ValueListenableBuilder<double>(
-            valueListenable: chatListTopPadding,
-            builder: (context, topPadding, _) => WnChatList(
-              itemCount: filteredChats.length,
-              isLoading: isLoading,
-              isSearchActive: searchQuery.value.isNotEmpty,
-              topPadding: topPadding,
-              header: ChatListSearchAndFilters(
-                onSearchChanged: (value) => searchQuery.value = value,
-                isLoading: chatListSearch.isSearching,
-                showFilterChips: !isArchiveView,
-                isChatsSelected: !isArchiveView,
-                onChatsSelected: (_) => selectedFilter.value = ChatListFilter.chats,
-                onArchiveSelected: (_) => selectedFilter.value = ChatListFilter.archive,
-              ),
-              headerHeight: isArchiveView ? archiveHeaderH : chatsHeaderH,
-              pinnedHeader: isArchiveView
-                  ? Padding(
-                      padding: EdgeInsets.only(top: 8.h),
-                      child: ChatListFilters(
-                        isChatsSelected: selectedFilter.value == ChatListFilter.chats,
-                        isArchiveSelected: selectedFilter.value == ChatListFilter.archive,
-                        onChatsSelected: (_) => selectedFilter.value = ChatListFilter.chats,
-                        onArchiveSelected: (_) {},
-                      ),
-                    )
-                  : null,
-              pinnedHeaderHeight: isArchiveView ? _filterChipsHeight.h : 0,
-              pinnedHeaderMinOffset: isArchiveView ? 8.h : 0,
-              emptyStateContent: isEmpty
-                  ? isArchiveView
-                        ? Center(
-                            key: const Key('archived_chats_empty'),
-                            child: Text(
-                              context.l10n.archivedChatsEmpty,
-                              style: typography.medium14.copyWith(
-                                color: colors.backgroundContentQuaternary,
-                              ),
-                            ),
-                          )
-                        : Padding(
-                            padding: EdgeInsets.symmetric(horizontal: 40.w),
-                            child: Text(
-                              key: const Key('welcome_slogan'),
-                              context.l10n.sloganFull,
-                              style: typography.medium16.copyWith(
-                                color: colors.backgroundContentTertiary,
-                              ),
-                              textAlign: TextAlign.center,
-                            ),
-                          )
-                  : null,
-              itemBuilder: (context, index) {
-                final chatSummary = filteredChats[index];
-                return ChatListTile(
-                  key: Key(chatSummary.mlsGroupId),
-                  chatSummary: chatSummary,
-                  isArchived: isArchiveView,
-                  searchSnippet: chatListSearch.messageSnippets[chatSummary.mlsGroupId],
-                  onChatListChanged: isArchiveView
-                      ? archivedChatListResult.refresh
-                      : chatListResult.refresh,
-                  onError: notice.showErrorNotice,
-                );
-              },
-            ),
-          ),
-          _MeasuredSlate(
-            onHeightChanged: (height) {
-              if (chatListTopPadding.value != height) {
-                chatListTopPadding.value = height;
-              }
-            },
-            child: SafeArea(
-              bottom: false,
-              child: WnSlate(
-                systemNotice: _buildSystemNotice(
-                  context,
-                  typography,
-                  colors,
-                  showWelcomeNotice: showWelcomeNotice,
-                  isOffline: isOffline,
-                  updateVersion: activeUpdateVersion,
-                  onUpdateDismiss: updateState.dismiss,
-                  onWelcomeDismiss: () {
-                    if (context.mounted) {
-                      welcomeNoticeDismissed.value = true;
-                    }
-                  },
-                  noticeMessage: notice.noticeMessage,
-                  noticeType: notice.noticeType,
-                  onNoticeDismiss: notice.dismissNotice,
+    final isSearchVisible = headerOpen.value || searchQuery.value.isNotEmpty;
+
+    return PopScope(
+      canPop: !isSearchVisible,
+      onPopInvokedWithResult: (didPop, _) {
+        if (didPop) return;
+        FocusScope.of(context).unfocus();
+        searchQuery.value = '';
+        headerOpen.value = false;
+      },
+      child: Scaffold(
+        backgroundColor: colors.backgroundPrimary,
+        body: Stack(
+          children: [
+            ValueListenableBuilder<double>(
+              valueListenable: chatListTopPadding,
+              builder: (context, topPadding, _) => WnChatList(
+                itemCount: filteredChats.length,
+                isLoading: isLoading,
+                isSearchActive: searchQuery.value.isNotEmpty,
+                topPadding: topPadding,
+                headerOpenNotifier: headerOpen,
+                header: ChatListSearchAndFilters(
+                  onSearchChanged: (value) => searchQuery.value = value,
+                  isLoading: chatListSearch.isSearching,
+                  showFilterChips: !isArchiveView,
+                  isChatsSelected: !isArchiveView,
+                  onChatsSelected: (_) => selectedFilter.value = ChatListFilter.chats,
+                  onArchiveSelected: (_) => selectedFilter.value = ChatListFilter.archive,
                 ),
-                header: const ChatListHeader(),
+                headerHeight: isArchiveView ? archiveHeaderH : chatsHeaderH,
+                pinnedHeader: isArchiveView
+                    ? Padding(
+                        padding: EdgeInsets.only(top: 8.h),
+                        child: ChatListFilters(
+                          isChatsSelected: selectedFilter.value == ChatListFilter.chats,
+                          isArchiveSelected: selectedFilter.value == ChatListFilter.archive,
+                          onChatsSelected: (_) => selectedFilter.value = ChatListFilter.chats,
+                          onArchiveSelected: (_) {},
+                        ),
+                      )
+                    : null,
+                pinnedHeaderHeight: isArchiveView ? _filterChipsHeight.h : 0,
+                pinnedHeaderMinOffset: isArchiveView ? 8.h : 0,
+                emptyStateContent: isEmpty
+                    ? isArchiveView
+                          ? Center(
+                              key: const Key('archived_chats_empty'),
+                              child: Text(
+                                context.l10n.archivedChatsEmpty,
+                                style: typography.medium14.copyWith(
+                                  color: colors.backgroundContentQuaternary,
+                                ),
+                              ),
+                            )
+                          : Padding(
+                              padding: EdgeInsets.symmetric(horizontal: 40.w),
+                              child: Text(
+                                key: const Key('welcome_slogan'),
+                                context.l10n.sloganFull,
+                                style: typography.medium16.copyWith(
+                                  color: colors.backgroundContentTertiary,
+                                ),
+                                textAlign: TextAlign.center,
+                              ),
+                            )
+                    : null,
+                itemBuilder: (context, index) {
+                  final chatSummary = filteredChats[index];
+                  return ChatListTile(
+                    key: Key(chatSummary.mlsGroupId),
+                    chatSummary: chatSummary,
+                    isArchived: isArchiveView,
+                    searchSnippet: chatListSearch.messageSnippets[chatSummary.mlsGroupId],
+                    onChatListChanged: isArchiveView
+                        ? archivedChatListResult.refresh
+                        : chatListResult.refresh,
+                    onError: notice.showErrorNotice,
+                  );
+                },
               ),
             ),
-          ),
-        ],
+            _MeasuredSlate(
+              onHeightChanged: (height) {
+                if (chatListTopPadding.value != height) {
+                  chatListTopPadding.value = height;
+                }
+              },
+              child: SafeArea(
+                bottom: false,
+                child: WnSlate(
+                  systemNotice: _buildSystemNotice(
+                    context,
+                    typography,
+                    colors,
+                    showWelcomeNotice: showWelcomeNotice,
+                    isOffline: isOffline,
+                    updateVersion: activeUpdateVersion,
+                    onUpdateDismiss: updateState.dismiss,
+                    onWelcomeDismiss: () {
+                      if (context.mounted) {
+                        welcomeNoticeDismissed.value = true;
+                      }
+                    },
+                    noticeMessage: notice.noticeMessage,
+                    noticeType: notice.noticeType,
+                    onNoticeDismiss: notice.dismissNotice,
+                  ),
+                  header: const ChatListHeader(),
+                ),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/widgets/wn_chat_list.dart
+++ b/lib/widgets/wn_chat_list.dart
@@ -101,6 +101,7 @@ class WnChatList extends HookWidget {
         }
       }
 
+      if (headerOpen.value) syncRevealToOpenState();
       headerOpen.addListener(syncRevealToOpenState);
       return () => headerOpen.removeListener(syncRevealToOpenState);
     }, [headerOpen, hasHeader]);

--- a/lib/widgets/wn_chat_list.dart
+++ b/lib/widgets/wn_chat_list.dart
@@ -27,6 +27,7 @@ class WnChatList extends HookWidget {
     this.pinnedHeaderHeight = 0,
     this.pinnedHeaderMinOffset = 0,
     this.emptyStateContent,
+    this.headerOpenNotifier,
   });
 
   final int itemCount;
@@ -44,6 +45,8 @@ class WnChatList extends HookWidget {
 
   final Widget? emptyStateContent;
 
+  final ValueNotifier<bool>? headerOpenNotifier;
+
   @override
   Widget build(BuildContext context) {
     final colors = context.colors;
@@ -56,7 +59,9 @@ class WnChatList extends HookWidget {
       duration: _kAnimationDuration,
     );
     final headerRevealAnimation = useAnimation(headerRevealController);
-    final headerOpen = useState(false);
+    final fallbackHeaderOpen = useState(false);
+    final headerOpen = headerOpenNotifier ?? fallbackHeaderOpen;
+    useListenable(headerOpen);
     final isAnimatingClosed = useRef(false);
     final peakReveal = useRef(0.0);
     final scrollController = useScrollController();
@@ -75,6 +80,38 @@ class WnChatList extends HookWidget {
       }
       return null;
     }, [isSearchActive, hasHeader]);
+
+    useEffect(() {
+      void syncRevealToOpenState() {
+        if (!hasHeader) return;
+        final target = headerOpen.value ? 1.0 : 0.0;
+        if (headerRevealController.value == target) return;
+        if (headerRevealController.isAnimating &&
+            headerRevealController.upperBound > 0 &&
+            ((target == 1.0 && headerRevealController.value > 0.99) ||
+                (target == 0.0 && headerRevealController.value < 0.01))) {
+          return;
+        }
+        if (target == 0.0) {
+          isAnimatingClosed.value = true;
+          headerRevealController.animateTo(0.0, curve: Curves.easeOut).then((_) {
+            isAnimatingClosed.value = false;
+          });
+          if (scrollController.hasClients && scrollController.offset > 0) {
+            scrollController.animateTo(
+              0,
+              duration: _kAnimationDuration,
+              curve: Curves.easeOut,
+            );
+          }
+        } else {
+          headerRevealController.animateTo(1.0, curve: Curves.easeOut);
+        }
+      }
+
+      headerOpen.addListener(syncRevealToOpenState);
+      return () => headerOpen.removeListener(syncRevealToOpenState);
+    }, [headerOpen, hasHeader]);
 
     void updateScrollState(ScrollMetrics metrics) {
       final newValue = metrics.extentBefore > 0;

--- a/lib/widgets/wn_chat_list.dart
+++ b/lib/widgets/wn_chat_list.dart
@@ -84,15 +84,9 @@ class WnChatList extends HookWidget {
     useEffect(() {
       void syncRevealToOpenState() {
         if (!hasHeader) return;
-        final target = headerOpen.value ? 1.0 : 0.0;
-        if (headerRevealController.value == target) return;
-        if (headerRevealController.isAnimating &&
-            headerRevealController.upperBound > 0 &&
-            ((target == 1.0 && headerRevealController.value > 0.99) ||
-                (target == 0.0 && headerRevealController.value < 0.01))) {
-          return;
-        }
-        if (target == 0.0) {
+        if (headerOpen.value) {
+          headerRevealController.animateTo(1.0, curve: Curves.easeOut);
+        } else {
           isAnimatingClosed.value = true;
           headerRevealController.animateTo(0.0, curve: Curves.easeOut).then((_) {
             isAnimatingClosed.value = false;
@@ -104,8 +98,6 @@ class WnChatList extends HookWidget {
               curve: Curves.easeOut,
             );
           }
-        } else {
-          headerRevealController.animateTo(1.0, curve: Curves.easeOut);
         }
       }
 

--- a/test/screens/chat_list_screen_test.dart
+++ b/test/screens/chat_list_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 import 'package:whitenoise/providers/auth_provider.dart';
 import 'package:whitenoise/providers/offline_provider.dart';
 import 'package:whitenoise/screens/chat_invite_screen.dart';
+import 'package:whitenoise/screens/chat_list_screen.dart';
 import 'package:whitenoise/screens/chat_screen.dart';
 import 'package:whitenoise/screens/settings_screen.dart';
 import 'package:whitenoise/screens/share_profile_screen.dart';
@@ -661,6 +662,41 @@ void main() {
           find.byType(ChatListSearchAndFilters),
         );
         expect(widget.onSearchChanged, isNotNull);
+      });
+
+      testWidgets('OS back closes search header without popping screen', (tester) async {
+        await pumpChatListScreen(tester);
+        await revealSearchBar(tester);
+        expect(find.byType(ChatListSearchAndFilters), findsOneWidget);
+
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ChatListScreen), findsOneWidget);
+        expect(find.byType(ChatListSearchAndFilters), findsNothing);
+      });
+
+      testWidgets('OS back clears search query without popping screen', (tester) async {
+        await pumpChatListScreen(tester);
+        await revealSearchBar(tester);
+        await tester.enterText(find.byType(TextField), 'Alice');
+        await tester.pump();
+        expect(find.byType(ChatListTile), findsOneWidget);
+
+        await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(ChatListScreen), findsOneWidget);
+        expect(find.byType(ChatListTile), findsNWidgets(3));
+      });
+
+      testWidgets('OS back with no search active does not consume pop', (tester) async {
+        await pumpChatListScreen(tester);
+
+        final handled = await tester.binding.handlePopRoute();
+        await tester.pumpAndSettle();
+
+        expect(handled, isFalse);
       });
     });
 

--- a/test/widgets/wn_chat_list_test.dart
+++ b/test/widgets/wn_chat_list_test.dart
@@ -476,6 +476,73 @@ void main() {
         expect(find.text('Header'), findsOneWidget);
       });
 
+      testWidgets('external notifier reveals header when set to true', (tester) async {
+        final notifier = ValueNotifier<bool>(false);
+        addTearDown(notifier.dispose);
+        await mountWidget(
+          WnChatList(
+            itemCount: 3,
+            itemBuilder: _textBuilder,
+            header: const Text('Header'),
+            headerHeight: 142,
+            headerOpenNotifier: notifier,
+          ),
+          tester,
+        );
+        await tester.pumpAndSettle();
+        expect(find.byKey(const Key('chat_list_header')), findsNothing);
+
+        notifier.value = true;
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('chat_list_header')), findsOneWidget);
+        expect(find.text('Header'), findsOneWidget);
+      });
+
+      testWidgets('external notifier hides header and scrolls list to top', (tester) async {
+        final notifier = ValueNotifier<bool>(false);
+        addTearDown(notifier.dispose);
+        await mountWidget(
+          WnChatList(
+            itemCount: 50,
+            itemBuilder: (context, index) => SizedBox(
+              height: 76,
+              child: Text('Item $index'),
+            ),
+            header: const Text('Header'),
+            headerHeight: 142,
+            headerOpenNotifier: notifier,
+          ),
+          tester,
+        );
+        await tester.pumpAndSettle();
+
+        await tester.drag(find.byKey(const Key('chat_list')), const Offset(0, -800));
+        await tester.pumpAndSettle();
+
+        final scrollableBefore = tester.widget<Scrollable>(
+          find.descendant(
+            of: find.byKey(const Key('chat_list')),
+            matching: find.byType(Scrollable),
+          ),
+        );
+        expect(scrollableBefore.controller!.offset, greaterThan(0));
+
+        notifier.value = true;
+        await tester.pumpAndSettle();
+        notifier.value = false;
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('chat_list_header')), findsNothing);
+        final scrollableAfter = tester.widget<Scrollable>(
+          find.descendant(
+            of: find.byKey(const Key('chat_list')),
+            matching: find.byType(Scrollable),
+          ),
+        );
+        expect(scrollableAfter.controller!.offset, 0);
+      });
+
       testWidgets('does not render header when header is null', (tester) async {
         await mountWidget(
           const WnChatList(itemCount: 3, itemBuilder: _textBuilder),

--- a/test/widgets/wn_chat_list_test.dart
+++ b/test/widgets/wn_chat_list_test.dart
@@ -476,6 +476,25 @@ void main() {
         expect(find.text('Header'), findsOneWidget);
       });
 
+      testWidgets('external notifier reveals header on mount when initially true', (tester) async {
+        final notifier = ValueNotifier<bool>(true);
+        addTearDown(notifier.dispose);
+        await mountWidget(
+          WnChatList(
+            itemCount: 3,
+            itemBuilder: _textBuilder,
+            header: const Text('Header'),
+            headerHeight: 142,
+            headerOpenNotifier: notifier,
+          ),
+          tester,
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const Key('chat_list_header')), findsOneWidget);
+        expect(find.text('Header'), findsOneWidget);
+      });
+
       testWidgets('external notifier reveals header when set to true', (tester) async {
         final notifier = ValueNotifier<bool>(false);
         addTearDown(notifier.dispose);


### PR DESCRIPTION
![marmot](https://blossom.primal.net/3dbf71efd665c3c69001188af6b8d1dd8d18f6a4ae803d11851488397070d5d9.png)

On Android (e.g. GrapheneOS), the swipe-back gesture used to evict the entire app even when the chat list search bar was open. Wrong target: back should dismiss in-screen state first.

The fix wraps `ChatListScreen` in a `PopScope` that intercepts the gesture whenever the search header is revealed or the query field has text. On intercept it unfocuses the keyboard, clears the query, and collapses the header. Once search is no longer visible, back falls through to its normal route pop.

To enable parent-driven dismissal, `WnChatList` now accepts an optional `headerOpenNotifier`. When provided, the screen owns the open/closed state and a `useEffect` inside `WnChatList` animates the reveal in response to external changes. Callers without the notifier keep the previous internal state.

Tested with three new widget tests covering: header dismissal on back, query clear on back, and pass-through when no search is active. Coverage holds at 99.33%.

The marmots wave goodbye to the search bar, not to the whole burrow.

Closes #612

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/640">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back button behavior when search UI is active. Back button now closes the search header instead of exiting the entire screen, then closes the app on subsequent press.
  * Enhanced header visibility synchronization with improved animation control.

* **Tests**
  * Added comprehensive test coverage for back navigation behavior with active search.
  * Added tests for header visibility control and scroll position management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->