### PR TITLE
Fix WnSystemNotice dismiss after unmount

### DIFF
--- a/lib/widgets/wn_system_notice.dart
+++ b/lib/widgets/wn_system_notice.dart
@@ -105,10 +105,12 @@ class WnSystemNotice extends HookWidget {
     final autoHideTimer = useRef<Timer?>(null);
 
     void handleDismiss() {
+      if (!context.mounted) return;
       if (isDismissing.value) return;
       isDismissing.value = true;
       autoHideTimer.value?.cancel();
       slideController.reverse().then((_) {
+        if (!context.mounted) return;
         onDismiss?.call();
       });
     }

--- a/test/widgets/wn_system_notice_test.dart
+++ b/test/widgets/wn_system_notice_test.dart
@@ -473,6 +473,54 @@ void main() {
 
       expect(dismissCount, 1);
     });
+
+    testWidgets('ignores queued dismiss callback after unmount', (tester) async {
+      var dismissed = false;
+      await mountWidget(
+        WnSystemNotice(
+          title: 'Auto-hide while navigating',
+          variant: WnSystemNoticeVariant.dismissible,
+          onDismiss: () => dismissed = true,
+        ),
+        tester,
+      );
+
+      await tester.pumpAndSettle();
+      final dismissGesture = tester.widget<GestureDetector>(
+        find.ancestor(
+          of: find.byKey(const ValueKey('systemNotice_actionIcon')),
+          matching: find.byType(GestureDetector),
+        ),
+      );
+      final queuedDismiss = dismissGesture.onTap;
+      expect(queuedDismiss, isNotNull);
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      queuedDismiss!();
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      expect(dismissed, isFalse);
+    });
+
+    testWidgets('cancels pending auto-hide timer on unmount', (tester) async {
+      var dismissed = false;
+      await mountWidget(
+        WnSystemNotice(
+          title: 'Auto-hide timer while navigating',
+          autoHideDuration: const Duration(milliseconds: 50),
+          onDismiss: () => dismissed = true,
+        ),
+        tester,
+      );
+
+      await tester.pump(const Duration(milliseconds: 30));
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(tester.takeException(), isNull);
+      expect(dismissed, isFalse);
+    });
   });
 
   group('Expand/Collapse Animation', () {


### PR DESCRIPTION
## Summary
- Guard WnSystemNotice dismiss callbacks with context.mounted before touching hook state or completing the reverse animation
- Add a regression test for a queued dismiss callback firing after the notice has unmounted

Fixes #645

## Tests
- flutter test test/widgets/wn_system_notice_test.dart --plain-name 'ignores queued dismiss callback after unmount'
- flutter test test/widgets/wn_system_notice_test.dart
- just test-flutter-quiet
- just precommit

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/646">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a crash where dismiss or auto-hide actions could run after a system notice was removed, ensuring dismiss callbacks only run while the notice is mounted.

* **Tests**
  * Added tests confirming dismissal and auto-hide timers are safely ignored if the notice is unmounted, preventing exceptions and unintended side effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/646)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->