### PR TITLE
Fix ios build script after moving frb

### DIFF
--- a/scripts/build_ios.sh
+++ b/scripts/build_ios.sh
@@ -94,12 +94,6 @@ print_success "whitenoise-rs checked out at $WHITENOISE_RS_REV"
 
 WHITENOISE_FRB_DIR="$WHITENOISE_RS_CACHE/crates/whitenoise-frb"
 
-# Add iOS targets
-print_step "Adding iOS targets to Rust"
-rustup target add aarch64-apple-ios     # Physical devices (arm64)
-rustup target add aarch64-apple-ios-sim # Simulator on Apple Silicon
-print_success "iOS targets added to Rust"
-
 IOS_DEPLOYMENT_TARGET="${IOS_DEPLOYMENT_TARGET:-13.0}"
 export IPHONEOS_DEPLOYMENT_TARGET="$IOS_DEPLOYMENT_TARGET"
 print_step "Using iOS deployment target $IPHONEOS_DEPLOYMENT_TARGET"
@@ -107,6 +101,12 @@ print_step "Using iOS deployment target $IPHONEOS_DEPLOYMENT_TARGET"
 # Build for each iOS architecture
 print_step "Building for iOS architectures"
 cd "$WHITENOISE_FRB_DIR"
+
+
+print_step "Adding iOS targets to Rust"
+rustup target add aarch64-apple-ios 
+rustup target add aarch64-apple-ios-sim 
+print_success "iOS targets added to Rust"
 
 print_step "Building for aarch64-apple-ios (physical devices)"
 cargo build --target aarch64-apple-ios --release --quiet

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -1073,7 +1073,7 @@ packages:
     dependency: transitive
     description:
       path: "."
-      ref: "91c492b0fad5c04499ea54d5bfd92090635bc047"
+      ref: flutter-package
       resolved-ref: "91c492b0fad5c04499ea54d5bfd92090635bc047"
       url: "https://github.com/marmot-protocol/whitenoise-rs"
     source: git


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
THis change in order of build ios script makes it ios build succeed 

⚠️  Only `just build-ios`, flutter run commands are still failing on my iphone

<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This

<!-- Describe what you ran or manually verified and include device/OS/simulator details. -->

## Screenshots

<!-- Required for UI changes. Drag images here. Delete this section if UI is not affected -->

| Before | After |
|---|---|
| | |

## Checklist

- [ ] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [ ] `CHANGELOG.md` updated (if user-visible change)
- [ ] Screenshots added (for UI changes)
