### PR TITLE
Make group info screen scrollable for long member lists

### DIFF
--- a/lib/screens/group_info_screen.dart
+++ b/lib/screens/group_info_screen.dart
@@ -105,6 +105,7 @@ class GroupInfoScreen extends HookConsumerWidget {
           SafeArea(
             child: WnSlate(
               showTopScrollEffect: true,
+              showBottomScrollEffect: true,
               header: WnSlateNavigationHeader(
                 title: context.l10n.groupInformation,
                 onNavigate: () => Routes.goBack(context),
@@ -117,7 +118,7 @@ class GroupInfoScreen extends HookConsumerWidget {
                       onDismiss: dismissNotice,
                     )
                   : null,
-              child: Padding(
+              child: SingleChildScrollView(
                 padding: EdgeInsets.fromLTRB(16.w, 0, 16.w, 16.h),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,

--- a/test/screens/group_info_screen_test.dart
+++ b/test/screens/group_info_screen_test.dart
@@ -327,6 +327,25 @@ void main() {
       expect(find.text('Bob'), findsOneWidget);
     });
 
+    testWidgets('scrolls to members that overflow the group info screen', (tester) async {
+      final members = List.generate(24, (index) => index.toRadixString(16).padLeft(64, '0'));
+      _api.membersList = members;
+      _api.adminsList = [members.first];
+      for (final (index, pubkey) in members.indexed) {
+        _api.metadataMap[pubkey] = FlutterMetadata(displayName: 'Member $index', custom: const {});
+      }
+
+      await pumpGroupInfoScreen(tester, groupId: testGroupId);
+
+      final lastMember = find.byKey(Key('member_${members.last}'));
+      expect(tester.getTopLeft(lastMember).dy, greaterThan(tester.view.physicalSize.height));
+
+      await tester.drag(groupInfoSlateFinder(), const Offset(0, -700));
+      await tester.pumpAndSettle();
+
+      expect(tester.getBottomLeft(lastMember).dy, lessThan(tester.view.physicalSize.height));
+    });
+
     testWidgets('shows admin badge for admin members', (tester) async {
       _api.membersList = [_testPubkey, testPubkeyB];
       _api.adminsList = [_testPubkey];


### PR DESCRIPTION
## Summary
- Wrapped the group info body in a vertical `SingleChildScrollView` so long member lists stay reachable.
- Enabled bottom scroll edge feedback on the slate to match other scrollable screens.
- Added a regression widget test that verifies the last member becomes visible after scrolling.

## Testing
- Added a new widget test covering overflowed member lists on the group info screen.
- Verified the focused screen test file passes.
- Verified the Flutter test suite passes in quiet mode.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/648">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<img width="1302" height="2334" alt="CleanShot 2026-05-10 at 12 33 28@2x" src="https://github.com/user-attachments/assets/4808f281-f546-44dd-b666-361d43dbc0eb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the group info screen when displaying large member lists.

* **Tests**
  * Added test coverage for group info screen scrolling with overflow content.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/648)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->