### PR TITLE
Support Android in integration tests

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <application
+        android:networkSecurityConfig="@xml/network_security_config"
+        tools:replace="android:networkSecurityConfig" />
 </manifest>

--- a/android/app/src/debug/res/xml/network_security_config.xml
+++ b/android/app/src/debug/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/integration_test/_support/app_setup.dart
+++ b/integration_test/_support/app_setup.dart
@@ -88,11 +88,14 @@ Future<ProviderContainer> mountApp(WidgetTester tester) async {
 Future<void> expectLocalRelaysAvailable() async {
   for (final url in _relayUrls) {
     final uri = Uri.tryParse(url);
-    if (uri == null) continue;
+    if (uri == null) {
+      debugPrint('[app_setup] Skipping unparseable relay URL: $url');
+      continue;
+    }
     final host = uri.host;
     final isLocal = host == 'localhost' || host == '127.0.0.1';
     if (!isLocal) continue;
-    final port = uri.port != 0
+    final port = uri.hasPort
         ? uri.port
         : (uri.scheme == 'wss' ? 443 : 80);
     await _expectLocalRelayAvailable(host, port);

--- a/integration_test/_support/app_setup.dart
+++ b/integration_test/_support/app_setup.dart
@@ -16,7 +16,15 @@ import 'package:whitenoise/src/rust/frb_generated.dart';
 import '../../test/mocks/mock_secure_storage.dart';
 import 'tester_helpers.dart';
 
-const _relayUrls = ['ws://localhost:8080', 'ws://localhost:7777'];
+const _relayUrlsEnv = String.fromEnvironment(
+  'WHITENOISE_INTEGRATION_RELAYS',
+  defaultValue: 'ws://localhost:8080,ws://localhost:7777',
+);
+final List<String> _relayUrls = _relayUrlsEnv
+    .split(',')
+    .map((s) => s.trim())
+    .where((s) => s.isNotEmpty)
+    .toList();
 
 bool _rustBridgeInitialized = false;
 Directory? _backendRoot;
@@ -78,21 +86,28 @@ Future<ProviderContainer> mountApp(WidgetTester tester) async {
 }
 
 Future<void> expectLocalRelaysAvailable() async {
-  await _expectLocalRelayAvailable(8080);
-  await _expectLocalRelayAvailable(7777);
+  for (final url in _relayUrls) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) continue;
+    final host = uri.host;
+    final isLocal = host == 'localhost' || host == '127.0.0.1';
+    if (!isLocal) continue;
+    final port = uri.hasPort ? uri.port : 80;
+    await _expectLocalRelayAvailable(host, port);
+  }
 }
 
-Future<void> _expectLocalRelayAvailable(int port) async {
+Future<void> _expectLocalRelayAvailable(String host, int port) async {
   try {
     final socket = await Socket.connect(
-      '127.0.0.1',
+      host,
       port,
       timeout: const Duration(seconds: 1),
     );
     socket.destroy();
   } catch (error) {
     fail(
-      'Expected a local Nostr relay on 127.0.0.1:$port before running this integration test. '
+      'Expected a local Nostr relay on $host:$port before running this integration test. '
       'Run `docker compose up -d`, then run the test again. '
       'Connection error: $error',
     );

--- a/integration_test/_support/app_setup.dart
+++ b/integration_test/_support/app_setup.dart
@@ -89,8 +89,10 @@ Future<void> expectLocalRelaysAvailable() async {
   for (final url in _relayUrls) {
     final uri = Uri.tryParse(url);
     if (uri == null) {
-      debugPrint('[app_setup] Skipping unparseable relay URL: $url');
-      continue;
+      fail(
+        'Unparseable relay URL "$url" in WHITENOISE_INTEGRATION_RELAYS. '
+        'Fix the relay list (comma-separated) and run the test again.',
+      );
     }
     final host = uri.host;
     final isLocal = host == 'localhost' || host == '127.0.0.1';

--- a/integration_test/_support/app_setup.dart
+++ b/integration_test/_support/app_setup.dart
@@ -92,7 +92,9 @@ Future<void> expectLocalRelaysAvailable() async {
     final host = uri.host;
     final isLocal = host == 'localhost' || host == '127.0.0.1';
     if (!isLocal) continue;
-    final port = uri.hasPort ? uri.port : 80;
+    final port = uri.port != 0
+        ? uri.port
+        : (uri.scheme == 'wss' ? 443 : 80);
     await _expectLocalRelayAvailable(host, port);
   }
 }

--- a/justfile
+++ b/justfile
@@ -168,35 +168,57 @@ test-flutter-quiet:
         echo "No test directory found."; \
     fi
 
-# Resolves the integration-test device: the given id, else the one booted simulator.
+# Resolves the integration-test device: the given id, else the one booted iOS simulator or Android device.
 _resolve-device device:
     @device="{{ device }}"; \
     if [ -n "$device" ]; then echo "$device"; exit 0; fi; \
-    booted=$(xcrun simctl list devices booted 2>/dev/null | grep -oiE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}'); \
-    count=$(printf '%s' "$booted" | grep -c .); \
-    if [ "$count" -eq 1 ]; then \
-        echo "Using booted simulator $booted" >&2; \
-        echo "$booted"; \
-    elif [ "$count" -eq 0 ]; then \
-        echo "No device id given and no booted simulator found. Boot one, pass a device id, or set WHITENOISE_INTEGRATION_DEVICE." >&2; \
+    if command -v xcrun >/dev/null 2>&1; then \
+        booted=$(xcrun simctl list devices booted 2>/dev/null | grep -oiE '[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}'); \
+    else \
+        booted=""; \
+    fi; \
+    ios_count=$(printf '%s' "$booted" | grep -c .); \
+    if command -v adb >/dev/null 2>&1; then \
+        android=$(adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}'); \
+    else \
+        android=""; \
+    fi; \
+    android_count=$(printf '%s' "$android" | grep -c .); \
+    total=$((ios_count + android_count)); \
+    if [ "$total" -eq 1 ]; then \
+        picked="${booted}${android}"; \
+        echo "Using device $picked" >&2; \
+        echo "$picked"; \
+    elif [ "$total" -eq 0 ]; then \
+        echo "No device id given and no booted iOS simulator or Android device found. Boot one, pass a device id, or set WHITENOISE_INTEGRATION_DEVICE." >&2; \
         exit 1; \
     else \
-        echo "Multiple booted simulators — pass a device id or set WHITENOISE_INTEGRATION_DEVICE:" >&2; \
-        xcrun simctl list devices booted >&2; \
+        echo "Multiple devices found — pass a device id or set WHITENOISE_INTEGRATION_DEVICE:" >&2; \
+        [ -n "$booted" ] && echo "iOS simulators:" >&2 && echo "$booted" >&2; \
+        [ -n "$android" ] && echo "Android devices:" >&2 && echo "$android" >&2; \
         exit 1; \
     fi
 
-# Run Flutter integration tests. Requires local Nostr relays on ports 8080 and 7777.
+# Run Flutter integration tests. iOS uses local Nostr relays on ports 8080 and 7777;
+# Android auto-uses public relays (emulator can't reach host localhost).
 
 # Run one file by passing its path: `just int-test integration_test/messaging_interactions_test.dart`.
-# Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator.
-int-test target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging":
+# Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator/emulator.
+# Relays: WHITENOISE_INTEGRATION_RELAYS (comma-separated) overrides defaults.
+int-test target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging" relays=env("WHITENOISE_INTEGRATION_RELAYS", ""):
     @echo "🧪 Testing Flutter integration flows..."
     @device=$(just _resolve-device "{{ device }}") || exit 1; \
+    relays="{{ relays }}"; \
+    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$device"; then \
+        relays="wss://nos.lol,wss://relay.primal.net,wss://relay.damus.io"; \
+        echo "📡 Android device detected — using public relays: $relays" >&2; \
+    fi; \
+    define=""; \
+    [ -n "$relays" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$relays"; \
     if [ -n "{{ flavor }}" ]; then \
-        flutter test -d "$device" --flavor {{ flavor }} {{ target }}; \
+        flutter test -d "$device" --flavor {{ flavor }} $define {{ target }}; \
     else \
-        flutter test -d "$device" {{ target }}; \
+        flutter test -d "$device" $define {{ target }}; \
     fi
 
 # Run Flutter integration tests with minimal output. Requires local Nostr relays on ports 8080 and 7777.

--- a/justfile
+++ b/justfile
@@ -199,19 +199,19 @@ _resolve-device device:
         exit 1; \
     fi
 
-# Resolves relay URLs: WHITENOISE_INTEGRATION_RELAYS env, else public relays when the
-# device is Android (emulator can't reach host localhost), else empty (= the localhost
-# defaults baked into integration_test/_support/app_setup.dart).
-_resolve-relays device:
-    @relays="${WHITENOISE_INTEGRATION_RELAYS:-}"; \
-    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -Fqx "{{ device }}"; then \
-        relays="wss://nos.lol,wss://relay.primal.net,wss://relay.damus.io"; \
-        echo "📡 Android device detected — using public relays: $relays" >&2; \
-    fi; \
-    echo "$relays"
+# If device is an Android adb device, tunnel host ports 8080/7777 to its loopback via
+# `adb reverse` so `ws://localhost:<port>` from the device hits the host's docker relays.
+# No-op for iOS simulators and desktop targets.
+_setup-android-relays device:
+    @if command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -Fqx "{{ device }}"; then \
+        adb -s "{{ device }}" reverse tcp:8080 tcp:8080 >/dev/null || { echo "❌ adb reverse tcp:8080 failed for {{ device }}" >&2; exit 1; }; \
+        adb -s "{{ device }}" reverse tcp:7777 tcp:7777 >/dev/null || { echo "❌ adb reverse tcp:7777 failed for {{ device }}" >&2; exit 1; }; \
+        echo "📡 Android device {{ device }} — adb reverse set for ports 8080, 7777 → host docker relays" >&2; \
+    fi
 
-# Run Flutter integration tests. iOS uses local Nostr relays on ports 8080 and 7777;
-# Android auto-uses public relays (emulator can't reach host localhost).
+# Run Flutter integration tests against local Nostr relays on ports 8080 and 7777
+# (`docker compose up -d`). On Android, `adb reverse` tunnels the device's localhost
+# to the host so the same URLs work on iOS simulators, desktop, and Android.
 
 # Run one file by passing its path: `just int-test integration_test/messaging_interactions_test.dart`.
 # Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator/emulator.
@@ -219,17 +219,17 @@ _resolve-relays device:
 int-test target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging":
     @echo "🧪 Testing Flutter integration flows..."
     @device=$(just _resolve-device "{{ device }}") || exit 1; \
-    relays=$(just _resolve-relays "$device") || exit 1; \
+    just _setup-android-relays "$device" || exit 1; \
     define=""; \
-    [ -n "$relays" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$relays"; \
+    [ -n "${WHITENOISE_INTEGRATION_RELAYS:-}" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$WHITENOISE_INTEGRATION_RELAYS"; \
     if [ -n "{{ flavor }}" ]; then \
         flutter test -d "$device" --flavor {{ flavor }} ${define:+"$define"} {{ target }}; \
     else \
         flutter test -d "$device" ${define:+"$define"} {{ target }}; \
     fi
 
-# Run Flutter integration tests with minimal output. iOS uses local Nostr relays on
-# ports 8080 and 7777; Android auto-uses public relays.
+# Run Flutter integration tests with minimal output against local Nostr relays on
+# ports 8080 and 7777; Android tunnels via `adb reverse`.
 
 # Run one file by passing its path: `just int-test-quiet integration_test/messaging_interactions_test.dart`.
 # Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator/emulator.
@@ -240,9 +240,9 @@ int-test-quiet target="integration_test/all_tests.dart" device=env("WHITENOISE_I
         exit 1; \
     fi; \
     device=$(just _resolve-device "{{ device }}") || exit 1; \
-    relays=$(just _resolve-relays "$device") || exit 1; \
+    just _setup-android-relays "$device" || exit 1; \
     define=""; \
-    [ -n "$relays" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$relays"; \
+    [ -n "${WHITENOISE_INTEGRATION_RELAYS:-}" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$WHITENOISE_INTEGRATION_RELAYS"; \
     if [ -n "{{ flavor }}" ]; then \
         flutter test -d "$device" --flavor {{ flavor }} --no-pub --reporter=failures-only ${define:+"$define"} {{ target }}; \
     else \

--- a/justfile
+++ b/justfile
@@ -199,42 +199,54 @@ _resolve-device device:
         exit 1; \
     fi
 
+# Resolves relay URLs: WHITENOISE_INTEGRATION_RELAYS env, else public relays when the
+# device is Android (emulator can't reach host localhost), else empty (= the localhost
+# defaults baked into integration_test/_support/app_setup.dart).
+_resolve-relays device:
+    @relays="${WHITENOISE_INTEGRATION_RELAYS:-}"; \
+    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "{{ device }}"; then \
+        relays="wss://nos.lol,wss://relay.primal.net,wss://relay.damus.io"; \
+        echo "📡 Android device detected — using public relays: $relays" >&2; \
+    fi; \
+    echo "$relays"
+
 # Run Flutter integration tests. iOS uses local Nostr relays on ports 8080 and 7777;
 # Android auto-uses public relays (emulator can't reach host localhost).
 
 # Run one file by passing its path: `just int-test integration_test/messaging_interactions_test.dart`.
 # Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator/emulator.
 # Relays: WHITENOISE_INTEGRATION_RELAYS (comma-separated) overrides defaults.
-int-test target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging" relays=env("WHITENOISE_INTEGRATION_RELAYS", ""):
+int-test target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging":
     @echo "🧪 Testing Flutter integration flows..."
     @device=$(just _resolve-device "{{ device }}") || exit 1; \
-    relays="{{ relays }}"; \
-    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "$device"; then \
-        relays="wss://nos.lol,wss://relay.primal.net,wss://relay.damus.io"; \
-        echo "📡 Android device detected — using public relays: $relays" >&2; \
-    fi; \
+    relays=$(just _resolve-relays "$device") || exit 1; \
     define=""; \
     [ -n "$relays" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$relays"; \
     if [ -n "{{ flavor }}" ]; then \
-        flutter test -d "$device" --flavor {{ flavor }} $define {{ target }}; \
+        flutter test -d "$device" --flavor {{ flavor }} ${define:+"$define"} {{ target }}; \
     else \
-        flutter test -d "$device" $define {{ target }}; \
+        flutter test -d "$device" ${define:+"$define"} {{ target }}; \
     fi
 
-# Run Flutter integration tests with minimal output. Requires local Nostr relays on ports 8080 and 7777.
+# Run Flutter integration tests with minimal output. iOS uses local Nostr relays on
+# ports 8080 and 7777; Android auto-uses public relays.
 
 # Run one file by passing its path: `just int-test-quiet integration_test/messaging_interactions_test.dart`.
-# Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator.
+# Device: WHITENOISE_INTEGRATION_DEVICE, else the one booted simulator/emulator.
+# Relays: WHITENOISE_INTEGRATION_RELAYS (comma-separated) overrides defaults.
 int-test-quiet target="integration_test/all_tests.dart" device=env("WHITENOISE_INTEGRATION_DEVICE", "") flavor="staging":
     @if [ ! -e "{{ target }}" ]; then \
         echo "No integration test target found at {{ target }}."; \
         exit 1; \
     fi; \
     device=$(just _resolve-device "{{ device }}") || exit 1; \
+    relays=$(just _resolve-relays "$device") || exit 1; \
+    define=""; \
+    [ -n "$relays" ] && define="--dart-define=WHITENOISE_INTEGRATION_RELAYS=$relays"; \
     if [ -n "{{ flavor }}" ]; then \
-        flutter test -d "$device" --flavor {{ flavor }} --no-pub --reporter=failures-only {{ target }}; \
+        flutter test -d "$device" --flavor {{ flavor }} --no-pub --reporter=failures-only ${define:+"$define"} {{ target }}; \
     else \
-        flutter test -d "$device" --no-pub --reporter=failures-only {{ target }}; \
+        flutter test -d "$device" --no-pub --reporter=failures-only ${define:+"$define"} {{ target }}; \
     fi
 
 coverage min="99":

--- a/justfile
+++ b/justfile
@@ -204,7 +204,7 @@ _resolve-device device:
 # defaults baked into integration_test/_support/app_setup.dart).
 _resolve-relays device:
     @relays="${WHITENOISE_INTEGRATION_RELAYS:-}"; \
-    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -qx "{{ device }}"; then \
+    if [ -z "$relays" ] && command -v adb >/dev/null 2>&1 && adb devices 2>/dev/null | awk 'NR>1 && $2=="device" {print $1}' | grep -Fqx "{{ device }}"; then \
         relays="wss://nos.lol,wss://relay.primal.net,wss://relay.damus.io"; \
         echo "📡 Android device detected — using public relays: $relays" >&2; \
     fi; \


### PR DESCRIPTION
![marmot](https://blossom.primal.net/dd1ac80777d20141b7bd33d3f22d917f040b45872cfbc5ca53d126f3f81f30ba.jpg)

`just int-test` now runs on Android.

## What changed

- `_resolve-device` falls back to `adb devices` when no booted iOS simulator is found, and skips `xcrun` on hosts where it isn't installed (so Linux works too).
- `int-test` auto-injects public Nostr relays through `--dart-define=WHITENOISE_INTEGRATION_RELAYS=...` when the resolved device is an Android one. The emulator can't reach the host's localhost, so the local docker relays aren't usable there.
- `integration_test/_support/app_setup.dart` reads the relay list from that dart-define (default: the same two localhost relays as before), and the TCP precheck now no-ops for non-localhost URLs. The iOS path is unchanged, and either platform can override the relay list with `WHITENOISE_INTEGRATION_RELAYS=...`.

## Why

The marmot colony hibernates near the host, but our Android sibling lives one virtual network away (it can't hear the local relays burrowing at `127.0.0.1`). So when the Android marmot wants to chat, we point it at the public relays already used in production: `nos.lol`, `relay.primal.net`, `relay.damus.io`.

## How to use

```bash
# iOS simulator (unchanged)
just int-test

# Android emulator (auto-detected, auto-uses public relays)
just int-test

# Override relays on any platform
WHITENOISE_INTEGRATION_RELAYS=wss://my.relay just int-test
```


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/690">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration tests accept a comma-separated relay env var (trimmed, empty entries dropped) and pass it into test runs.
  * Local relay preflight parses each relay URL, validates only localhost/127.0.0.1 hosts for connectivity, and derives the port from the URL or scheme.
  * Device resolution now detects both booted iOS simulators and connected Android devices; test runs adapt accordingly.

* **Chores**
  * Android test flow adds automatic port forwarding for Android devices when needed and enables debug build network config to allow cleartext to localhost.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->