### PR TITLE
Fix show author name in last message of pending invites in chat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to Calendar Versioning (CalVer).
 
 ### Fixed
 - Fixed QR scanner not showing camera on first attempt after giving permission [PR #654](https://github.com/marmot-protocol/whitenoise/pull/654)
+- Fix show author name in last message of pending invites in chat list [PR #668](https://github.com/marmot-protocol/whitenoise/pull/668)
 
 ### Security
 

--- a/lib/widgets/chat_list_tile.dart
+++ b/lib/widgets/chat_list_tile.dart
@@ -139,7 +139,7 @@ _TileDisplay _buildTileDisplay({
   }
 
   String? prefixSubtitle;
-  if (!isPending && !chatSummary.selfRemoved && chatSummary.lastMessage != null) {
+  if (!chatSummary.selfRemoved && chatSummary.lastMessage != null) {
     if (chatSummary.lastMessage!.author == myPubkey) {
       prefixSubtitle = '${context.l10n.you}: ';
     } else if (!isDm) {

--- a/test/widgets/chat_list_tile_test.dart
+++ b/test/widgets/chat_list_tile_test.dart
@@ -408,6 +408,37 @@ void main() {
             expect(item.subtitle, 'Look at this');
             expect(item.subtitleIcon, isNull);
           });
+
+          testWidgets('shows "You: " prefix for own message in pending group', (tester) async {
+            await pumpTile(
+              tester,
+              _chatSummary(
+                pendingConfirmation: true,
+                lastMessageContent: 'My message',
+                lastMessageAuthor: testPubkeyA,
+              ),
+            );
+            final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+            expect(item.prefixSubtitle, 'You: ');
+            expect(item.subtitle, 'My message');
+          });
+
+          testWidgets("shows author name prefix for other's message in pending group", (
+            tester,
+          ) async {
+            await pumpTile(
+              tester,
+              _chatSummary(
+                pendingConfirmation: true,
+                lastMessageContent: 'Hello group',
+                lastMessageAuthor: testPubkeyB,
+                lastMessageAuthorDisplayName: 'Alice',
+              ),
+            );
+            final item = tester.widget<WnChatListItem>(find.byType(WnChatListItem));
+            expect(item.prefixSubtitle, 'Alice: ');
+            expect(item.subtitle, 'Hello group');
+          });
         });
       });
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

I found this tiny bug on chat list tile: before accepted, the prefix of the last message author didn't appear. Once accepted, it was shown correctly. 


## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This

- Signed up in a same device with 2 accounts (A and B)
- From B, sent a group chat invite and a a message to A
- Switched to A
- Checked in chat list that I saw B's name as prefix in the last message preview.

<!-- Describe what you ran or manually verified and include device/OS/simulator details. -->

## Screenshots

<!-- Required for UI changes. Drag images here. Delete this section if UI is not affected -->

| Before | After |
|---|---|
| <img width="250"  alt="before" src="https://github.com/user-attachments/assets/f3d01fc6-dc70-4ef4-9f34-31eb8cff47ef" />|<img width="250"  alt="after" src="https://github.com/user-attachments/assets/a823fc43-233c-488e-bd79-0a7116a21e88" />|

## Checklist

- [ ] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [ ] `CHANGELOG.md` updated (if user-visible change)
- [ ] Screenshots added (for UI changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display of author names in pending group chat invitations—the last message preview now shows who authored the message (e.g., "You:" for your messages or the author's name for others' messages).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/668?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->