### PR TITLE
Show notifications settings screen on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,13 @@ and this project adheres to Calendar Versioning (CalVer).
 ### Added
 - Leave group from chat list for non-last admins [PR #638](https://github.com/marmot-protocol/whitenoise/pull/638)
 - Add archive option in chat removed warning and change wording for leave case [PR #657](https://github.com/marmot-protocol/whitenoise/pull/657)
+- Add native deep links for users, chats, and settings [PR #661](https://github.com/marmot-protocol/whitenoise/pull/661)
+- Add markdown rendering for chat messages [PR #665](https://github.com/marmot-protocol/whitenoise/pull/665)
+- Push notifications [PR #673](https://github.com/marmot-protocol/whitenoise/pull/673)
 - Enable leave group [PR #675](https://github.com/marmot-protocol/whitenoise/pull/675)
+- Add members from group info screen [PR #679](https://github.com/marmot-protocol/whitenoise/pull/679)
+- Add key package developer controls [PR #685](https://github.com/marmot-protocol/whitenoise/pull/685)
+- Show notifications settings screen on iOS [PR #688](https://github.com/marmot-protocol/whitenoise/pull/688)
 
 ### Changed
 

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart' show defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
@@ -146,13 +145,12 @@ class SettingsScreen extends HookConsumerWidget {
                       label: context.l10n.appearance,
                       onTap: () => Routes.pushToAppearance(context),
                     ),
-                    if (defaultTargetPlatform == TargetPlatform.android)
-                      WnMenuItem(
-                        key: const Key('notification_settings_menu_item'),
-                        icon: WnIcons.notification,
-                        label: context.l10n.notificationSettings,
-                        onTap: () => Routes.pushToNotificationSettings(context),
-                      ),
+                    WnMenuItem(
+                      key: const Key('notification_settings_menu_item'),
+                      icon: WnIcons.notification,
+                      label: context.l10n.notificationSettings,
+                      onTap: () => Routes.pushToNotificationSettings(context),
+                    ),
                     WnMenuItem(
                       key: const Key('help_and_support_menu_item'),
                       icon: WnIcons.helpChat,

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -316,7 +316,7 @@ void main() {
       expect(find.text('v1.2.3+45'), findsOneWidget);
     });
 
-    group('notification settings menu item (Android-only)', () {
+    group('notification settings menu item', () {
       testWidgets('shows Notification Settings menu item on Android', (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.android;
         await pumpSettingsScreen(tester);
@@ -326,12 +326,12 @@ void main() {
         expect(find.text('Notifications'), findsOneWidget);
       });
 
-      testWidgets('does not show Notification Settings menu item on iOS', (tester) async {
+      testWidgets('shows Notification Settings menu item on iOS', (tester) async {
         debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
         await pumpSettingsScreen(tester);
         debugDefaultTargetPlatformOverride = null;
 
-        expect(find.byKey(const Key('notification_settings_menu_item')), findsNothing);
+        expect(find.byKey(const Key('notification_settings_menu_item')), findsOneWidget);
       });
 
       testWidgets('tapping Notification Settings navigates to NotificationSettingsScreen', (


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The notification settings screen was only visible on android. Now that we have push notifications for ios, we want to show this screen in ios too. I really want this to disable notifications on ios cause otherwise it is too noisy 🙉

This tiny PR removes the condition to show that screen only on android. 

<!--
Describe what changed and why. Link the related issue: `Closes #NNN`
-->

## Type of Change

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests

## How I Tested This
In my iphone:
- Go to settings screen
- Check that notifications option is visible
- Uncheck the checkbox
- Go to chatlist
- Send a message from other device
- Check that I don't get a notificaton
- GO back to settings screen
- Click on notifications
- Check the checkbox
- Go to chatlist
- Send a message from other device
- Check that I get the notifcation


## Screenshots

<!-- Required for UI changes. Drag images here. Delete this section if UI is not affected -->

https://github.com/user-attachments/assets/a12f2291-188f-4bd0-be41-e71e21732b85



## Checklist

- [x] `just precommit` passes
- [ ] Related issue linked (`Closes #NNN`)
- [X] `CHANGELOG.md` updated (if user-visible change)
- [X] Screenshots added (for UI changes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Notification settings menu item is now available in Settings on all platforms (shown between Appearance and Help & support).

* **Tests**
  * Test coverage updated to verify the notification settings item appears across platforms.

* **Documentation**
  * Release notes expanded to list recent additions: deep links, markdown in chats, push notifications, group member additions, developer controls, and notification settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/688?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->