### PR TITLE
Adopt whitenoise-rs arch-refactor: per-account sessions replace the god object

### DIFF
--- a/lib/src/rust/api.dart
+++ b/lib/src/rust/api.dart
@@ -8,6 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import 'api/error.dart';
 import 'frb_generated.dart';
 
+// These functions are ignored because they are not marked as `pub`: `wn_session`, `wn`
 // These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`, `from`
 
 /// Creates a `WhitenoiseConfig` object from string directory paths.

--- a/lib/src/rust/api/accounts.dart
+++ b/lib/src/rust/api/accounts.dart
@@ -11,7 +11,7 @@ import 'metadata.dart';
 import 'relays.dart';
 import 'users.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Future<List<Account>> getAccounts() => RustLib.instance.api.crateApiAccountsGetAccounts();
 

--- a/lib/src/rust/api/chat_list.dart
+++ b/lib/src/rust/api/chat_list.dart
@@ -14,7 +14,7 @@ import 'messages.dart';
 
 part 'chat_list.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`
 
 /// Sets the pin order for a chat.
 ///

--- a/lib/src/rust/api/group_state.dart
+++ b/lib/src/rust/api/group_state.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import '../frb_generated.dart';
 import 'error.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `eq`, `fmt`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `eq`, `fmt`, `from`
 
 /// Subscribe to real-time group state events for a single `(account, group)` pair.
 ///

--- a/lib/src/rust/api/groups.dart
+++ b/lib/src/rust/api/groups.dart
@@ -10,7 +10,7 @@ import '../lib.dart';
 import 'account_groups.dart';
 import 'error.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Future<List<Group>> activeGroups({required String pubkey}) =>
     RustLib.instance.api.crateApiGroupsActiveGroups(pubkey: pubkey);

--- a/lib/src/rust/api/messages.dart
+++ b/lib/src/rust/api/messages.dart
@@ -12,7 +12,7 @@ import 'media_files.dart';
 
 part 'messages.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Future<MessageWithTokens> sendMessageToGroup({
   required String pubkey,

--- a/lib/src/rust/api/mute_list.dart
+++ b/lib/src/rust/api/mute_list.dart
@@ -8,7 +8,8 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import '../frb_generated.dart';
 import 'error.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`, `from`
+// These functions are ignored because they are not marked as `pub`: `from_entry`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `clone`, `fmt`
 
 Future<void> blockUser({
   required String accountPubkey,

--- a/lib/src/rust/api/notifications.dart
+++ b/lib/src/rust/api/notifications.dart
@@ -8,7 +8,7 @@ import 'package:flutter_rust_bridge/flutter_rust_bridge_for_generated.dart';
 import '../frb_generated.dart';
 import 'error.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`, `from`
 
 Stream<NotificationUpdate> subscribeToNotifications() =>
     RustLib.instance.api.crateApiNotificationsSubscribeToNotifications();

--- a/lib/src/rust/api/user_search.dart
+++ b/lib/src/rust/api/user_search.dart
@@ -12,7 +12,7 @@ import 'metadata.dart';
 
 part 'user_search.freezed.dart';
 
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`, `from`, `from`
 
 Stream<UserSearchUpdate> searchUsers({
   required String accountPubkey,

--- a/lib/src/rust/api/users.dart
+++ b/lib/src/rust/api/users.dart
@@ -15,7 +15,7 @@ import 'relays.dart';
 part 'users.freezed.dart';
 
 // These functions are ignored because they are not marked as `pub`: `resolve_whitenoise_user`
-// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_fields_are_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`
+// These function are ignored because they are on traits that is not defined in current crate (put an empty `#[frb]` on it to unignore): `assert_receiver_is_total_eq`, `clone`, `clone`, `clone`, `clone`, `clone`, `eq`, `fmt`, `fmt`, `fmt`, `fmt`, `fmt`, `from`, `from`, `from`
 
 Stream<UserStreamItem> subscribeToUser({required String pubkey}) =>
     RustLib.instance.api.crateApiUsersSubscribeToUser(pubkey: pubkey);

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2664,10 +2664,10 @@ dependencies = [
  "mdk-macros",
  "mdk-storage-traits",
  "nostr",
- "openmls",
+ "openmls 0.8.1 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "openmls_basic_credential",
  "openmls_rust_crypto",
- "openmls_traits",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "serde",
  "sha2",
  "thiserror 2.0.18",
@@ -2692,8 +2692,8 @@ dependencies = [
  "keyring-core",
  "mdk-storage-traits",
  "nostr",
- "openmls",
- "openmls_traits",
+ "openmls 0.8.1 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "refinery",
  "rusqlite",
  "serde",
@@ -2709,8 +2709,8 @@ version = "0.8.0"
 source = "git+https://github.com/marmot-protocol/mdk?rev=7f809f8549458a0d7f7d885bcdd694023abf299c#7f809f8549458a0d7f7d885bcdd694023abf299c"
 dependencies = [
  "nostr",
- "openmls",
- "openmls_traits",
+ "openmls 0.8.1 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "pastey 0.2.1",
  "postcard",
  "serde",
@@ -3060,10 +3060,26 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "openmls"
 version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb512bfe6a55777518853ea535c6241f069cb0e8984678c117151d2a1e7e903"
+dependencies = [
+ "log",
+ "openmls_traits 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon",
+ "serde",
+ "serde_bytes",
+ "thiserror 2.0.18",
+ "tls_codec",
+ "zeroize",
+]
+
+[[package]]
+name = "openmls"
+version = "0.8.1"
 source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "log",
- "openmls_traits",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "rayon",
  "serde",
  "serde_bytes",
@@ -3078,7 +3094,7 @@ version = "0.5.0"
 source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "ed25519-dalek",
- "openmls_traits",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "p256",
  "rand 0.8.5",
  "serde",
@@ -3091,7 +3107,7 @@ version = "0.5.0"
 source = "git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8#04c50d7fb12d52f4f9aee26de5f5234f3df29fa8"
 dependencies = [
  "log",
- "openmls_traits",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3111,13 +3127,23 @@ dependencies = [
  "hpke-rs-crypto",
  "hpke-rs-rust-crypto",
  "openmls_memory_storage",
- "openmls_traits",
+ "openmls_traits 0.5.0 (git+https://github.com/openmls/openmls?rev=04c50d7fb12d52f4f9aee26de5f5234f3df29fa8)",
  "p256",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "serde",
  "sha2",
  "thiserror 2.0.18",
+ "tls_codec",
+]
+
+[[package]]
+name = "openmls_traits"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f88ccdd53448dfdbfa5b8da8ba4e527c418fdb966418172bace2e3b41eedd56"
+dependencies = [
+ "serde",
  "tls_codec",
 ]
 
@@ -5495,7 +5521,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=59aa42cc4cb5257beff49fd337b6c55857c80f73#59aa42cc4cb5257beff49fd337b6c55857c80f73"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#f73301592d730cca39b63bc3b13dec52213902e9"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -5516,6 +5542,7 @@ dependencies = [
  "nostr-blossom",
  "nostr-sdk",
  "once_cell",
+ "openmls 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.9.4",
  "reqwest 0.13.2",
  "rustls",
@@ -5539,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=59aa42cc4cb5257beff49fd337b6c55857c80f73#59aa42cc4cb5257beff49fd337b6c55857c80f73"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#f73301592d730cca39b63bc3b13dec52213902e9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5521,7 +5521,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#16683e6bee79a769bfeb9580a14f4da8cbcecd7b"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#eefe3fe927b53c9c890c2ac1bbc19b269fb41382"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#16683e6bee79a769bfeb9580a14f4da8cbcecd7b"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#eefe3fe927b53c9c890c2ac1bbc19b269fb41382"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5521,7 +5521,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#eefe3fe927b53c9c890c2ac1bbc19b269fb41382"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=df5f6ae9f7396ccdf96bf49a5d7a139014db9516#df5f6ae9f7396ccdf96bf49a5d7a139014db9516"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#eefe3fe927b53c9c890c2ac1bbc19b269fb41382"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=df5f6ae9f7396ccdf96bf49a5d7a139014db9516#df5f6ae9f7396ccdf96bf49a5d7a139014db9516"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -5521,7 +5521,7 @@ checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 [[package]]
 name = "whitenoise"
 version = "0.2.1"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#f73301592d730cca39b63bc3b13dec52213902e9"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#16683e6bee79a769bfeb9580a14f4da8cbcecd7b"
 dependencies = [
  "android-native-keyring-store",
  "apple-native-keyring-store",
@@ -5566,7 +5566,7 @@ dependencies = [
 [[package]]
 name = "whitenoise-macros"
 version = "0.1.0"
-source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#f73301592d730cca39b63bc3b13dec52213902e9"
+source = "git+https://github.com/marmot-protocol/whitenoise-rs?rev=2cd3fe653#16683e6bee79a769bfeb9580a14f4da8cbcecd7b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { version = "0.2.1", git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "59aa42cc4cb5257beff49fd337b6c55857c80f73" }
+whitenoise = { git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "2cd3fe653" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "2.0.12"
 tokio = { version = "1.44", features = ["rt", "rt-multi-thread"] }
 tracing = "0.1"
 url = "2.5.1"
-whitenoise = { git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "2cd3fe653" }
+whitenoise = { git = "https://github.com/marmot-protocol/whitenoise-rs", rev = "df5f6ae9f7396ccdf96bf49a5d7a139014db9516" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(frb_expand)'] }

--- a/rust/src/api/account_groups.rs
+++ b/rust/src/api/account_groups.rs
@@ -1,8 +1,8 @@
+use crate::api::wn_session;
 use crate::api::{error::ApiError, utils::group_id_to_string};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
 use whitenoise::AccountGroup as WhitenoiseAccountGroup;
-use whitenoise::Whitenoise;
 use whitenoise::mdk::GroupId;
 
 /// Represents the relationship between an account and an MLS group.
@@ -76,18 +76,11 @@ pub async fn accept_account_group(
     account_pubkey: String,
     mls_group_id: String,
 ) -> Result<AccountGroup, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = ::hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-
-    let ag = WhitenoiseAccountGroup::get(whitenoise, &pubkey, &group_id)
-        .await?
-        .ok_or_else(|| ApiError::Other {
-            message: "AccountGroup not found".to_string(),
-        })?;
-
-    let updated = ag.accept(whitenoise).await?;
+    let session = wn_session(&pubkey)?;
+    let updated = session.membership().for_group(&group_id).accept().await?;
     Ok(updated.into())
 }
 
@@ -98,18 +91,11 @@ pub async fn decline_account_group(
     account_pubkey: String,
     mls_group_id: String,
 ) -> Result<AccountGroup, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = ::hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-
-    let ag = WhitenoiseAccountGroup::get(whitenoise, &pubkey, &group_id)
-        .await?
-        .ok_or_else(|| ApiError::Other {
-            message: "AccountGroup not found".to_string(),
-        })?;
-
-    let updated = ag.decline(whitenoise).await?;
+    let session = wn_session(&pubkey)?;
+    let updated = session.membership().for_group(&group_id).decline().await?;
     Ok(updated.into())
 }
 
@@ -118,17 +104,15 @@ pub async fn get_account_group(
     account_pubkey: String,
     mls_group_id: String,
 ) -> Result<AccountGroup, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = ::hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-
-    let ag = WhitenoiseAccountGroup::get(whitenoise, &pubkey, &group_id)
-        .await?
-        .ok_or_else(|| ApiError::Other {
-            message: "AccountGroup not found".to_string(),
-        })?;
-
+    let session = wn_session(&pubkey)?;
+    let (ag, _) = session
+        .membership()
+        .for_group(&group_id)
+        .get_or_create(None)
+        .await?;
     Ok(ag.into())
 }
 
@@ -137,33 +121,34 @@ pub async fn get_dm_group_with_peer(
     account_pubkey: String,
     peer_pubkey: String,
 ) -> Result<Option<String>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let peer = PublicKey::parse(&peer_pubkey)?;
-    let group_id = whitenoise.get_dm_group_with_peer(&account, &peer).await?;
+    let session = wn_session(&pubkey)?;
+    let group_id = session.membership().dm_group_with_peer(&peer).await?;
     Ok(group_id.map(|id| group_id_to_string(&id)))
 }
 
 #[frb]
 pub async fn archive_chat(account_pubkey: String, mls_group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = ::hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise.archive_chat(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    session.membership().for_group(&group_id).archive().await?;
     Ok(())
 }
 
 #[frb]
 pub async fn unarchive_chat(account_pubkey: String, mls_group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = ::hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise.unarchive_chat(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    session
+        .membership()
+        .for_group(&group_id)
+        .unarchive()
+        .await?;
     Ok(())
 }
 
@@ -176,11 +161,9 @@ pub async fn mark_message_read(
     account_pubkey: String,
     message_id: String,
 ) -> Result<AccountGroup, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let event_id = EventId::from_hex(&message_id)?;
-
-    let updated = whitenoise.mark_message_read(&account, &event_id).await?;
+    let session = wn_session(&pubkey)?;
+    let updated = session.membership().mark_message_read(&event_id).await?;
     Ok(updated.into())
 }

--- a/rust/src/api/accounts.rs
+++ b/rust/src/api/accounts.rs
@@ -1,13 +1,14 @@
 use crate::api::{
     DEFAULT_RELAY_URLS, error::ApiError, metadata::FlutterMetadata, relays::Relay, users::User,
 };
+use crate::api::{wn, wn_session};
 use chrono::{DateTime, TimeZone, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
 use whitenoise::{
     Account as WhitenoiseAccount, AccountSettings as WhitenoiseAccountSettings,
     AccountType as WhitenoiseAccountType, ImageType, LoginResult as WhitenoiseLoginResult,
-    LoginStatus as WhitenoiseLoginStatus, RelayType, Whitenoise,
+    LoginStatus as WhitenoiseLoginStatus, RelayType,
 };
 
 /// The type of account authentication.
@@ -124,14 +125,14 @@ impl From<Event> for FlutterEvent {
 
 #[frb]
 pub async fn get_accounts() -> Result<Vec<Account>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let accounts = whitenoise.all_accounts().await?;
     Ok(accounts.into_iter().map(|a| a.into()).collect())
 }
 
 #[frb]
 pub async fn get_account(pubkey: String) -> Result<Account, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     Ok(account.into())
@@ -139,7 +140,7 @@ pub async fn get_account(pubkey: String) -> Result<Account, ApiError> {
 
 #[frb]
 pub async fn create_identity() -> Result<Account, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let account = whitenoise.create_identity().await?;
     Ok(account.into())
 }
@@ -150,14 +151,14 @@ pub async fn create_identity() -> Result<Account, ApiError> {
 
 #[frb]
 pub async fn login_start(nsec_or_hex_privkey: String) -> Result<LoginResult, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let result = whitenoise.login_start(nsec_or_hex_privkey).await?;
     Ok(result.into())
 }
 
 #[frb]
 pub async fn login_publish_default_relays(pubkey: String) -> Result<LoginResult, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let result = whitenoise.login_publish_default_relays(&pubkey).await?;
     Ok(result.into())
@@ -168,7 +169,7 @@ pub async fn login_with_custom_relay(
     pubkey: String,
     relay_url: String,
 ) -> Result<LoginResult, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let relay_url = RelayUrl::parse(&relay_url)?;
     let result = whitenoise
@@ -179,7 +180,7 @@ pub async fn login_with_custom_relay(
 
 #[frb]
 pub async fn login_cancel(pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     whitenoise.login_cancel(&pubkey).await?;
     Ok(())
@@ -187,14 +188,14 @@ pub async fn login_cancel(pubkey: String) -> Result<(), ApiError> {
 
 #[frb]
 pub async fn logout(pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     whitenoise.logout(&pubkey).await.map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn export_account_nsec(pubkey: String) -> Result<String, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     whitenoise
@@ -208,7 +209,7 @@ pub async fn update_account_metadata(
     pubkey: String,
     metadata: &FlutterMetadata,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     account
@@ -224,7 +225,7 @@ pub async fn upload_account_profile_picture(
     file_path: String,
     image_type: String,
 ) -> Result<String, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let image_type = ImageType::try_from(image_type).map_err(|error| ApiError::Other {
         message: error.to_string(),
@@ -241,21 +242,23 @@ pub async fn upload_account_profile_picture(
 
 #[frb]
 pub async fn account_relays(pubkey: String, relay_type: RelayType) -> Result<Vec<Relay>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let relays = account.relays(relay_type, whitenoise).await?;
+    let relays = account.relays(relay_type, &whitenoise.shared).await?;
     Ok(relays.into_iter().map(|r| r.into()).collect())
 }
 
 #[frb]
 pub async fn restore_default_relays(pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
 
     for relay_type in [RelayType::Nip65, RelayType::Inbox, RelayType::KeyPackage] {
-        let current_relays = account.relays(relay_type.clone(), whitenoise).await?;
+        let current_relays = account
+            .relays(relay_type.clone(), &whitenoise.shared)
+            .await?;
         for relay in &current_relays {
             account
                 .remove_relay(relay, relay_type.clone(), whitenoise)
@@ -279,7 +282,7 @@ pub async fn add_account_relay(
     url: String,
     relay_type: RelayType,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let relay_url = RelayUrl::parse(&url)?;
@@ -296,7 +299,7 @@ pub async fn remove_account_relay(
     url: String,
     relay_type: RelayType,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let relay_url = RelayUrl::parse(&url)?;
@@ -309,31 +312,28 @@ pub async fn remove_account_relay(
 
 #[frb]
 pub async fn account_key_package(pubkey: String) -> Result<Option<FlutterEvent>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let user = whitenoise.find_user_by_pubkey(&pubkey).await?;
-    let event = user.key_package_event(whitenoise).await?;
+    let event = user.key_package_event(&whitenoise.shared).await?;
     Ok(event.map(|e| e.into()))
 }
 
 #[frb]
 pub async fn account_key_packages(account_pubkey: String) -> Result<Vec<FlutterEvent>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let key_packages = whitenoise
-        .fetch_all_key_packages_for_account(&account)
-        .await?;
+    let session = wn_session(&pubkey)?;
+    let key_packages = session.key_packages().fetch_all().await?;
     Ok(key_packages.into_iter().map(|e| e.into()).collect())
 }
 
 #[frb]
 pub async fn publish_account_key_package(account_pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise
-        .publish_key_package_for_account(&account)
+    let session = wn_session(&pubkey)?;
+    session
+        .key_packages()
+        .publish()
         .await
         .map_err(ApiError::from)
 }
@@ -343,33 +343,29 @@ pub async fn delete_account_key_package(
     account_pubkey: String,
     key_package_id: String,
 ) -> Result<bool, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let key_package_id = EventId::parse(&key_package_id)?;
-    whitenoise
-        .delete_key_package_for_account(&account, &key_package_id, true)
+    session
+        .key_packages()
+        .delete(&key_package_id, true)
         .await
         .map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn delete_account_key_packages(account_pubkey: String) -> Result<usize, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let deleted_count = whitenoise
-        .delete_legacy_key_packages_for_account(&account)
-        .await?;
+    let session = wn_session(&pubkey)?;
+    let deleted_count = session.key_packages().delete_legacy().await?;
     Ok(deleted_count)
 }
 
 #[frb]
 pub async fn account_follows(pubkey: String) -> Result<Vec<User>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let follows = whitenoise.follows(&account).await?;
+    let session = wn_session(&pubkey)?;
+    let follows = session.social().follows().await?;
     Ok(follows.into_iter().map(|u| u.into()).collect())
 }
 
@@ -378,12 +374,12 @@ pub async fn follow_user(
     account_pubkey: String,
     user_to_follow_pubkey: String,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let user_to_follow_pubkey = PublicKey::parse(&user_to_follow_pubkey)?;
-    whitenoise
-        .follow_user(&account, &user_to_follow_pubkey)
+    session
+        .social()
+        .follow_user(&user_to_follow_pubkey)
         .await
         .map_err(ApiError::from)
 }
@@ -393,12 +389,12 @@ pub async fn unfollow_user(
     account_pubkey: String,
     user_to_unfollow_pubkey: String,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let user_to_unfollow_pubkey = PublicKey::parse(&user_to_unfollow_pubkey)?;
-    whitenoise
-        .unfollow_user(&account, &user_to_unfollow_pubkey)
+    session
+        .social()
+        .unfollow_user(&user_to_unfollow_pubkey)
         .await
         .map_err(ApiError::from)
 }
@@ -408,12 +404,12 @@ pub async fn is_following_user(
     account_pubkey: String,
     user_pubkey: String,
 ) -> Result<bool, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let user_pubkey = PublicKey::parse(&user_pubkey)?;
-    whitenoise
-        .is_following_user(&account, &user_pubkey)
+    session
+        .social()
+        .is_following(&user_pubkey)
         .await
         .map_err(ApiError::from)
 }
@@ -434,10 +430,14 @@ impl From<WhitenoiseAccountSettings> for AccountSettings {
 
 #[frb]
 pub async fn account_settings(pubkey: String) -> Result<AccountSettings, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let settings = whitenoise.account_settings(&account).await?;
+    let session = whitenoise
+        .session(&pubkey)
+        .ok_or_else(|| ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })?;
+    let settings = session.settings().get().await?;
     Ok(settings.into())
 }
 
@@ -446,11 +446,16 @@ pub async fn update_notifications_enabled(
     pubkey: String,
     enabled: bool,
 ) -> Result<AccountSettings, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let settings = whitenoise
-        .update_notifications_enabled(&account, enabled)
+    let session = whitenoise
+        .session(&pubkey)
+        .ok_or_else(|| ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })?;
+    let settings = session
+        .settings()
+        .update_notifications_enabled(enabled)
         .await?;
     Ok(settings.into())
 }

--- a/rust/src/api/chat_list.rs
+++ b/rust/src/api/chat_list.rs
@@ -1,5 +1,6 @@
 use crate::api::chat_summary::ChatSummary;
 use crate::api::error::ApiError;
+use crate::api::{wn, wn_session};
 use crate::frb_generated::StreamSink;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
@@ -7,7 +8,7 @@ use nostr_sdk::PublicKey;
 use whitenoise::mdk::GroupId;
 use whitenoise::{
     ChatListUpdate as WhitenoiseChatListUpdate,
-    ChatListUpdateTrigger as WhitenoiseChatListUpdateTrigger, MuteDuration, Whitenoise,
+    ChatListUpdateTrigger as WhitenoiseChatListUpdateTrigger, MuteDuration,
 };
 
 /// How long to mute a chat.
@@ -133,14 +134,15 @@ pub async fn set_chat_pin_order(
     mls_group_id: String,
     pin_order: Option<i64>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
 
-    whitenoise
-        .set_chat_pin_order(&account, &group_id, pin_order)
+    session
+        .membership()
+        .for_group(&group_id)
+        .set_pin_order(pin_order)
         .await?;
 
     Ok(())
@@ -156,14 +158,15 @@ pub async fn mute_chat(
     mls_group_id: String,
     duration: ChatMuteDuration,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
 
-    whitenoise
-        .mute_chat(&account, &group_id, duration.into())
+    session
+        .membership()
+        .for_group(&group_id)
+        .mute(duration.into())
         .await?;
 
     Ok(())
@@ -174,13 +177,12 @@ pub async fn mute_chat(
 /// Notifications for this chat will resume immediately.
 #[frb]
 pub async fn unmute_chat(account_pubkey: String, mls_group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id_bytes = hex::decode(&mls_group_id)?;
     let group_id = GroupId::from_slice(&group_id_bytes);
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
 
-    whitenoise.unmute_chat(&account, &group_id).await?;
+    session.membership().for_group(&group_id).unmute().await?;
 
     Ok(())
 }
@@ -193,10 +195,9 @@ pub async fn unmute_chat(account_pubkey: String, mls_group_id: String) -> Result
 /// 3. Groups without messages are sorted by creation date
 #[frb]
 pub async fn get_chat_list(account_pubkey: String) -> Result<Vec<ChatSummary>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let chat_list = whitenoise.get_chat_list(&account).await?;
+    let session = wn_session(&pubkey)?;
+    let chat_list = session.chat_list().active().await?;
     Ok(chat_list.into_iter().map(|item| item.into()).collect())
 }
 
@@ -212,7 +213,7 @@ pub async fn subscribe_to_chat_list(
     account_pubkey: String,
     sink: StreamSink<ChatListStreamItem>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
 
@@ -265,7 +266,7 @@ pub async fn subscribe_to_archived_chat_list(
     account_pubkey: String,
     sink: StreamSink<ChatListStreamItem>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
 

--- a/rust/src/api/chat_summary.rs
+++ b/rust/src/api/chat_summary.rs
@@ -1,11 +1,11 @@
 use crate::api::error::ApiError;
 use crate::api::groups::GroupType;
 use crate::api::messages::ChatMessageSummary;
-use crate::api::utils::{group_id_from_string, group_id_to_string};
+use crate::api::utils::group_id_to_string;
+use crate::api::wn_session;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::PublicKey;
-use whitenoise::Whitenoise;
 use whitenoise::whitenoise::chat_list::ChatListItem as WhitenoiseChatListItem;
 
 #[frb(non_opaque)]
@@ -84,10 +84,16 @@ pub async fn get_chat_summary(
     account_pubkey: String,
     mls_group_id: String,
 ) -> Result<ChatSummary, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let group_id = group_id_from_string(&mls_group_id)?;
-    let item = whitenoise.get_chat_list_item(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    let active = session.chat_list().active().await?;
+    let archived = session.chat_list().archived().await?;
+    let item = active
+        .into_iter()
+        .chain(archived)
+        .find(|item| group_id_to_string(&item.mls_group_id) == mls_group_id)
+        .ok_or_else(|| ApiError::Other {
+            message: format!("Chat not found: {}", mls_group_id),
+        })?;
     Ok(item.into())
 }

--- a/rust/src/api/drafts.rs
+++ b/rust/src/api/drafts.rs
@@ -1,3 +1,4 @@
+use crate::api::wn_session;
 use crate::api::{
     error::ApiError,
     media_files::MediaFile,
@@ -6,7 +7,7 @@ use crate::api::{
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
-use whitenoise::{Draft as WhitenoiseDraft, MediaFile as WhitenoiseMediaFile, Whitenoise};
+use whitenoise::{Draft as WhitenoiseDraft, MediaFile as WhitenoiseMediaFile};
 
 /// Flutter-compatible draft message for a specific group.
 ///
@@ -54,23 +55,17 @@ pub async fn save_draft(
     reply_to_id: Option<String>,
     media_attachments: Vec<MediaFile>,
 ) -> Result<Draft, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let reply_to = reply_to_id.as_deref().map(EventId::parse).transpose()?;
     let attachments = media_attachments
         .into_iter()
         .map(WhitenoiseMediaFile::try_from)
         .collect::<Result<Vec<_>, _>>()?;
-    let draft = whitenoise
-        .save_draft(
-            &account,
-            &group_id,
-            &content,
-            reply_to.as_ref(),
-            &attachments,
-        )
+    let draft = session
+        .drafts()
+        .save(&group_id, &content, reply_to.as_ref(), &attachments)
         .await?;
     Ok(draft.into())
 }
@@ -78,11 +73,10 @@ pub async fn save_draft(
 /// Loads the draft for the given account and group, if one exists.
 #[frb]
 pub async fn load_draft(pubkey: String, group_id: String) -> Result<Option<Draft>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let draft = whitenoise.load_draft(&account, &group_id).await?;
+    let draft = session.drafts().load(&group_id).await?;
     Ok(draft.map(|d| d.into()))
 }
 
@@ -91,10 +85,9 @@ pub async fn load_draft(pubkey: String, group_id: String) -> Result<Option<Draft
 /// No-op if no draft exists.
 #[frb]
 pub async fn delete_draft(pubkey: String, group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    whitenoise.delete_draft(&account, &group_id).await?;
+    session.drafts().delete(&group_id).await?;
     Ok(())
 }

--- a/rust/src/api/group_state.rs
+++ b/rust/src/api/group_state.rs
@@ -1,9 +1,9 @@
 use crate::api::error::ApiError;
 use crate::api::utils::group_id_from_string;
+use crate::api::wn;
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
 use nostr_sdk::PublicKey;
-use whitenoise::Whitenoise;
 use whitenoise::whitenoise::group_state_streaming::GroupStateUpdate as WhitenoiseGroupStateUpdate;
 
 /// Real-time group state event for the subscribed `(account, group)` pair.
@@ -45,7 +45,7 @@ pub async fn subscribe_to_group_state(
     mls_group_id: String,
     sink: StreamSink<GroupStateUpdate>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&mls_group_id)?;
 

--- a/rust/src/api/groups.rs
+++ b/rust/src/api/groups.rs
@@ -476,13 +476,8 @@ impl From<WhitenoiseGroupWithInfoAndMembership> for GroupWithInfoAndMembership {
 pub async fn visible_groups_with_info(
     account_pubkey: String,
 ) -> Result<Vec<GroupWithInfoAndMembership>, ApiError> {
-    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let session = whitenoise
-        .session(&pubkey)
-        .ok_or_else(|| ApiError::Whitenoise {
-            message: "Account session not found".to_string(),
-        })?;
+    let session = wn_session(&pubkey)?;
     let groups = session.groups().visible_with_info().await?;
     Ok(groups.into_iter().map(|g| g.into()).collect())
 }

--- a/rust/src/api/groups.rs
+++ b/rust/src/api/groups.rs
@@ -1,6 +1,7 @@
 use crate::api::{
     default_relay_urls_parsed, error::ApiError, group_id_from_string, group_id_to_string,
 };
+use crate::api::{wn, wn_session};
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
@@ -9,7 +10,7 @@ use whitenoise::mdk::{NostrGroupConfigData, NostrGroupDataUpdate};
 use whitenoise::whitenoise::groups::RequiredProposal as WhitenoiseRequiredProposal;
 use whitenoise::{
     GroupInformation as WhitenoiseGroupInformation, GroupType as WhitenoiseGroupType,
-    GroupWithInfoAndMembership as WhitenoiseGroupWithInfoAndMembership, Whitenoise,
+    GroupWithInfoAndMembership as WhitenoiseGroupWithInfoAndMembership,
 };
 #[frb(non_opaque)]
 #[derive(Debug, Clone)]
@@ -90,7 +91,7 @@ impl From<FlutterGroupDataUpdate> for NostrGroupDataUpdate {
 impl Group {
     #[frb]
     pub async fn group_type(&self, account_pubkey: String) -> Result<GroupType, ApiError> {
-        let whitenoise = Whitenoise::get_instance()?;
+        let whitenoise = wn()?;
         let mls_group_id = group_id_from_string(&self.mls_group_id)?;
         let parsed_pubkey = PublicKey::parse(&account_pubkey)?;
         let group_information = whitenoise
@@ -101,7 +102,7 @@ impl Group {
 
     #[frb]
     pub async fn is_direct_message_type(&self, account_pubkey: String) -> Result<bool, ApiError> {
-        let whitenoise = Whitenoise::get_instance()?;
+        let whitenoise = wn()?;
         let mls_group_id = group_id_from_string(&self.mls_group_id)?;
         let parsed_pubkey = PublicKey::parse(&account_pubkey)?;
         let group_information = whitenoise
@@ -112,7 +113,7 @@ impl Group {
 
     #[frb]
     pub async fn is_group_type(&self, account_pubkey: String) -> Result<bool, ApiError> {
-        let whitenoise = Whitenoise::get_instance()?;
+        let whitenoise = wn()?;
         let mls_group_id = group_id_from_string(&self.mls_group_id)?;
         let parsed_pubkey = PublicKey::parse(&account_pubkey)?;
         let group_information = whitenoise
@@ -127,12 +128,12 @@ impl Group {
         account_pubkey: String,
         group_data: FlutterGroupDataUpdate,
     ) -> Result<(), ApiError> {
-        let whitenoise = Whitenoise::get_instance()?;
         let mls_group_id = group_id_from_string(&self.mls_group_id)?;
         let parsed_pubkey = PublicKey::parse(&account_pubkey)?;
-        let account = whitenoise.find_account_by_pubkey(&parsed_pubkey).await?;
-        whitenoise
-            .update_group_data(&account, &mls_group_id, group_data.into())
+        let session = wn_session(&parsed_pubkey)?;
+        session
+            .groups()
+            .update_group_data(&mls_group_id, group_data.into())
             .await
             .map_err(ApiError::from)
     }
@@ -216,30 +217,27 @@ impl From<WhitenoiseGroupInformation> for GroupInformation {
 
 #[frb]
 pub async fn active_groups(pubkey: String) -> Result<Vec<Group>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let groups = whitenoise.groups(&account, true).await?;
+    let session = wn_session(&pubkey)?;
+    let groups = session.groups().all(true)?;
     Ok(groups.into_iter().map(|g| g.into()).collect())
 }
 
 #[frb]
 pub async fn group_members(pubkey: String, group_id: String) -> Result<Vec<String>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let members = whitenoise.group_members(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    let members = session.groups().members(&group_id)?;
     Ok(members.into_iter().map(|m| m.to_hex()).collect())
 }
 
 #[frb]
 pub async fn group_admins(pubkey: String, group_id: String) -> Result<Vec<String>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let admins = whitenoise.group_admins(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    let admins = session.groups().admins(&group_id)?;
     Ok(admins.into_iter().map(|a| a.to_hex()).collect())
 }
 
@@ -257,9 +255,8 @@ pub async fn create_group(
         GroupType::Group => WhitenoiseGroupType::Group,
     };
 
-    let whitenoise = Whitenoise::get_instance()?;
     let creator_pubkey = PublicKey::parse(&creator_pubkey)?;
-    let creator_account = whitenoise.find_account_by_pubkey(&creator_pubkey).await?;
+    let session = wn_session(&creator_pubkey)?;
 
     let admin_pubkeys = admin_pubkeys
         .into_iter()
@@ -281,9 +278,9 @@ pub async fn create_group(
         .map(|pk| PublicKey::parse(&pk))
         .collect::<Result<Vec<_>, _>>()?;
 
-    let group = whitenoise
+    let group = session
+        .groups()
         .create_group(
-            &creator_account,
             member_pubkeys,
             nostr_group_config,
             Some(whitenoise_group_type),
@@ -298,16 +295,16 @@ pub async fn add_members_to_group(
     group_id: String,
     member_pubkeys: Vec<String>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let member_pubkeys = member_pubkeys
         .into_iter()
         .map(|pk| PublicKey::parse(&pk))
         .collect::<Result<Vec<_>, _>>()?;
-    whitenoise
-        .add_members_to_group(&account, &group_id, member_pubkeys)
+    session
+        .groups()
+        .add_members(&group_id, member_pubkeys)
         .await
         .map_err(ApiError::from)
 }
@@ -318,16 +315,16 @@ pub async fn remove_members_from_group(
     group_id: String,
     member_pubkeys: Vec<String>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let member_pubkeys = member_pubkeys
         .into_iter()
         .map(|pk| PublicKey::parse(&pk))
         .collect::<Result<Vec<_>, _>>()?;
-    whitenoise
-        .remove_members_from_group(&account, &group_id, member_pubkeys)
+    session
+        .groups()
+        .remove_members(&group_id, member_pubkeys)
         .await
         .map_err(ApiError::from)
 }
@@ -338,11 +335,14 @@ pub async fn remove_members_from_group(
 /// Local-only: nothing is published to relays.
 #[frb]
 pub async fn clear_chat(account_pubkey: String, group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise.clear_chat(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    session
+        .membership()
+        .for_group(&group_id)
+        .clear_chat()
+        .await?;
     Ok(())
 }
 
@@ -353,7 +353,7 @@ pub async fn clear_chat(account_pubkey: String, group_id: String) -> Result<(), 
 /// to exit the group entirely.
 #[frb]
 pub async fn delete_chat(account_pubkey: String, group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
@@ -370,34 +370,34 @@ pub async fn leave_and_delete_group(
     account_pubkey: String,
     group_id: String,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise.leave_group(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    session.groups().leave(&group_id).await?;
     whitenoise.delete_chat(&account, &group_id).await?;
     Ok(())
 }
 
 #[frb]
 pub async fn leave_group(pubkey: String, group_id: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise
-        .leave_group(&account, &group_id)
+    let session = wn_session(&pubkey)?;
+    session
+        .groups()
+        .leave(&group_id)
         .await
         .map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn get_group(account_pubkey: String, group_id: String) -> Result<Group, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let group = whitenoise.group(&account, &group_id).await?;
+    let group = session.groups().get(&group_id)?;
     Ok(group.into())
 }
 
@@ -406,7 +406,7 @@ pub async fn group_required_proposals(
     account_pubkey: String,
     group_id: String,
 ) -> Result<Vec<RequiredProposal>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let group_id = group_id_from_string(&group_id)?;
@@ -424,7 +424,7 @@ pub async fn get_group_information(
     account_pubkey: String,
     group_id: String,
 ) -> Result<GroupInformation, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let group_id = group_id_from_string(&group_id)?;
     let parsed_pubkey = PublicKey::parse(&account_pubkey)?;
     Ok(whitenoise
@@ -438,7 +438,7 @@ pub async fn get_groups_informations(
     account_pubkey: String,
     group_ids: Vec<String>,
 ) -> Result<Vec<GroupInformation>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let group_ids = group_ids
         .into_iter()
         .map(|id| group_id_from_string(&id))
@@ -476,10 +476,14 @@ impl From<WhitenoiseGroupWithInfoAndMembership> for GroupWithInfoAndMembership {
 pub async fn visible_groups_with_info(
     account_pubkey: String,
 ) -> Result<Vec<GroupWithInfoAndMembership>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let groups = whitenoise.visible_groups_with_info(&account).await?;
+    let session = whitenoise
+        .session(&pubkey)
+        .ok_or_else(|| ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })?;
+    let groups = session.groups().visible_with_info().await?;
     Ok(groups.into_iter().map(|g| g.into()).collect())
 }
 
@@ -499,14 +503,15 @@ pub async fn upload_group_image(
     file_path: String,
     server_url: String,
 ) -> Result<UploadGroupImageResult, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let server = Url::parse(&server_url)?;
 
-    let (encrypted_hash, image_key, image_nonce) = whitenoise
-        .upload_group_image(&account, &group_id, &file_path, Some(server), None)
+    let (encrypted_hash, image_key, image_nonce) = session
+        .groups()
+        .media()
+        .upload_group_image(&group_id, &file_path, Some(server), None)
         .await?;
 
     Ok(UploadGroupImageResult {
@@ -538,11 +543,14 @@ pub async fn get_group_image_path(
     account_pubkey: String,
     group_id: String,
 ) -> Result<Option<String>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let path = whitenoise.get_group_image_path(&account, &group_id).await?;
+    let session = wn_session(&pubkey)?;
+    let path = session
+        .groups()
+        .media()
+        .get_group_image_path(&group_id)
+        .await?;
     Ok(path.map(|p| p.to_string_lossy().to_string()))
 }
 
@@ -577,7 +585,7 @@ pub async fn get_ratchet_tree_info(
     account_pubkey: String,
     group_id: String,
 ) -> Result<RatchetTreeInfo, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;

--- a/rust/src/api/media_files.rs
+++ b/rust/src/api/media_files.rs
@@ -1,11 +1,10 @@
+use crate::api::wn_session;
 use crate::api::{error::ApiError, group_id_from_string, group_id_to_string};
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
 use std::path::PathBuf;
-use whitenoise::{
-    FileMetadata as WhitenoiseFileMetadata, MediaFile as WhitenoiseMediaFile, Whitenoise,
-};
+use whitenoise::{FileMetadata as WhitenoiseFileMetadata, MediaFile as WhitenoiseMediaFile};
 
 #[frb(non_opaque)]
 #[derive(Debug, Clone)]
@@ -122,13 +121,14 @@ pub async fn upload_chat_media(
     group_id: String,
     file_path: String,
 ) -> Result<MediaFile, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
 
-    let media_file = whitenoise
-        .upload_chat_media(&account, &group_id, &file_path, None, None)
+    let media_file = session
+        .groups()
+        .media()
+        .upload_chat_media(&group_id, &file_path, None, None)
         .await?;
 
     Ok(media_file.into())
@@ -140,9 +140,8 @@ pub async fn download_chat_media(
     group_id: String,
     original_file_hash: String,
 ) -> Result<MediaFile, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
+    let session = wn_session(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let original_file_hash_bytes = ::hex::decode(&original_file_hash)?;
     let hash_array: [u8; 32] =
@@ -152,8 +151,10 @@ pub async fn download_chat_media(
                 message: "Invalid original_file_hash length; must be 32 bytes.".to_string(),
             })?;
 
-    let media_file = whitenoise
-        .download_chat_media(&account, &group_id, &hash_array)
+    let media_file = session
+        .groups()
+        .media()
+        .download_chat_media(&group_id, &hash_array)
         .await?;
 
     Ok(media_file.into())

--- a/rust/src/api/messages.rs
+++ b/rust/src/api/messages.rs
@@ -1,3 +1,4 @@
+use crate::api::wn;
 use crate::api::{
     error::ApiError,
     media_files::MediaFile,
@@ -430,7 +431,7 @@ pub async fn send_message_to_group(
     kind: u16,
     tags: Option<Vec<Tag>>,
 ) -> Result<MessageWithTokens, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let group_id = group_id_from_string(&group_id)?;
@@ -449,7 +450,7 @@ pub async fn retry_message_publish(
     group_id: String,
     event_id: String,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let group_id = group_id_from_string(&group_id)?;
@@ -475,7 +476,7 @@ pub async fn search_messages_in_group(
     query: String,
     limit: Option<u32>,
 ) -> Result<Vec<SearchResult>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let results = whitenoise
@@ -496,7 +497,7 @@ pub async fn search_messages(
     query: String,
     limit: Option<u32>,
 ) -> Result<Vec<SearchResult>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let results = whitenoise.search_messages(&pubkey, &query, limit).await?;
     Ok(results.into_iter().map(|r| r.into()).collect())
@@ -515,7 +516,7 @@ pub async fn fetch_aggregated_messages_for_group(
     before_message_id: Option<String>,
     limit: Option<u32>,
 ) -> Result<Vec<ChatMessage>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let before_ts = before
@@ -549,7 +550,7 @@ pub async fn fetch_message_by_id(
     group_id: String,
     message_id: String,
 ) -> Result<Option<ChatMessage>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let message = whitenoise
@@ -572,7 +573,7 @@ pub async fn fetch_messages_unread_with_minimum(
     group_id: String,
     minimum: Option<u32>,
 ) -> Result<Vec<ChatMessage>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let group_id = group_id_from_string(&group_id)?;
     let messages = whitenoise
@@ -606,7 +607,7 @@ pub async fn subscribe_to_group_messages(
     group_id: String,
     sink: StreamSink<MessageStreamItem>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let group_id_str = group_id.clone();
     let group_id = group_id_from_string(&group_id)?;
 

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,10 +1,11 @@
 // Re-export everything from the whitenoise crate
 use flutter_rust_bridge::frb;
 use std::path::Path;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
+use tokio::sync::OnceCell;
 pub use whitenoise::{AppSettings, Language, RelayType, ThemeMode, Whitenoise};
 
-static GLOBAL_WN: OnceLock<Arc<Whitenoise>> = OnceLock::new();
+static GLOBAL_WN: OnceCell<Arc<Whitenoise>> = OnceCell::const_new();
 
 pub(crate) fn wn() -> Result<&'static Whitenoise, error::ApiError> {
     GLOBAL_WN
@@ -126,18 +127,18 @@ pub use zapstore::*;
 
 #[frb]
 pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<(), ApiError> {
-    if GLOBAL_WN.get().is_some() {
-        return Ok(());
-    }
     let core_config = whitenoise::WhitenoiseConfig::new(
         Path::new(&config.data_dir),
         Path::new(&config.logs_dir),
         "com.whitenoise.app",
     );
-    let arc = Whitenoise::ensure_initialized(core_config)
-        .await
-        .map_err(ApiError::from)?;
-    let _ = GLOBAL_WN.set(arc);
+    GLOBAL_WN
+        .get_or_try_init(|| async {
+            Whitenoise::ensure_initialized(core_config)
+                .await
+                .map_err(ApiError::from)
+        })
+        .await?;
     Ok(())
 }
 

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -126,6 +126,9 @@ pub use zapstore::*;
 
 #[frb]
 pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<(), ApiError> {
+    if GLOBAL_WN.get().is_some() {
+        return Ok(());
+    }
     let core_config = whitenoise::WhitenoiseConfig::new(
         Path::new(&config.data_dir),
         Path::new(&config.logs_dir),

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1,7 +1,29 @@
 // Re-export everything from the whitenoise crate
 use flutter_rust_bridge::frb;
 use std::path::Path;
+use std::sync::{Arc, OnceLock};
 pub use whitenoise::{AppSettings, Language, RelayType, ThemeMode, Whitenoise};
+
+static GLOBAL_WN: OnceLock<Arc<Whitenoise>> = OnceLock::new();
+
+pub(crate) fn wn() -> Result<&'static Whitenoise, error::ApiError> {
+    GLOBAL_WN
+        .get()
+        .map(|arc| arc.as_ref())
+        .ok_or_else(|| error::ApiError::Whitenoise {
+            message: "Whitenoise not initialized".to_string(),
+        })
+}
+
+pub(crate) fn wn_session(
+    pubkey: &nostr_sdk::PublicKey,
+) -> Result<Arc<whitenoise::whitenoise::session::AccountSession>, error::ApiError> {
+    wn()?
+        .session(pubkey)
+        .ok_or_else(|| error::ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })
+}
 
 // Re-export types that flutter_rust_bridge needs
 pub use nostr_sdk::{Event, PublicKey, RelayUrl, Tag};
@@ -109,26 +131,28 @@ pub async fn initialize_whitenoise(config: WhitenoiseConfig) -> Result<(), ApiEr
         Path::new(&config.logs_dir),
         "com.whitenoise.app",
     );
-    Whitenoise::initialize_whitenoise(core_config)
+    let arc = Whitenoise::ensure_initialized(core_config)
         .await
-        .map_err(ApiError::from)
+        .map_err(ApiError::from)?;
+    let _ = GLOBAL_WN.set(arc);
+    Ok(())
 }
 
 #[frb]
 pub async fn delete_all_data() -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise.delete_all_data().await.map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn get_app_settings() -> Result<AppSettings, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise.app_settings().await.map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn update_theme_mode(theme_mode: ThemeMode) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise
         .update_theme_mode(theme_mode)
         .await
@@ -142,7 +166,7 @@ pub fn app_settings_theme_mode(app_settings: &AppSettings) -> ThemeMode {
 
 #[frb]
 pub async fn update_language(language: Language) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise
         .update_language(language)
         .await

--- a/rust/src/api/mute_list.rs
+++ b/rust/src/api/mute_list.rs
@@ -1,7 +1,8 @@
+use crate::api::wn_session;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::PublicKey;
-use whitenoise::{MuteListEntry as WhitenoiseEntry, Whitenoise};
+use whitenoise::MuteListEntry as WhitenoiseEntry;
 
 use crate::api::ApiError;
 
@@ -14,10 +15,10 @@ pub struct MuteListEntry {
     pub created_at: DateTime<Utc>,
 }
 
-impl From<WhitenoiseEntry> for MuteListEntry {
-    fn from(e: WhitenoiseEntry) -> Self {
+impl MuteListEntry {
+    fn from_entry(account_pubkey: &PublicKey, e: WhitenoiseEntry) -> Self {
         Self {
-            account_pubkey: e.account_pubkey.to_hex(),
+            account_pubkey: account_pubkey.to_hex(),
             muted_pubkey: e.muted_pubkey.to_hex(),
             is_private: e.is_private,
             created_at: e.created_at,
@@ -27,35 +28,37 @@ impl From<WhitenoiseEntry> for MuteListEntry {
 
 #[frb]
 pub async fn block_user(account_pubkey: String, target_pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let account_pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&account_pubkey).await?;
+    let session = wn_session(&account_pubkey)?;
     let target = PublicKey::parse(&target_pubkey)?;
-    whitenoise
-        .block_user(&account, &target)
+    session
+        .mute_list()
+        .block_user(&target)
         .await
         .map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn unblock_user(account_pubkey: String, target_pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let account_pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&account_pubkey).await?;
+    let session = wn_session(&account_pubkey)?;
     let target = PublicKey::parse(&target_pubkey)?;
-    whitenoise
-        .unblock_user(&account, &target)
+    session
+        .mute_list()
+        .unblock_user(&target)
         .await
         .map_err(ApiError::from)
 }
 
 #[frb]
 pub async fn get_blocked_users(account_pubkey: String) -> Result<Vec<MuteListEntry>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let account_pubkey = PublicKey::parse(&account_pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&account_pubkey).await?;
-    let entries = whitenoise.get_blocked_users(&account).await?;
-    Ok(entries.into_iter().map(|e| e.into()).collect())
+    let session = wn_session(&account_pubkey)?;
+    let entries = session.mute_list().get_blocked_users().await?;
+    Ok(entries
+        .into_iter()
+        .map(|e| MuteListEntry::from_entry(&account_pubkey, e))
+        .collect())
 }
 
 #[frb]
@@ -63,11 +66,12 @@ pub async fn is_user_blocked(
     account_pubkey: String,
     target_pubkey: String,
 ) -> Result<bool, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let account_pubkey = PublicKey::parse(&account_pubkey)?;
+    let session = wn_session(&account_pubkey)?;
     let target = PublicKey::parse(&target_pubkey)?;
-    whitenoise
-        .is_user_blocked(&account_pubkey, &target)
+    session
+        .mute_list()
+        .is_user_blocked(&target)
         .await
         .map_err(ApiError::from)
 }

--- a/rust/src/api/mute_list.rs
+++ b/rust/src/api/mute_list.rs
@@ -85,23 +85,19 @@ mod tests {
 
     #[test]
     fn test_mute_list_entry_conversion() {
-        let account_keys = Keys::generate();
+        let account_pubkey = Keys::generate().public_key();
         let muted_keys = Keys::generate();
         let now = Utc::now();
 
         let entry = WhitenoiseEntry {
-            account_pubkey: account_keys.public_key(),
             muted_pubkey: muted_keys.public_key(),
             is_private: true,
             created_at: now,
         };
 
-        let flutter_entry: MuteListEntry = entry.into();
+        let flutter_entry = MuteListEntry::from_entry(&account_pubkey, entry);
 
-        assert_eq!(
-            flutter_entry.account_pubkey,
-            account_keys.public_key().to_hex()
-        );
+        assert_eq!(flutter_entry.account_pubkey, account_pubkey.to_hex());
         assert_eq!(flutter_entry.muted_pubkey, muted_keys.public_key().to_hex());
         assert!(flutter_entry.is_private);
         assert_eq!(flutter_entry.created_at, now);
@@ -109,17 +105,16 @@ mod tests {
 
     #[test]
     fn test_mute_list_entry_conversion_public() {
-        let account_keys = Keys::generate();
+        let account_pubkey = Keys::generate().public_key();
         let muted_keys = Keys::generate();
 
         let entry = WhitenoiseEntry {
-            account_pubkey: account_keys.public_key(),
             muted_pubkey: muted_keys.public_key(),
             is_private: false,
             created_at: Utc::now(),
         };
 
-        let flutter_entry: MuteListEntry = entry.into();
+        let flutter_entry = MuteListEntry::from_entry(&account_pubkey, entry);
         assert!(!flutter_entry.is_private);
     }
 }

--- a/rust/src/api/notifications.rs
+++ b/rust/src/api/notifications.rs
@@ -1,10 +1,10 @@
 use crate::api::error::ApiError;
 use crate::api::utils::group_id_to_string;
+use crate::api::{wn, wn_session};
 use crate::frb_generated::StreamSink;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::{PublicKey, RelayUrl};
-use whitenoise::Whitenoise;
 use whitenoise::whitenoise::notification_streaming::{
     NotificationTrigger as WhitenoiseNotificationTrigger,
     NotificationUpdate as WhitenoiseNotificationUpdate,
@@ -80,7 +80,7 @@ impl From<WhitenoiseNotificationUpdate> for NotificationUpdate {
 pub async fn subscribe_to_notifications(
     sink: StreamSink<NotificationUpdate>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let subscription = whitenoise.subscribe_to_notifications();
     let mut rx = subscription.updates;
 
@@ -159,10 +159,9 @@ impl From<WhitenoisePushRegistration> for PushRegistration {
 
 #[frb]
 pub async fn get_push_registration(pubkey: String) -> Result<Option<PushRegistration>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    let registration = whitenoise.push_registration(&account).await?;
+    let session = wn_session(&pubkey)?;
+    let registration = session.push().registration().await?;
     Ok(registration.map(PushRegistration::from))
 }
 
@@ -174,33 +173,36 @@ pub async fn upsert_push_registration(
     server_pubkey: String,
     relay_hint: Option<String>,
 ) -> Result<PushRegistration, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
     let server_pk = PublicKey::parse(&server_pubkey)?;
     let relay = relay_hint
         .as_deref()
         .map(RelayUrl::parse)
         .transpose()
         .map_err(ApiError::from)?;
-    let registration = whitenoise
-        .upsert_push_registration(
-            &account,
-            platform.into(),
-            &raw_token,
-            &server_pk,
-            relay.as_ref(),
-        )
+    let session = whitenoise
+        .session(&pubkey)
+        .ok_or_else(|| ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })?;
+    let registration = session
+        .push()
+        .upsert_registration(platform.into(), &raw_token, &server_pk, relay.as_ref())
         .await?;
     Ok(registration.into())
 }
 
 #[frb]
 pub async fn clear_push_registration(pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let account = whitenoise.find_account_by_pubkey(&pubkey).await?;
-    whitenoise.clear_push_registration(&account).await?;
+    let session = whitenoise
+        .session(&pubkey)
+        .ok_or_else(|| ApiError::Whitenoise {
+            message: "Account session not found".to_string(),
+        })?;
+    session.push().clear_registration().await?;
     Ok(())
 }
 

--- a/rust/src/api/notifications.rs
+++ b/rust/src/api/notifications.rs
@@ -173,7 +173,6 @@ pub async fn upsert_push_registration(
     server_pubkey: String,
     relay_hint: Option<String>,
 ) -> Result<PushRegistration, ApiError> {
-    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let server_pk = PublicKey::parse(&server_pubkey)?;
     let relay = relay_hint
@@ -181,11 +180,7 @@ pub async fn upsert_push_registration(
         .map(RelayUrl::parse)
         .transpose()
         .map_err(ApiError::from)?;
-    let session = whitenoise
-        .session(&pubkey)
-        .ok_or_else(|| ApiError::Whitenoise {
-            message: "Account session not found".to_string(),
-        })?;
+    let session = wn_session(&pubkey)?;
     let registration = session
         .push()
         .upsert_registration(platform.into(), &raw_token, &server_pk, relay.as_ref())
@@ -195,13 +190,8 @@ pub async fn upsert_push_registration(
 
 #[frb]
 pub async fn clear_push_registration(pubkey: String) -> Result<(), ApiError> {
-    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
-    let session = whitenoise
-        .session(&pubkey)
-        .ok_or_else(|| ApiError::Whitenoise {
-            message: "Account session not found".to_string(),
-        })?;
+    let session = wn_session(&pubkey)?;
     session.push().clear_registration().await?;
     Ok(())
 }

--- a/rust/src/api/relays.rs
+++ b/rust/src/api/relays.rs
@@ -1,8 +1,9 @@
 use crate::api::error::ApiError;
+use crate::api::wn;
 use chrono::{DateTime, Utc};
 use flutter_rust_bridge::frb;
 use nostr_sdk::prelude::*;
-use whitenoise::{Relay as WhitenoiseRelay, RelayType, Whitenoise};
+use whitenoise::{Relay as WhitenoiseRelay, RelayType};
 
 #[frb(non_opaque)]
 #[derive(Debug, Clone)]
@@ -39,7 +40,7 @@ pub fn relay_type_key_package() -> RelayType {
 
 #[frb]
 pub async fn debug_relay_control_state() -> Result<String, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise
         .debug_relay_control_state()
         .await
@@ -48,7 +49,7 @@ pub async fn debug_relay_control_state() -> Result<String, ApiError> {
 
 #[frb]
 pub async fn ensure_all_subscriptions() -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     whitenoise
         .ensure_all_subscriptions()
         .await

--- a/rust/src/api/signer.rs
+++ b/rust/src/api/signer.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 use crate::api::accounts::LoginResult;
 use crate::api::error::ApiError;
+use crate::api::wn;
 
 /// An external signer that delegates signing operations to Dart callbacks.
 ///
@@ -157,7 +158,7 @@ pub async fn register_external_signer(
     nip44_encrypt: impl Fn(String, String) -> DartFnFuture<String> + Send + Sync + 'static,
     nip44_decrypt: impl Fn(String, String) -> DartFnFuture<String> + Send + Sync + 'static,
 ) -> Result<(), ApiError> {
-    let whitenoise = whitenoise::Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
 
     let signer = DartSigner::new(
@@ -193,7 +194,7 @@ pub async fn login_external_signer_start(
     nip44_encrypt: impl Fn(String, String) -> DartFnFuture<String> + Send + Sync + 'static,
     nip44_decrypt: impl Fn(String, String) -> DartFnFuture<String> + Send + Sync + 'static,
 ) -> Result<LoginResult, ApiError> {
-    let whitenoise = whitenoise::Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
 
     let signer = DartSigner::new(
@@ -218,7 +219,7 @@ pub async fn login_external_signer_start(
 pub async fn login_external_signer_publish_default_relays(
     pubkey: String,
 ) -> Result<LoginResult, ApiError> {
-    let whitenoise = whitenoise::Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let result = whitenoise
         .login_external_signer_publish_default_relays(&pubkey)
@@ -234,7 +235,7 @@ pub async fn login_external_signer_with_custom_relay(
     pubkey: String,
     relay_url: String,
 ) -> Result<LoginResult, ApiError> {
-    let whitenoise = whitenoise::Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let relay_url = nostr_sdk::RelayUrl::parse(&relay_url)?;
     let result = whitenoise

--- a/rust/src/api/user_search.rs
+++ b/rust/src/api/user_search.rs
@@ -1,5 +1,6 @@
 use crate::api::error::ApiError;
 use crate::api::metadata::FlutterMetadata;
+use crate::api::wn;
 use crate::frb_generated::StreamSink;
 use flutter_rust_bridge::frb;
 use nostr_sdk::PublicKey;
@@ -7,7 +8,7 @@ use whitenoise::whitenoise::user_search::UserSearchParams;
 use whitenoise::{
     MatchQuality as WnMatchQuality, MatchedField as WnMatchedField,
     SearchUpdateTrigger as WnSearchUpdateTrigger, UserSearchResult as WnUserSearchResult,
-    UserSearchUpdate as WnUserSearchUpdate, Whitenoise,
+    UserSearchUpdate as WnUserSearchUpdate,
 };
 
 #[frb]
@@ -150,7 +151,7 @@ pub async fn search_users(
     radius_end: u8,
     sink: StreamSink<UserSearchUpdate>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&account_pubkey)?;
 
     let params = UserSearchParams {

--- a/rust/src/api/users.rs
+++ b/rust/src/api/users.rs
@@ -1,4 +1,5 @@
 use crate::api::relays::Relay;
+use crate::api::wn;
 use crate::api::{ApiError, metadata::FlutterMetadata};
 use crate::frb_generated::StreamSink;
 use chrono::{DateTime, Utc};
@@ -96,7 +97,7 @@ pub async fn subscribe_to_user(
     pubkey: String,
     sink: StreamSink<UserStreamItem>,
 ) -> Result<(), ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let subscription = whitenoise.subscribe_to_user(&pubkey).await?;
 
@@ -136,7 +137,7 @@ pub async fn subscribe_to_user(
 
 #[frb]
 pub async fn get_user(pubkey: String, blocking_data_sync: bool) -> Result<User, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     Ok(user.into())
@@ -147,7 +148,7 @@ pub async fn user_metadata(
     pubkey: String,
     blocking_data_sync: bool,
 ) -> Result<FlutterMetadata, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     Ok(user.metadata.into())
@@ -159,7 +160,7 @@ pub async fn user_relays(
     relay_type: RelayType,
     blocking_data_sync: bool,
 ) -> Result<Vec<Relay>, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
     let relays = user.relays_by_type(relay_type, &whitenoise).await?;
@@ -171,10 +172,10 @@ pub async fn user_has_key_package(
     pubkey: String,
     blocking_data_sync: bool,
 ) -> Result<KeyPackageStatus, ApiError> {
-    let whitenoise = Whitenoise::get_instance()?;
+    let whitenoise = wn()?;
     let pubkey = PublicKey::parse(&pubkey)?;
     let user = resolve_whitenoise_user(whitenoise, &pubkey, blocking_data_sync).await?;
-    match user.key_package_status(whitenoise).await? {
+    match user.key_package_status(&whitenoise.shared).await? {
         WhitenoiseKeyPackageStatus::Valid(_) => Ok(KeyPackageStatus::Valid),
         WhitenoiseKeyPackageStatus::NotFound => Ok(KeyPackageStatus::NotFound),
         WhitenoiseKeyPackageStatus::Incompatible => Ok(KeyPackageStatus::Incompatible),


### PR DESCRIPTION
![marmot](https://blossom.primal.net/78dc0ac6367f959479dea509953a057bf83f10b1d64cbb0307e7f2dd507e5a91.jpg)

## What changed

`whitenoise-rs` is now pinned to the `arch-refactor` branch (sha `eefe3fe9...`). That branch removed `Whitenoise::get_instance()` and split the god object into one `AccountSession` per account.

## Shim layer

`rust/src/api/mod.rs` holds a private `tokio::sync::OnceCell<Arc<Whitenoise>>` populated by `initialize_whitenoise`. Two helpers:

- `wn() -> &'static Whitenoise` for the few global calls that remain (login, all-accounts, app settings).
- `wn_session(&pubkey) -> Arc<AccountSession>` for everything else.

Init goes through `OnceCell::get_or_try_init`, so two concurrent `initialize_whitenoise` calls share one underlying `Whitenoise::ensure_initialized` run.

## Call-site migration

About 95 sites in `rust/src/api/` moved off the deleted facades onto `session.<ops>()`:

- `session.membership().for_group(&gid)` for accept / decline / archive / unarchive / mute / unmute / pin / mark-read / clear-chat.
- `session.groups()` for visible / by-id / members / admins / create / add-members / remove-members / leave / update-data.
- `session.groups().media()` for upload / download / image-path.
- `session.drafts()`, `session.chat_list()`, `session.mute_list()`, `session.social()`, `session.key_packages()`, `session.push()`, `session.settings()`.

`get_chat_summary` now searches both active and archived chat lists so archived chats render correctly (master commit 8135cbe's intent, under the new API).

## Other adjustments

- `MuteListEntry.account_pubkey` is gone upstream; the shim now passes the pubkey through `MuteListEntry::from_entry`.
- `account.relays(...)` and `user.key_package_*(...)` now take `&Arc<SharedServices>`; the shim passes `&whitenoise.shared`.
- `AccountGroup::get` is gone; the shim uses `session.membership().for_group(&gid).get_or_create(None)`.
- The new `subscribe_to_group_state` from master switched from `Whitenoise::get_instance()` to `wn()`.

## Status

Bridge regenerated. `just precommit` is green. The colony of marmots can stop fetching from the one big burrow and head to their own.

---

Built against `whitenoise-rs` arch-refactor sha `eefe3fe927b53c9c890c2ac1bbc19b269fb41382`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated whitenoise dependency to a newer revision.

* **Refactor**
  * Centralized client initialization via internal helpers.
  * Migration to per-account/session-backed handling for media, chats, groups, accounts, notifications, relays, drafts, mute lists, messages, and related APIs to improve reliability and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/649)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->