### PR TITLE
fix: route user-tag taps to the group member screen for members

### DIFF
--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -207,6 +207,10 @@ class ChatScreen extends HookConsumerWidget {
       },
       [mentionMembers],
     );
+    final groupMemberPubkeySet = useMemoized(
+      () => mentionMemberPubkeys.toSet(),
+      [mentionMemberPubkeyKey],
+    );
     String? resolveMentionDisplayName(String hexPubkey) =>
         mentionNamesByPubkey[hexPubkey] ?? presentName(getAuthorMetadata(hexPubkey));
     final resolveMentionDisplayNameRef = useRef(resolveMentionDisplayName);
@@ -547,6 +551,8 @@ class ChatScreen extends HookConsumerWidget {
                   : null,
               onHorizontalDragEnd: isSearchMode ? null : () => input.setReplyingTo(message),
               mentionDisplayName: resolveMentionDisplayName,
+              groupId: groupId,
+              groupMemberPubkeys: isGroupChat ? groupMemberPubkeySet : null,
               onRetry:
                   !isSearchMode && isOwnMessage && message.deliveryStatus is DeliveryStatus_Failed
                   ? () async {

--- a/lib/screens/chat_screen.dart
+++ b/lib/screens/chat_screen.dart
@@ -207,10 +207,6 @@ class ChatScreen extends HookConsumerWidget {
       },
       [mentionMembers],
     );
-    final groupMemberPubkeySet = useMemoized(
-      () => mentionMemberPubkeys.toSet(),
-      [mentionMemberPubkeyKey],
-    );
     String? resolveMentionDisplayName(String hexPubkey) =>
         mentionNamesByPubkey[hexPubkey] ?? presentName(getAuthorMetadata(hexPubkey));
     final resolveMentionDisplayNameRef = useRef(resolveMentionDisplayName);
@@ -551,8 +547,7 @@ class ChatScreen extends HookConsumerWidget {
                   : null,
               onHorizontalDragEnd: isSearchMode ? null : () => input.setReplyingTo(message),
               mentionDisplayName: resolveMentionDisplayName,
-              groupId: groupId,
-              groupMemberPubkeys: isGroupChat ? groupMemberPubkeySet : null,
+              groupId: isGroupChat ? groupId : null,
               onRetry:
                   !isSearchMode && isOwnMessage && message.deliveryStatus is DeliveryStatus_Failed
                   ? () async {

--- a/lib/screens/group_member_screen.dart
+++ b/lib/screens/group_member_screen.dart
@@ -95,11 +95,10 @@ class GroupMemberScreen extends HookConsumerWidget {
       if (membersState.members.contains(memberPubkey)) return null;
       didRedirect.value = true;
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        final nav = Routes.navigatorKey.currentContext;
-        if (nav == null || !nav.mounted) return;
-        Routes.goBack(nav);
-        if (!nav.mounted) return;
-        StartChatScreen.show(nav, userPubkey: memberPubkey);
+        if (!context.mounted) return;
+        Routes.goBack(context);
+        if (!context.mounted) return;
+        StartChatScreen.show(context, userPubkey: memberPubkey);
       });
       return null;
     }, [membersState.isLoading, membersState.members]);

--- a/lib/screens/group_member_screen.dart
+++ b/lib/screens/group_member_screen.dart
@@ -12,6 +12,7 @@ import 'package:whitenoise/hooks/use_user_metadata.dart';
 import 'package:whitenoise/l10n/l10n.dart';
 import 'package:whitenoise/providers/account_pubkey_provider.dart';
 import 'package:whitenoise/routes.dart';
+import 'package:whitenoise/screens/start_chat_screen.dart';
 import 'package:whitenoise/theme.dart';
 import 'package:whitenoise/utils/avatar_color.dart';
 import 'package:whitenoise/utils/metadata.dart' show presentName;
@@ -86,6 +87,22 @@ class GroupMemberScreen extends HookConsumerWidget {
       }
       return null;
     }, [membersState.error]);
+
+    final didRedirect = useRef(false);
+    useEffect(() {
+      if (didRedirect.value) return null;
+      if (membersState.isLoading || membersState.error != null) return null;
+      if (membersState.members.contains(memberPubkey)) return null;
+      didRedirect.value = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        final nav = Routes.navigatorKey.currentContext;
+        if (nav == null || !nav.mounted) return;
+        Routes.goBack(nav);
+        if (!nav.mounted) return;
+        StartChatScreen.show(nav, userPubkey: memberPubkey);
+      });
+      return null;
+    }, [membersState.isLoading, membersState.members]);
 
     final isCurrentUserAdmin = membersState.admins.contains(accountPubkey);
     final isMemberAdmin = membersState.admins.contains(memberPubkey);

--- a/lib/screens/start_chat_screen.dart
+++ b/lib/screens/start_chat_screen.dart
@@ -191,8 +191,8 @@ class StartChatScreen extends HookConsumerWidget {
         child: SafeArea(
           child: Column(
             children: [
-              const Spacer(),
               WnSlate(
+                shrinkWrapContent: true,
                 header: WnSlateNavigationHeader(
                   title: context.l10n.startNewChat,
                   onNavigate: () => Routes.goBack(context),

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -3,6 +3,7 @@ import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:whitenoise/hooks/use_chat_messages.dart' show ChatMessageQuoteData;
 import 'package:whitenoise/l10n/l10n.dart';
+import 'package:whitenoise/routes.dart';
 import 'package:whitenoise/screens/start_chat_screen.dart';
 import 'package:whitenoise/src/rust/api/markdown.dart';
 import 'package:whitenoise/src/rust/api/messages.dart';
@@ -38,6 +39,8 @@ class ChatMessageBubble extends StatelessWidget {
   final VoidCallback? onHorizontalDragEnd;
   final VoidCallback? onRetry;
   final String? Function(String hexPubkey)? mentionDisplayName;
+  final String? groupId;
+  final Set<String>? groupMemberPubkeys;
 
   const ChatMessageBubble({
     super.key,
@@ -60,6 +63,8 @@ class ChatMessageBubble extends StatelessWidget {
     this.onHorizontalDragEnd,
     this.onRetry,
     this.mentionDisplayName,
+    this.groupId,
+    this.groupMemberPubkeys,
   });
 
   ChatStatusType? get _deliveryStatusType {
@@ -161,7 +166,11 @@ class ChatMessageBubble extends StatelessWidget {
       onNostrTap: (hrp, bech32) async {
         if (hrp == MarkdownNostrHrp.npub) {
           final hex = hexFromNpub(bech32);
-          if (hex != null && context.mounted) {
+          if (hex == null || !context.mounted) return;
+          final gid = groupId;
+          if (gid != null && (groupMemberPubkeys?.contains(hex) ?? false)) {
+            Routes.pushToGroupMember(context, gid, hex);
+          } else {
             await StartChatScreen.show(context, userPubkey: hex);
           }
           return;

--- a/lib/widgets/chat_message_bubble.dart
+++ b/lib/widgets/chat_message_bubble.dart
@@ -40,7 +40,6 @@ class ChatMessageBubble extends StatelessWidget {
   final VoidCallback? onRetry;
   final String? Function(String hexPubkey)? mentionDisplayName;
   final String? groupId;
-  final Set<String>? groupMemberPubkeys;
 
   const ChatMessageBubble({
     super.key,
@@ -64,7 +63,6 @@ class ChatMessageBubble extends StatelessWidget {
     this.onRetry,
     this.mentionDisplayName,
     this.groupId,
-    this.groupMemberPubkeys,
   });
 
   ChatStatusType? get _deliveryStatusType {
@@ -168,7 +166,7 @@ class ChatMessageBubble extends StatelessWidget {
           final hex = hexFromNpub(bech32);
           if (hex == null || !context.mounted) return;
           final gid = groupId;
-          if (gid != null && (groupMemberPubkeys?.contains(hex) ?? false)) {
+          if (gid != null) {
             Routes.pushToGroupMember(context, gid, hex);
           } else {
             await StartChatScreen.show(context, userPubkey: hex);

--- a/test/screens/group_member_screen_test.dart
+++ b/test/screens/group_member_screen_test.dart
@@ -5,6 +5,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart' show AsyncData;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:whitenoise/providers/auth_provider.dart';
 import 'package:whitenoise/routes.dart';
+import 'package:whitenoise/screens/group_member_screen.dart';
+import 'package:whitenoise/screens/start_chat_screen.dart';
 import 'package:whitenoise/src/rust/api/groups.dart';
 import 'package:whitenoise/src/rust/api/metadata.dart';
 import 'package:whitenoise/src/rust/frb_generated.dart';
@@ -724,6 +726,28 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('Add to group'), findsWidgets);
+      });
+    });
+
+    group('non-member redirect', () {
+      testWidgets('redirects to StartChatScreen when the user is not in the group', (
+        tester,
+      ) async {
+        _api.adminsList = [_testPubkey];
+        await pumpGroupMemberScreen(tester, memberPubkey: testPubkeyD);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(GroupMemberScreen), findsNothing);
+        expect(find.byType(StartChatScreen), findsOneWidget);
+      });
+
+      testWidgets('does not redirect when the user is a member', (tester) async {
+        _api.adminsList = [_testPubkey];
+        await pumpGroupMemberScreen(tester, memberPubkey: _memberPubkey);
+        await tester.pumpAndSettle();
+
+        expect(find.byType(GroupMemberScreen), findsOneWidget);
+        expect(find.byType(StartChatScreen), findsNothing);
       });
     });
   });

--- a/test/widgets/chat_message_bubble_test.dart
+++ b/test/widgets/chat_message_bubble_test.dart
@@ -919,6 +919,82 @@ void main() {
         );
       });
 
+      testWidgets('npub mention of group member navigates to group member screen', (tester) async {
+        await _mountBubbleWithRouter(
+          tester,
+          ChatMessageBubble(
+            message: withDoc(
+              const MarkdownDocument(
+                blocks: [
+                  MarkdownBlock.paragraph(
+                    inlines: [
+                      MarkdownInline.nostrMention(
+                        entity: MarkdownNostrEntity(
+                          hrp: MarkdownNostrHrp.npub,
+                          bech32: testNpubA,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            isOwnMessage: false,
+            groupId: testGroupId,
+            groupMemberPubkeys: const {testPubkeyA},
+          ),
+        );
+        final span = tester.widget<RichText>(find.byType(RichText).first).text as TextSpan;
+        final entity = _firstTextSpanWithRecognizer(span);
+        (entity.recognizer as TapGestureRecognizer).onTap!();
+        await tester.pumpAndSettle();
+        expect(launcher.calls, isEmpty);
+        expect(find.byType(StartChatScreen), findsNothing);
+        expect(
+          find.byKey(const ValueKey('group_member_route_${testGroupId}_$testPubkeyA')),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('npub mention of non-member in group opens StartChatScreen', (tester) async {
+        await _mountBubbleWithRouter(
+          tester,
+          ChatMessageBubble(
+            message: withDoc(
+              const MarkdownDocument(
+                blocks: [
+                  MarkdownBlock.paragraph(
+                    inlines: [
+                      MarkdownInline.nostrMention(
+                        entity: MarkdownNostrEntity(
+                          hrp: MarkdownNostrHrp.npub,
+                          bech32: testNpubA,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            isOwnMessage: false,
+            groupId: testGroupId,
+            groupMemberPubkeys: const {testPubkeyB},
+          ),
+        );
+        final span = tester.widget<RichText>(find.byType(RichText).first).text as TextSpan;
+        final entity = _firstTextSpanWithRecognizer(span);
+        (entity.recognizer as TapGestureRecognizer).onTap!();
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 50));
+        tester.takeException();
+        expect(launcher.calls, isEmpty);
+        expect(
+          find.byKey(const ValueKey('group_member_route_${testGroupId}_$testPubkeyA')),
+          findsNothing,
+        );
+        expect(find.byType(StartChatScreen), findsOneWidget);
+      });
+
       testWidgets('whitenoise://chat/<id> tap navigates via GoRouter', (tester) async {
         await _mountBubbleWithRouter(
           tester,
@@ -1072,6 +1148,16 @@ Future<void> _mountBubbleWithRouter(WidgetTester tester, Widget bubble) async {
         path: '/start-chat/:pubkey',
         builder: (_, state) => Scaffold(
           key: ValueKey('user_route_${state.pathParameters['pubkey']}'),
+          body: const SizedBox(),
+        ),
+      ),
+      GoRoute(
+        name: 'groupMember',
+        path: '/group-member/:groupId/:memberPubkey',
+        builder: (_, state) => Scaffold(
+          key: ValueKey(
+            'group_member_route_${state.pathParameters['groupId']}_${state.pathParameters['memberPubkey']}',
+          ),
           body: const SizedBox(),
         ),
       ),

--- a/test/widgets/chat_message_bubble_test.dart
+++ b/test/widgets/chat_message_bubble_test.dart
@@ -919,7 +919,7 @@ void main() {
         );
       });
 
-      testWidgets('npub mention of group member navigates to group member screen', (tester) async {
+      testWidgets('npub mention in a group navigates to the group member screen', (tester) async {
         await _mountBubbleWithRouter(
           tester,
           ChatMessageBubble(
@@ -941,7 +941,6 @@ void main() {
             ),
             isOwnMessage: false,
             groupId: testGroupId,
-            groupMemberPubkeys: const {testPubkeyA},
           ),
         );
         final span = tester.widget<RichText>(find.byType(RichText).first).text as TextSpan;
@@ -954,45 +953,6 @@ void main() {
           find.byKey(const ValueKey('group_member_route_${testGroupId}_$testPubkeyA')),
           findsOneWidget,
         );
-      });
-
-      testWidgets('npub mention of non-member in group opens StartChatScreen', (tester) async {
-        await _mountBubbleWithRouter(
-          tester,
-          ChatMessageBubble(
-            message: withDoc(
-              const MarkdownDocument(
-                blocks: [
-                  MarkdownBlock.paragraph(
-                    inlines: [
-                      MarkdownInline.nostrMention(
-                        entity: MarkdownNostrEntity(
-                          hrp: MarkdownNostrHrp.npub,
-                          bech32: testNpubA,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ),
-            isOwnMessage: false,
-            groupId: testGroupId,
-            groupMemberPubkeys: const {testPubkeyB},
-          ),
-        );
-        final span = tester.widget<RichText>(find.byType(RichText).first).text as TextSpan;
-        final entity = _firstTextSpanWithRecognizer(span);
-        (entity.recognizer as TapGestureRecognizer).onTap!();
-        await tester.pump();
-        await tester.pump(const Duration(milliseconds: 50));
-        tester.takeException();
-        expect(launcher.calls, isEmpty);
-        expect(
-          find.byKey(const ValueKey('group_member_route_${testGroupId}_$testPubkeyA')),
-          findsNothing,
-        );
-        expect(find.byType(StartChatScreen), findsOneWidget);
       });
 
       testWidgets('whitenoise://chat/<id> tap navigates via GoRouter', (tester) async {


### PR DESCRIPTION
![marmot](https://blossom.primal.net/3bc2fd2a26b31776a66740df4df014b23b1e1319feacd49e667f722f9a4e3f1d.png)

Closes #681.

Tapping an @-mention inside a chat bubble used to open the start-chat shade, even when the tagged marmot was already in the group. Now the bubble checks the group roster and routes to the group member shade for members, keeping the start-chat shade for non-members and DMs.

Since the chat screen already loads the member list once via `useGroupMembers`, the bubble gets a memoized `Set<String>` instead of fetching members per bubble. That keeps the "don't fetch in every chat bubble" line from the issue satisfied.

For consistency, the start-chat shade now anchors to the top of the screen, matching the group member shade. Both shades slide in from the same spot.


https://github.com/user-attachments/assets/5162955e-a366-46ab-bfc2-ee186768fc24



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tapping a user mention in group chat opens the group-member profile when available; if the user isn’t a group member it opens a direct chat.

* **Style**
  * Adjusted start chat screen spacing for improved layout balance.

* **Tests**
  * Added tests for mention navigation and non-member redirect behavior to validate routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/686?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->