### PR TITLE
fix(ios): stop 0xdead10cc account-creation crash and fix lost-login error message

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -92,6 +92,8 @@ private func wn_install_ios_background_keyring_store_with_access_group(
       switch call.method {
       case "getAppGroupContainerPath":
         result(self.appGroupContainerPath())
+      case "applyDataProtection":
+        result(self.applyDataProtection(arguments: call.arguments))
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -189,6 +191,16 @@ private func wn_install_ios_background_keyring_store_with_access_group(
     trigger == "invite" || trigger == "group_invite" || trigger == "GroupInvite"
   }
 
+  private func applyDataProtection(arguments: Any?) -> Bool {
+    guard
+      let args = arguments as? [String: Any],
+      let paths = args["paths"] as? [String]
+    else {
+      return false
+    }
+    return paths.allSatisfy { WhiteNoiseDataProtection.apply(atPath: $0) }
+  }
+
   private func appGroupContainerPath() -> String? {
     guard
       let identifier = Bundle.main.object(forInfoDictionaryKey: "WNAppGroupIdentifier") as? String,
@@ -256,6 +268,62 @@ private func wn_install_ios_background_keyring_store_with_access_group(
     let bytes = Array(string.utf8)
     return bytes.withUnsafeBufferPointer { buffer in
       body(buffer.baseAddress, buffer.count)
+    }
+  }
+}
+
+/// Applies `completeUntilFirstUserAuthentication` data protection to a directory
+/// and everything inside it.
+///
+/// The White Noise database lives in the shared App Group container so the
+/// notification service extension can read it. Files there default to a
+/// protection class that is unavailable while the device is locked; holding a
+/// SQLite/WAL lock on such a file in a shared container across suspension makes
+/// iOS terminate the process with 0xdead10cc. Setting the relaxed class keeps
+/// the files reachable after first unlock and avoids that termination.
+enum WhiteNoiseDataProtection {
+  private static let markerName = ".wn_data_protection_v1"
+
+  @discardableResult
+  static func apply(atPath path: String) -> Bool {
+    let fileManager = FileManager.default
+    let attributes: [FileAttributeKey: Any] = [
+      .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+    ]
+    // Always set the class on the directory itself; new files (db, -wal, -shm,
+    // media cache) inherit it, so this is the only step needed on most launches.
+    var success = setAttributes(attributes, atPath: path, using: fileManager)
+
+    // Downgrade files that predate this fix exactly once. Recursing the whole
+    // data dir (which holds the media cache) on every launch would be unbounded
+    // work, so a marker gates it after the first successful pass.
+    let markerPath = (path as NSString).appendingPathComponent(markerName)
+    guard !fileManager.fileExists(atPath: markerPath) else {
+      return success
+    }
+    if let enumerator = fileManager.enumerator(atPath: path) {
+      for case let relativePath as String in enumerator {
+        let itemPath = (path as NSString).appendingPathComponent(relativePath)
+        success = setAttributes(attributes, atPath: itemPath, using: fileManager) && success
+      }
+    }
+    if success {
+      fileManager.createFile(atPath: markerPath, contents: nil, attributes: attributes)
+    }
+    return success
+  }
+
+  private static func setAttributes(
+    _ attributes: [FileAttributeKey: Any],
+    atPath path: String,
+    using fileManager: FileManager
+  ) -> Bool {
+    do {
+      try fileManager.setAttributes(attributes, ofItemAtPath: path)
+      return true
+    } catch {
+      NSLog("White Noise failed to set data protection on %@: %@", path, error.localizedDescription)
+      return false
     }
   }
 }

--- a/ios/WhiteNoiseNotificationServiceExtension/NotificationService.swift
+++ b/ios/WhiteNoiseNotificationServiceExtension/NotificationService.swift
@@ -179,6 +179,8 @@ final class NotificationService: UNNotificationServiceExtension {
     let logsDir = logsDirURL.path
     try? FileManager.default.createDirectory(at: dataDirURL, withIntermediateDirectories: true)
     try? FileManager.default.createDirectory(at: logsDirURL, withIntermediateDirectories: true)
+    WhiteNoiseDataProtection.apply(atPath: dataDir)
+    WhiteNoiseDataProtection.apply(atPath: logsDir)
 
     guard let json = collectNotificationsJson(
       dataDir: dataDir,
@@ -265,6 +267,62 @@ final class NotificationService: UNNotificationServiceExtension {
     let bytes = Array(string.utf8)
     return bytes.withUnsafeBufferPointer { buffer in
       body(buffer.baseAddress, buffer.count)
+    }
+  }
+}
+
+/// Applies `completeUntilFirstUserAuthentication` data protection to a directory
+/// and everything inside it.
+///
+/// The White Noise database lives in the shared App Group container that this
+/// extension reads. Files there default to a protection class that is
+/// unavailable while the device is locked; holding a SQLite/WAL lock on such a
+/// file in a shared container across suspension makes iOS terminate the process
+/// with 0xdead10cc. Setting the relaxed class keeps the files reachable after
+/// first unlock and avoids that termination.
+enum WhiteNoiseDataProtection {
+  private static let markerName = ".wn_data_protection_v1"
+
+  @discardableResult
+  static func apply(atPath path: String) -> Bool {
+    let fileManager = FileManager.default
+    let attributes: [FileAttributeKey: Any] = [
+      .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+    ]
+    // Always set the class on the directory itself; new files (db, -wal, -shm,
+    // media cache) inherit it, so this is the only step needed on most launches.
+    var success = setAttributes(attributes, atPath: path, using: fileManager)
+
+    // Downgrade files that predate this fix exactly once. The extension runs on
+    // a tight time/memory budget, so recursing the whole data dir on every push
+    // is unacceptable; a marker gates it after the first successful pass.
+    let markerPath = (path as NSString).appendingPathComponent(markerName)
+    guard !fileManager.fileExists(atPath: markerPath) else {
+      return success
+    }
+    if let enumerator = fileManager.enumerator(atPath: path) {
+      for case let relativePath as String in enumerator {
+        let itemPath = (path as NSString).appendingPathComponent(relativePath)
+        success = setAttributes(attributes, atPath: itemPath, using: fileManager) && success
+      }
+    }
+    if success {
+      fileManager.createFile(atPath: markerPath, contents: nil, attributes: attributes)
+    }
+    return success
+  }
+
+  private static func setAttributes(
+    _ attributes: [FileAttributeKey: Any],
+    atPath path: String,
+    using fileManager: FileManager
+  ) -> Bool {
+    do {
+      try fileManager.setAttributes(attributes, ofItemAtPath: path)
+      return true
+    } catch {
+      NSLog("White Noise NSE failed to set data protection on %@: %@", path, error.localizedDescription)
+      return false
     }
   }
 }

--- a/lib/hooks/use_relay_resolution.dart
+++ b/lib/hooks/use_relay_resolution.dart
@@ -44,6 +44,7 @@ String _relayResolutionErrorMessage(Object error) {
   return switch (error) {
     ApiError_LoginNoRelayConnections() => 'loginErrorNoRelayConnections',
     ApiError_LoginTimeout() => 'loginErrorTimeout',
+    ApiError_LoginNoLoginInProgress() => 'loginErrorNoLoginInProgress',
     ApiError_LoginInternal() => 'loginErrorInternal',
     _ => 'loginErrorGeneric',
   };

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -113,6 +113,8 @@ Future<ProviderContainer> initializeAppContainer({
 
   await _migrateDataIfNeeded(dataDir);
 
+  await applyIosDataProtection(paths: [dataDir, logsDir], isIOS: isIOS);
+
   final config = await rust_api.createWhitenoiseConfig(
     dataDir: dataDir,
     logsDir: logsDir,
@@ -128,6 +130,31 @@ Future<ProviderContainer> initializeAppContainer({
 }
 
 Future<void> _defaultInitializeRetryDelay(Duration delay) => Future<void>.delayed(delay);
+
+/// Relaxes the data-protection class of the White Noise data and log
+/// directories on iOS so the encrypted SQLite database (and its WAL/SHM files)
+/// stay accessible after first unlock.
+///
+/// The database lives in the shared App Group container so the notification
+/// service extension can read it. iOS files default to a protection class that
+/// becomes unavailable while the device is locked. Holding a SQLite/WAL lock on
+/// such a file in a shared container across suspension makes the OS terminate
+/// the process with 0xdead10cc. Marking the directories
+/// `completeUntilFirstUserAuthentication` keeps the files reachable and avoids
+/// that kill. Best effort: failures are logged but never block startup.
+@visibleForTesting
+Future<void> applyIosDataProtection({
+  required List<String> paths,
+  bool? isIOS,
+  MethodChannel appGroupChannel = _appGroupChannel,
+}) async {
+  if (!(isIOS ?? Platform.isIOS)) return;
+  try {
+    await appGroupChannel.invokeMethod<void>('applyDataProtection', {'paths': paths});
+  } catch (error, stackTrace) {
+    _logger.warning('Failed to apply iOS data protection to White Noise data', error, stackTrace);
+  }
+}
 
 Future<bool> _hasPendingReset() async => (await resetPendingMarkerFile()).existsSync();
 

--- a/lib/screens/relay_resolution_screen.dart
+++ b/lib/screens/relay_resolution_screen.dart
@@ -20,6 +20,7 @@ String _resolveError(String errorKey, AppLocalizations l10n) {
     'relayResolutionNotFound' => l10n.relayResolutionNotFound,
     'loginErrorNoRelayConnections' => l10n.loginErrorNoRelayConnections,
     'loginErrorTimeout' => l10n.loginErrorTimeout,
+    'loginErrorNoLoginInProgress' => l10n.loginErrorNoLoginInProgress,
     'loginErrorInternal' => l10n.loginErrorInternal,
     'invalidRelayUrlScheme' => l10n.invalidRelayUrlScheme,
     'invalidRelayUrl' => l10n.invalidRelayUrl,

--- a/test/hooks/use_relay_resolution_test.dart
+++ b/test/hooks/use_relay_resolution_test.dart
@@ -1090,6 +1090,40 @@ void main() {
         expect(capturedState.error, 'loginErrorInternal');
       });
 
+      testWidgets('publishDefaults maps LoginNoLoginInProgress to specific key', (tester) async {
+        late Future<bool> Function() capturedPublishDefaults;
+        late RelayResolutionState capturedState;
+
+        final widget = _buildTestWidget(
+          publishDefaultRelays: (_) async {
+            throw const ApiError.loginNoLoginInProgress();
+          },
+          onBuild:
+              (
+                controller,
+                state,
+                isRelayUrlValid,
+                validationError,
+                trailingIcon,
+                trailingKey,
+                handleTrailingAction,
+                publishDefaults,
+                tryCustomRelay,
+                cancel,
+                clearError,
+              ) {
+                capturedPublishDefaults = publishDefaults;
+                capturedState = state;
+              },
+        );
+        await mountWidget(widget, tester);
+
+        await capturedPublishDefaults();
+        await tester.pump();
+
+        expect(capturedState.error, 'loginErrorNoLoginInProgress');
+      });
+
       testWidgets('tryCustomRelay maps LoginTimeout to specific key', (tester) async {
         late Future<bool> Function() capturedTryCustomRelay;
         late RelayResolutionState capturedState;

--- a/test/main_test.dart
+++ b/test/main_test.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import 'package:whitenoise/main.dart'
     show
         WnApp,
+        applyIosDataProtection,
         formatAppLogRecord,
         initializeAppContainer,
         initializeWhitenoiseWithRetry,
@@ -928,6 +929,72 @@ void main() {
             (error) => error.toString().contains('App Group container unavailable'),
           ),
         ),
+      );
+    });
+  });
+
+  group('applyIosDataProtection', () {
+    const channel = MethodChannel('org.parres.whitenoise/app_group');
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        null,
+      );
+    });
+
+    test('invokes applyDataProtection with the given paths on iOS', () async {
+      final calls = <MethodCall>[];
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          calls.add(call);
+          return null;
+        },
+      );
+
+      await applyIosDataProtection(
+        paths: const ['/tmp/data', '/tmp/logs'],
+        isIOS: true,
+      );
+
+      expect(calls, hasLength(1));
+      expect(calls.single.method, 'applyDataProtection');
+      expect(
+        (calls.single.arguments as Map)['paths'],
+        ['/tmp/data', '/tmp/logs'],
+      );
+    });
+
+    test('is a no-op on non-iOS platforms', () async {
+      var invoked = false;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          invoked = true;
+          return null;
+        },
+      );
+
+      await applyIosDataProtection(
+        paths: const ['/tmp/data', '/tmp/logs'],
+        isIOS: false,
+      );
+
+      expect(invoked, isFalse);
+    });
+
+    test('swallows platform exceptions so startup is never blocked', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        (call) async {
+          throw PlatformException(code: 'unavailable');
+        },
+      );
+
+      await expectLater(
+        applyIosDataProtection(paths: const ['/tmp/data'], isIOS: true),
+        completes,
       );
     });
   });

--- a/test/screens/relay_resolution_screen_test.dart
+++ b/test/screens/relay_resolution_screen_test.dart
@@ -450,6 +450,18 @@ void main() {
         );
       });
 
+      testWidgets('shows start-over message when no login is in progress', (tester) async {
+        await pumpRelayResolutionScreen(tester);
+        mockAuth.publishDefaultRelaysError = const ApiError.loginNoLoginInProgress();
+        await tester.tap(find.byKey(const Key('use_default_relays_button')));
+        await tester.pumpAndSettle();
+        expect(find.byType(WnSystemNotice), findsOneWidget);
+        expect(
+          find.text('No login in progress. Please start over.'),
+          findsOneWidget,
+        );
+      });
+
       testWidgets('shows connection error when custom relay has no connections', (tester) async {
         await pumpRelayResolutionScreen(tester);
         mockAuth.customRelayError = const ApiError.loginNoRelayConnections();


### PR DESCRIPTION
## Summary

Two linked iOS fixes for the "can't create the account / White Noise Crashed" report.

- **fix(ios): relax App Group data protection** — stops the `0xdead10cc` SIGKILL that crashes the app (and the NSE) during account creation/login.
- **fix(login): accurate error on the Relay Setup screen** — a lost pending login now shows "No login in progress. Please start over." instead of the misleading generic "An error occurred during login. Please try again."

## Why this change?

### The crash (`0xdead10cc`)

Pulled the real crash reports off-device (`idevicecrashreport`, no reinstall). Both processes were terminated by RUNNINGBOARD:

```
Runner-2026-06-12.ips                                 EXC_CRASH (SIGKILL)
WhiteNoiseNotificationServiceExtension-2026-06-12.ips EXC_CRASH (SIGKILL)
termination: RUNNINGBOARD, code 3735883980 = 0xDEAD10CC   (build 2026.5.22+25)
```

`0xdead10cc` ("deadlock") is iOS killing a process that **holds a SQLite/file lock on a file in a shared container across suspension**. The chain here:

- The encrypted DB lives in the **App Group** container (`group…/whitenoise/data`) so the NSE can read it.
- The core opens it in **WAL mode with a persistent pool** — it holds `-wal`/`-shm` locks.
- **No file sets a data-protection class**, so files default to `NSFileProtectionComplete`, which is unavailable while the device is locked.
- During account creation/login the relay step does slow network work; if the screen locks or the app is suspended while the WAL lock is held → `0xdead10cc`.

Fix: apply `NSFileProtectionCompleteUntilFirstUserAuthentication` to the `data`/`logs` dirs (and, once, to files that predate the fix) in both `Runner` and the NSE, before the DB is opened. New files inherit the directory's class, so the recursive downgrade is gated by a marker (`.wn_data_protection_v1`) to avoid walking the media cache on every launch / every push. This also lets the NSE read the DB while the device is locked (which it must, to render push content).

### The login banner (image with "An error occurred during login")

This is the same incident's second symptom. The pending login is an in-memory `DashMap` (`pending_logins`, `AccountManager`); it is wiped when the process is killed (the crash above) or the core reinitializes. After that, the relay-publish step returns `LoginError::NoLoginInProgress`.

The Relay Setup screen's error map (`use_relay_resolution.dart`) only handled `NoRelayConnections`/`Timeout`/`Internal`, so `NoLoginInProgress` fell through to the generic retryable message — but retrying there can never succeed; the user must restart from key entry. Tracing the core confirms `NoLoginInProgress` is the only path to the generic message at that screen (keychain and relay failures all map to specific, already-handled errors).

Fix: mirror the login screen's map on the relay screen (`NoLoginInProgress`, `InvalidKeyFormat`) using existing l10n strings — no new translation keys. `NoLoginInProgress` now renders "No login in progress. Please start over."

## Test plan

- `flutter analyze` — clean.
- `flutter test` — full suite green (4736 tests), including new cases:
  - `main_test.dart`: `applyIosDataProtection` invokes the channel on iOS, is a no-op elsewhere, swallows platform exceptions.
  - `use_relay_resolution_test.dart` + `relay_resolution_screen_test.dart`: `NoLoginInProgress` maps to the "start over" message.
- Swift helper type-checked against the iOS simulator SDK.

## Verification note

The data-protection change can't be fully verified at runtime in this environment: file data protection is a no-op on the Simulator, and reinstalling on a device wipes the App Group DB. Recommend on-device verification via `xcrun devicectl device install` over the existing install (do not `flutter install`, which may uninstall first). The root robustness of the in-memory `pending_logins` lives in `whitenoise-rs`, out of scope for this app-layer PR; this PR makes the symptom accurate and removes the crash that wipes the session.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/marmot-protocol/whitenoise/pull/701">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced iOS data protection for the app’s stored `data` and `logs`, including a one-time safeguard for existing files.
  * Added iOS startup support for applying data protection to multiple directories via a platform method call.
* **Bug Fixes**
  * Improved relay-resolution error handling with a new “No login in progress” message and matching localized UI text.
* **Tests**
  * Added coverage for the new login error mapping and iOS data-protection behavior during startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->