### PR TITLE
Restore the Login with Amber button on Android

### DIFF
--- a/android/app/src/main/kotlin/org/parres/whitenoise/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/parres/whitenoise/MainActivity.kt
@@ -29,6 +29,11 @@ class MainActivity : FlutterActivity() {
         // Keyring.initializeNdkContext moved to WhitenoiseApplication.onCreate
         // so the Android Context is available from every process entry point,
         // not just Activity launch.
+        // Register the signer plugin on the UI engine. WhitenoiseApplication
+        // only registers it on the foreground-task background engine, so without
+        // this the login screen's signer channel is missing and the "Login with
+        // Amber" button never appears.
+        flutterEngine.plugins.add(AndroidSignerPlugin())
     }
 
     private fun cleanForegroundTaskPrefs() {


### PR DESCRIPTION
## Problem

The **Login with Amber** button no longer appears on the Android login screen. The NIP-55 external-signer flow looks broken from the user's side — the option is simply gone.

## Root cause

`#673` (`d57a883`, the iOS NSE / Android push-token PR) removed the signer-plugin registration from `MainActivity.configureFlutterEngine`:

```diff
-        flutterEngine.plugins.add(AndroidSignerPlugin())
-        flutterEngine.plugins.add(AndroidPlayServicesPlugin())
```

Registration was relocated into `WhitenoiseApplication.onEngineCreate(...)`. But `onEngineCreate` is a `FlutterForegroundTaskLifecycleListener` callback — it fires for the **foreground-task background engine**, not the main UI engine that `MainActivity` runs.

Result: `AndroidSignerPlugin` is registered only on the background engine. The login screen runs on the UI engine, where the `org.parres.whitenoise/android_signer` MethodChannel has no handler. So:

`AndroidSignerService.isAvailable()` → `MissingPluginException` → caught → returns `false` → `if (isAndroidSignerAvailable)` is false → button hidden.

## Fix

Re-register `AndroidSignerPlugin` on the UI engine in `MainActivity.configureFlutterEngine`, restoring exactly what `#673` dropped. `AndroidPlayServicesPlugin` / push plumbing is intentionally left where `#673` put it.

## Testing

- [ ] Staging build installed on a device with Amber present → "Login with Amber" button appears and the signer flow completes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the "Login with Amber" authentication option on the login screen. The Amber wallet signer functionality is now properly accessible during login, allowing users to authenticate using their wallet directly from the login screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->