### PR TITLE
fix(mentions): use accent Color/500 so mentions stay legible on both bubbles

### DIFF
--- a/lib/utils/avatar_color.dart
+++ b/lib/utils/avatar_color.dart
@@ -11,11 +11,13 @@ class AvatarColorSet {
   final Color background;
   final Color border;
   final Color content;
+  final Color contentSecondary;
 
   const AvatarColorSet({
     required this.background,
     required this.border,
     required this.content,
+    required this.contentSecondary,
   });
 }
 
@@ -59,6 +61,7 @@ enum AvatarColor {
         background: colors.fillSecondary,
         border: colors.borderSecondary,
         content: colors.fillContentSecondary,
+        contentSecondary: colors.fillContentTertiary,
       ),
       blue => _fromAccent(colors.accent.blue),
       cyan => _fromAccent(colors.accent.cyan),
@@ -80,4 +83,5 @@ AvatarColorSet _fromAccent(AccentColorSet accent) => AvatarColorSet(
   background: accent.fill,
   border: accent.border,
   content: accent.contentPrimary,
+  contentSecondary: accent.contentSecondary,
 );

--- a/lib/widgets/markdown_text.dart
+++ b/lib/widgets/markdown_text.dart
@@ -580,12 +580,14 @@ class _MarkdownRenderer {
   }
 
   /// Style for an npub mention: bold, in the user's per-pubkey color.
-  /// Same palette as the bubble's sender-name color. When the hex pubkey
-  /// can't be derived, falls back to the surrounding text color so the
-  /// mention is still bold but doesn't pretend to identify someone.
+  /// Uses the accent `contentSecondary` (Color/500) step so the mention
+  /// stays legible on both light and dark bubble backgrounds. When the
+  /// hex pubkey can't be derived, falls back to the surrounding text
+  /// color so the mention is still bold but doesn't pretend to identify
+  /// someone.
   TextStyle _mentionStyle(TextStyle style, String? hex) {
     final color = hex != null
-        ? AvatarColor.fromPubkey(hex).toColorSet(context.colors).content
+        ? AvatarColor.fromPubkey(hex).toColorSet(context.colors).contentSecondary
         : style.color;
     return style.copyWith(color: color, fontWeight: FontWeight.w700);
   }

--- a/test/widgets/markdown_text_test.dart
+++ b/test/widgets/markdown_text_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:leak_tracker_flutter_testing/leak_tracker_flutter_testing.dart';
 import 'package:whitenoise/src/rust/api/markdown.dart';
 import 'package:whitenoise/src/rust/frb_generated.dart';
+import 'package:whitenoise/theme/semantic_colors.dart';
+import 'package:whitenoise/utils/avatar_color.dart';
 import 'package:whitenoise/widgets/markdown_text.dart';
 
 import '../mocks/mock_wn_api.dart';
@@ -608,6 +610,33 @@ void main() {
       // base style colour so we know the user-color path fired.
       expect(mention.style?.color, isNotNull);
       expect(mention.style?.color, isNot(_baseStyle.color));
+    });
+
+    testWidgets('npub mention uses accent contentSecondary (Color/500), not contentPrimary', (
+      tester,
+    ) async {
+      await _pump(
+        tester,
+        MarkdownText(
+          document: _doc([
+            _paragraph([
+              const MarkdownInline.nostrMention(
+                entity: MarkdownNostrEntity(
+                  hrp: MarkdownNostrHrp.npub,
+                  bech32: testNpubA,
+                ),
+              ),
+            ]),
+          ]),
+          baseStyle: _baseStyle,
+          mentionDisplayName: (_) => 'Alice',
+        ),
+      );
+      final span = tester.widget<Text>(find.byType(Text).first).textSpan! as TextSpan;
+      final mention = span.children!.first as TextSpan;
+      final colorSet = AvatarColor.fromPubkey(testPubkeyA).toColorSet(SemanticColors.light);
+      expect(mention.style?.color, colorSet.contentSecondary);
+      expect(mention.style?.color, isNot(colorSet.content));
     });
 
     testWidgets('npub mention with empty resolved name falls back to truncation', (tester) async {


### PR DESCRIPTION
![marmot](https://blossom.primal.net/12fc74d461a4b879e9a68324e78d2076bf39151b9536cf557f51dcd8ad1c79f6.png)

Mentions disappear on the "wrong-side" bubble in each theme. In dark mode an orange username sits at orange-50 (near-white) on a white outgoing bubble. Vlad caught it and posted the spec.

The mention renderer was reading `AvatarColorSet.content`, wired to `accent.contentPrimary`. That step is `Color/900` in light mode and `Color/50` in dark, so it inverts with the theme and clashes with whichever bubble is the opposite shade. That token belongs on the tinted avatar pill, not the chat bubble.

Per the foundations file (node 297-1992), mentions should use `Accent/{color}/Content Secondary`, which is `Color/500` in both modes. The 500 step is mid-saturation and reads on both white and near-black bubbles.

### Changes

- `lib/utils/avatar_color.dart`: add `contentSecondary` to `AvatarColorSet`. Wires to `accent.contentSecondary` for accent buckets and `fillContentTertiary` for the neutral bucket.
- `lib/widgets/markdown_text.dart`: npub mention text uses `.contentSecondary`.
- `test/widgets/markdown_text_test.dart`: widget test asserts the mention color equals `contentSecondary` and is not `content`. Regression guard so a future marmot does not revert it by accident.

### Scope

Mentions only. Sender names and reply-author labels have the same root cause but are outside Vlad's note. The new field is in place if we apply the rule to them later.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/692">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual styling of mentions to use improved secondary color variants, providing better visual distinction and consistency across the interface.

* **Tests**
  * Enhanced test coverage to verify mention color styling behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/marmot-protocol/whitenoise/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->