### PR TITLE
Fix QR scanner not showing camera on first attempt after giving permission 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to Calendar Versioning (CalVer).
 ### Removed
 
 ### Fixed
+- Fixed QR scanner not showing camera on first attempt after giving permission [PR #654](https://github.com/marmot-protocol/whitenoise/pull/654)
 
 ### Security
 

--- a/lib/widgets/qr_scanner.dart
+++ b/lib/widgets/qr_scanner.dart
@@ -80,7 +80,7 @@ class QrScanner extends HookWidget {
     final isProcessing = useState(false);
     final scannerRetryKey = useState(UniqueKey());
     final isMounted = useRef(true);
-    final boxState = useState(ScannerState.loading);
+    final scannerState = useState(ScannerState.loading);
     final lastDeniedStatus = useRef<PermissionStatus?>(null);
 
     useEffect(() {
@@ -95,12 +95,12 @@ class QrScanner extends HookWidget {
 
         if (status.isGranted || status.isLimited) {
           lastDeniedStatus.value = null;
-          boxState.value = ScannerState.ready;
+          scannerState.value = ScannerState.ready;
         } else {
           final currentStatus = await checkCameraPermissionStatus();
           if (!isMounted.value) return;
           lastDeniedStatus.value = currentStatus;
-          boxState.value = ScannerState.permissionDenied;
+          scannerState.value = ScannerState.permissionDenied;
         }
       }
 
@@ -114,7 +114,7 @@ class QrScanner extends HookWidget {
     );
 
     useEffect(() {
-      if (boxState.value != ScannerState.ready) return null;
+      if (scannerState.value != ScannerState.ready) return null;
 
       var started = false;
 
@@ -144,33 +144,34 @@ class QrScanner extends HookWidget {
         unawaited(subscription.cancel());
         controller.dispose();
       };
-    }, [controller, boxState.value]);
+    }, [controller, scannerState.value]);
 
     void retryScanner() {
-      boxState.value = ScannerState.loading;
+      scannerState.value = ScannerState.loading;
       scannerRetryKey.value = UniqueKey();
     }
 
     useOnAppLifecycleStateChange((previous, current) {
       if (current != AppLifecycleState.resumed || !isMounted.value) return;
-      if (boxState.value == ScannerState.permissionDenied) {
+      if (scannerState.value == ScannerState.permissionDenied) {
         unawaited(() async {
-          final status = await checkCameraPermissionStatus();
+          final cameraPermissionStatus = await checkCameraPermissionStatus();
           if (!isMounted.value) return;
           final snapshotWasDenied =
               lastDeniedStatus.value != null &&
               !(lastDeniedStatus.value!.isGranted || lastDeniedStatus.value!.isLimited);
-          if (snapshotWasDenied && (status.isGranted || status.isLimited)) {
+          if (snapshotWasDenied &&
+              (cameraPermissionStatus.isGranted || cameraPermissionStatus.isLimited)) {
             retryScanner();
           }
         }());
-      } else if (boxState.value == ScannerState.ready) {
+      } else {
         retryScanner();
       }
     });
 
-    final showScanner = boxState.value == ScannerState.ready;
-    final isError = boxState.value != ScannerState.loading && !showScanner;
+    final showScanner = scannerState.value == ScannerState.ready;
+    final isError = scannerState.value != ScannerState.loading && !showScanner;
 
     return Container(
       key: const Key('qr_scanner'),
@@ -194,7 +195,7 @@ class QrScanner extends HookWidget {
                   };
                   Future.microtask(() {
                     if (isMounted.value) {
-                      boxState.value = newState;
+                      scannerState.value = newState;
                     }
                   });
                   return _ScannerNotice(
@@ -205,7 +206,7 @@ class QrScanner extends HookWidget {
               )
             : isError
             ? _ScannerNotice(
-                scannerState: boxState.value,
+                scannerState: scannerState.value,
                 onRetry: retryScanner,
               )
             : _ScannerPlaceholder(colors: colors),

--- a/test/widgets/qr_scanner_test.dart
+++ b/test/widgets/qr_scanner_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui' show AppLifecycleState;
 
 import 'package:flutter/material.dart' show Key, SizedBox;
@@ -288,7 +289,7 @@ void main() {
     });
 
     group('lifecycle', () {
-      testWidgets('recreates scanner on resume', (tester) async {
+      testWidgets('recreates scanner controller on resume', (tester) async {
         setPermissionStatusChecker(() async => PermissionStatus.granted);
 
         await mountWidget(
@@ -297,17 +298,45 @@ void main() {
         );
         await tester.pump();
 
-        final scanner = tester.widget<MobileScanner>(find.byType(MobileScanner));
-        final initialKey = scanner.key;
+        expect(mockController.startCallCount, 1);
+        expect(mockController.disposeCalled, isFalse);
 
         tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
         await tester.pump();
         await tester.pump();
         await tester.pump();
 
-        final newScanner = tester.widget<MobileScanner>(find.byType(MobileScanner));
-        expect(newScanner.key, isNot(equals(initialKey)));
+        expect(mockController.startCallCount, 2);
+        expect(mockController.disposeCalled, isTrue);
+        expect(find.byType(MobileScanner), findsOneWidget);
       });
+
+      testWidgets(
+        'recreates scanner controller after first-time permission grant when app resumes',
+        (tester) async {
+          final completer = Completer<PermissionStatus>();
+          setPermissionRequester(() => completer.future);
+
+          await mountWidget(QrScanner(onBarcodeDetected: (_) {}), tester);
+          await tester.pump();
+
+          expect(find.byKey(const Key('scanner_placeholder')), findsOneWidget);
+
+          completer.complete(PermissionStatus.granted);
+          await tester.pump();
+          await tester.pump();
+          expect(find.byType(MobileScanner), findsOneWidget);
+          expect(mockController.startCallCount, 1);
+
+          tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+          await tester.pump();
+          await tester.pump();
+
+          expect(mockController.startCallCount, 2);
+          expect(mockController.disposeCalled, isTrue);
+          expect(find.byType(MobileScanner), findsOneWidget);
+        },
+      );
 
       testWidgets('does not re-request permission on resume when denied', (tester) async {
         var requestCount = 0;
@@ -476,7 +505,7 @@ void main() {
         expect(mockController.startCallCount, 1);
       });
 
-      testWidgets('resets start guard on retry', (tester) async {
+      testWidgets('resets start guard on resume', (tester) async {
         setPermissionStatusChecker(() async => PermissionStatus.granted);
 
         await mountWidget(


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

On the first time granting camera permissions to the app, the camera didn't open. In that case the scanner state wasn't ready yet.  The quick fix is to remove that state condition condition and retry the scanner if the permission is not denied. I tried this in my phone and is seems to fix the issue without reintroducing the previous issue fixed by #620 for the denied case. 

I feel this scanner widget is too complex and I have a refactor in progress, but I feel this fix is enough in case we want to ship a release once the PR with the rust crate updated is merge. 

<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This

First case: givin permissions
- Deleted staging app
- Then run the app
- Signed up
- Go to the scanner to start a chat
- Give permission
- Check that the camera appears


Second case: denying permissions
- Deleted staging app
- Then run the app
- Signed up
- Go to the scanner to start a chat
- Deny permission
- Check that the warning to change permissions in settings appears

## Screenrecordings

**Now granting permissions** 


https://github.com/user-attachments/assets/e1b7a5d2-d8ed-4020-bad7-8b4dfc49af3c


**Now denying permissions**


https://github.com/user-attachments/assets/1d2bc7c9-5fa6-4d66-be69-4b3ed3d639a7



## Checklist

- [ ] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [x] `CHANGELOG.md` updated (if user-visible change)
- [x] Screenshots added (for UI changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR scanner permission and resume behavior so the camera reliably appears after granting permission and errors update scanner state for consistent startup.
  * Cleared start-guard on app resume so the scanner restarts correctly when returning to the app.

* **Tests**
  * Updated lifecycle and permission-handling tests to cover resume, retry, and permission-change scenarios.

* **Documentation**
  * Noted fix in CHANGELOG for camera display after permission grant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/654)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->